### PR TITLE
add nofixedtma metric files as build time resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,9 @@ build-public/postprocess:
 					--add-data "./events/metric_skx_clx.json:." \
 					--add-data "./events/metric_bdx.json:." \
 					--add-data "./events/metric_icx.json:." \
+					--add-data "./events/metric_icx_nofixedtma.json:." \
 					--add-data "./events/metric_spr_emr.json:." \
+					--add-data "./events/metric_spr_emr_nofixedtma.json:." \
 					--add-data "./events/metric_srf.json:." \
 					--add-data "./src/base.html:." \
 					--runtime-tmpdir . \


### PR DESCRIPTION
Earlier commit did not include these files in the pyinstaller build, thus they are not available at runtime.