### PR TITLE
send SIGINT and SIGTERM to children when received

### DIFF
--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -504,6 +504,8 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		sig := <-sigChannel
 		setSignalReceived()
 		slog.Info("received signal", slog.String("signal", sig.String()))
+		// propogate signal to children
+		util.SignalChildren(sig)
 	}()
 	// round up to next perfPrintInterval second (the collection interval used by perf stat)
 	if flagDuration != 0 {


### PR DESCRIPTION
Addresses https://github.com/intel/PerfSpect/issues/96.

When SIGINT or SIGTERM is received by the perfspect process, the signal will be sent to child processes.

This is to address the problem seen when SIGINT is sent through the signal command, e.g., when scripted.

