### PR TITLE
timeout on commands

### DIFF
--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -21,19 +21,6 @@ import (
 //go:embed resources
 var Resources embed.FS
 
-type ScriptDefinition struct {
-	Name          string   // just a name
-	Script        string   // the bash script that will be run
-	Architectures []string // architectures, i.e., x86_64, arm64. If empty, it will run on all architectures.
-	Families      []string // families, e.g., 6, 7. If empty, it will run on all families.
-	Models        []string // models, e.g., 62, 63. If empty, it will run on all models.
-	Lkms          []string // loadable kernel modules
-	Depends       []string // binary dependencies that must be available for the script to run
-	Superuser     bool     // requires sudo or root
-	Sequential    bool     // run script sequentially (not at the same time as others)
-	Timeout       int      // seconds
-}
-
 type ScriptOutput struct {
 	ScriptDefinition
 	Stdout   string
@@ -254,7 +241,7 @@ func RunScriptAsync(myTarget target.Target, script ScriptDefinition, localTempDi
 		}()
 	}
 	cmd := prepareCommand(script, myTarget.GetTempDirectory())
-	err = myTarget.RunCommandAsync(cmd, stdoutChannel, stderrChannel, exitcodeChannel, script.Timeout, cmdChannel)
+	err = myTarget.RunCommandAsync(cmd, stdoutChannel, stderrChannel, exitcodeChannel, 0, cmdChannel)
 	errorChannel <- err
 }
 

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -471,7 +471,7 @@ rdmsr 0x2FFE`, // uncore client cha count, uncore cha count, uncore cha count sp
 		},
 		{
 			Name:      LshwScriptName,
-			Script:    "lshw -businfo -numeric",
+			Script:    "timeout 30 lshw -businfo -numeric",
 			Depends:   []string{"lshw"},
 			Superuser: true,
 		},
@@ -489,7 +489,7 @@ rdmsr 0x2FFE`, // uncore client cha count, uncore cha count, uncore cha count sp
 		},
 		{
 			Name: NicInfoScriptName,
-			Script: `lshw -businfo -numeric | grep -E "^(pci|usb).*? \S+\s+network\s+\S.*?" \
+			Script: `timeout 30 lshw -businfo -numeric | grep -E "^(pci|usb).*? \S+\s+network\s+\S.*?" \
 | while read -r a ifc c ; do
 	ethtool "$ifc"
 	ethtool -i "$ifc"
@@ -588,26 +588,26 @@ done`,
 		},
 		{
 			Name:      IpmitoolSensorsScriptName,
-			Script:    "LC_ALL=C ipmitool sdr list full",
+			Script:    "LC_ALL=C timeout 30 ipmitool sdr list full",
 			Superuser: true,
 			Depends:   []string{"ipmitool"},
 		},
 		{
 			Name:      IpmitoolChassisScriptName,
-			Script:    "LC_ALL=C ipmitool chassis status",
+			Script:    "LC_ALL=C timeout 30 ipmitool chassis status",
 			Superuser: true,
 			Depends:   []string{"ipmitool"},
 		},
 		{
 			Name:      IpmitoolEventsScriptName,
-			Script:    `LC_ALL=C ipmitool sel elist | tail -n20 | cut -d'|' -f2-`,
+			Script:    `LC_ALL=C timeout 30 ipmitool sel elist | tail -n20 | cut -d'|' -f2-`,
 			Superuser: true,
 			Lkms:      []string{"ipmi_devintf", "ipmi_si"},
 			Depends:   []string{"ipmitool"},
 		},
 		{
 			Name:      IpmitoolEventTimeScriptName,
-			Script:    "LC_ALL=C ipmitool sel time get",
+			Script:    "LC_ALL=C timeout 30 ipmitool sel time get",
 			Superuser: true,
 			Depends:   []string{"ipmitool"},
 		},

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -11,6 +11,18 @@ import (
 	"strings"
 )
 
+type ScriptDefinition struct {
+	Name          string   // just a name
+	Script        string   // the bash script that will be run
+	Architectures []string // architectures, i.e., x86_64, arm64. If empty, it will run on all architectures.
+	Families      []string // families, e.g., 6, 7. If empty, it will run on all families.
+	Models        []string // models, e.g., 62, 63. If empty, it will run on all models.
+	Lkms          []string // loadable kernel modules
+	Depends       []string // binary dependencies that must be available for the script to run
+	Superuser     bool     // requires sudo or root
+	Sequential    bool     // run script sequentially (not at the same time as others)
+}
+
 const (
 	HostnameScriptName                          = "hostname"
 	DateScriptName                              = "date"

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -38,7 +38,6 @@ func TestRunScript(t *testing.T) {
 				Superuser: superuser,
 				Lkms:      []string{},
 				Depends:   []string{},
-				Timeout:   0,
 			}
 			tempDir, err := os.MkdirTemp(os.TempDir(), "test")
 			if err != nil {
@@ -73,7 +72,6 @@ echo "Core Count: $num_cores_per_socket"`,
 				Superuser: superuser,
 				Lkms:      []string{},
 				Depends:   []string{},
-				Timeout:   0,
 			}
 			tempDir, err = os.MkdirTemp(os.TempDir(), "test")
 			if err != nil {
@@ -109,7 +107,6 @@ mpstat -u -T -I SCPU -P ALL 1 $count`,
 					Superuser: superuser,
 					Lkms:      []string{},
 					Depends:   []string{"mpstat"},
-					Timeout:   0,
 				}
 				tempDir, err := os.MkdirTemp(os.TempDir(), "test")
 				if err != nil {


### PR DESCRIPTION
Use the Linux timeout command in scripts that we have historically seen enter endless loops or run for an unexpected duration.

This addresses a portion of #113.