### PR TITLE
abbreviate uncore event names to shorten the length of the arguments on the perf command line

### DIFF
--- a/cmd/metrics/metric_defs.go
+++ b/cmd/metrics/metric_defs.go
@@ -136,6 +136,8 @@ func ConfigureMetrics(metrics []MetricDefinition, evaluatorFunctions map[string]
 		metrics[metricIdx].Expression = strings.ReplaceAll(metrics[metricIdx].Expression, "[SOCKET_COUNT]", socketCount)
 		metrics[metricIdx].Expression = strings.ReplaceAll(metrics[metricIdx].Expression, "[HYPERTHREADING_ON]", hyperThreadingOn)
 		metrics[metricIdx].Expression = strings.ReplaceAll(metrics[metricIdx].Expression, "[CONST_THREAD_COUNT]", threadsPerCore)
+		// abbreviate event names
+		metrics[metricIdx].Expression = abbreviateEventName(metrics[metricIdx].Expression)
 		// get a list of the variables in the expression
 		metrics[metricIdx].Variables = make(map[string]int)
 		expressionIdx := 0


### PR DESCRIPTION
The uncore events repeat for each related uncore device. On a system with many uncore devices (high core-count systems), this results in a large number of uncore events that will be request on the perf stat command line and possibly be too large for the bash arguments stack.

We defined a function that contains a list of verbose uncore event names and abbreviations for them. The function replaces the verbose name with the abbreviated form.
 
closes 101