### PR TITLE
bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/*
 dist/*
 pmu-checker/pmu-checker
 src/libtsc.so
+__pycache__

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Requires recent python and golang.
 
 ```
 pip3 install -r requirements.txt
-make dist
+make
 ```
 
 On successful build, binaries will be created in "dist" folder

--- a/perf-collect.py
+++ b/perf-collect.py
@@ -519,9 +519,11 @@ if __name__ == "__main__":
         False,
     )
 
+    # reset nmi_watchdog to what it was before running perfspect
     if (int(nmi_watchdog) != 0) and supervisor:
         f_nmi = open("/proc/sys/kernel/nmi_watchdog", "w")
         f_nmi.write(nmi_watchdog)
+        f_nmi.close()
 
     if (args.muxinterval > 0) and supervisor:
         perf_helpers.set_perf_event_mux_interval(True, 1, mux_intervals)

--- a/perf-collect.spec
+++ b/perf-collect.spec
@@ -1,0 +1,49 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+block_cipher = None
+
+
+a = Analysis(
+    ['perf-collect.py'],
+    pathex=[],
+    binaries=[('../build/pmu-checker', '.')],
+    datas=[('./src/libtsc.so', '.'), ('./events/bdx.txt', '.'), ('./events/skx.txt', '.'), ('./events/clx.txt', '.'), ('./events/icx.txt', '.'), ('./events/spr.txt', '.'), ('./events/icx_aws.txt', '.'), ('./events/spr_aws.txt', '.'), ('./events/clx_aws.txt', '.'), ('./events/skx_aws.txt', '.')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=['readline'],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+# exclude libtinfo shared library from distributed binaries due to warning observed on Ubuntu 16.04:
+#    "/bin/bash: ./_MEIuU3XMv/libtinfo.so.5: no version information available (required by /bin/bash)"
+a.binaries = [bin for bin in a.binaries if not bin[0].startswith('libtinfo')]
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='perf-collect',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir='.',
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/perf-postprocess.py
+++ b/perf-postprocess.py
@@ -763,8 +763,6 @@ def write_perf_tmp_output(use_epoch):
                     epoch = int(words[-1])
                 except ValueError:
                     exit("Conversion error parsing timestamp")
-                except:
-                    exit("Unkown error parsing timestamp")
                 break
     # TO:DO remove "not_counted" and "not_supported" events from dat_file
 
@@ -1433,7 +1431,7 @@ if __name__ == "__main__":
     if (args.outfile).endswith("xlsx"):
         try:
             import xlsxwriter
-        except:
+        except ImportError:
             raise SystemExit(
                 "xlsxwriter not found to generate excel output. Install xlsxwriter or use .csv"
             )

--- a/pmu-checker/msr/msr.go
+++ b/pmu-checker/msr/msr.go
@@ -52,7 +52,7 @@ func (dpt retMSR) read(msr int64) (uint64, error) {
 	rc, err := syscall.Pread(dpt.fd, buf, msr)
 	if err != nil {
 		log.Fatal(err)
-		panic(err)
+		return 0, err
 	}
 
 	if rc != 8 {

--- a/src/perf_helpers.py
+++ b/src/perf_helpers.py
@@ -14,8 +14,9 @@ import math
 import collections
 import psutil
 import subprocess  # nosec
+import logging
 from time import strptime
-from ctypes import *  # flake8: noqa
+from ctypes import cdll, CDLL
 from datetime import datetime
 from dateutil import tz
 
@@ -166,7 +167,7 @@ def get_version():
     try:
         fo = open("/proc/version", "r")
     except EnvironmentError as e:
-        warnings.warn(str(e), UserWarning)
+        logging.warn(str(e), UserWarning)
     else:
         version = fo.read()
         version = version.split("#")[0]
@@ -180,7 +181,7 @@ def get_cpuinfo():
     try:
         fo = open("/proc/cpuinfo", "r")
     except EnvironmentError as e:
-        warnings.warn(str(e), UserWarning)
+        logging.warn(str(e), UserWarning)
     else:
         for line in fo:
             try:


### PR DESCRIPTION
1. fixes libinfo warnings thrown on ubuntu 16.04
2. change `make dist` to `make`
3. close nmi file 
4. handle msr read errors without panic