### PR TITLE
run without root permission

### DIFF
--- a/perf-collect.py
+++ b/perf-collect.py
@@ -295,7 +295,9 @@ if __name__ == "__main__":
         sys.exit()
 
     if os.geteuid() != 0:
-        crash("Must run PerfSpect as root, please re-run")
+        logging.warning(
+            "PerfSpect requires elevated permissions to run. User is not root. Proceeding anyway..."
+        )
 
     # disable nmi watchdog before collecting perf
     nmi_watchdog = perf_helpers.disable_nmi_watchdog()

--- a/src/prepare_perf_events.py
+++ b/src/prepare_perf_events.py
@@ -63,8 +63,8 @@ def is_cpu_event(line):
     if (
         (len(tmp_list) == 1 or tmp_list[0] == "cpu" or tmp_list[0].startswith("cstate"))
         and "OCR." not in line
-        and "uops_retired.ms" not in line
-        and "int_misc.unknown_branch_cycles" not in line
+        and "uops_retired.ms" not in line.lower()
+        and "int_misc.unknown_branch_cycles" not in line.lower()
         and "power/" not in line
     ):
         return True


### PR DESCRIPTION
This is an experimental PR that allows running perf-collect as a regular, non-root, user.

The caveat is that a 'root' user must pre-configure the system before running perf-collect. There are three configuration items:

- sysctl -w kernel.perf_event_paranoid=0
- sysctl -w kernel.nmi_watchdog=0
- write '125' to all perf_event_mux_interval_ms files found under /sys/devices/*. 
` for i in $(find /sys/devices -name perf_event_mux_interval_ms); do
    echo 125 > $i
done
`
