### PR TITLE
Fix an issue for make dist: once the internal/resources directory contains no files, //go:embed will be invalid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ else # no prebuilt tools found
 		@echo "No prebuilt tools found in /prebuilt/tools or tools/bin"
 endif
 endif
+ifeq ("$(ls -A internal/script/resources/x86_64)","") # //go:embeded can not support empty directory
+	touch internal/script/resources/x86_64/nofiles
+endif
 
 
 # Build the distribution package


### PR DESCRIPTION
**Problem**

When build as 'make dist', it will report errors like below:
    
 ```
    internal/script/script.go:21:3: invalid go:embed: build system did not supply embed configuration (compile)
    internal/script/script.go:21:12: pattern resources: cannot embed directory resources: contains no embeddable files (compile)
    make: *** [Makefile:90: check_static] Error 1
```

**Proposed Solution**

Check if the resources/x64 directory is empty, if yes, just touch a empty file to workaround the go compilation error
