### PR TITLE
build perf with support for bpf

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -146,7 +146,7 @@ PERF_LINUX_VERSION := 6.1.52
 perf:
 	wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-$(PERF_LINUX_VERSION).tar.xz
 	tar -xf linux-$(PERF_LINUX_VERSION).tar.xz && mv linux-$(PERF_LINUX_VERSION)/ linux_perf/
-	cd linux_perf/tools/perf && make LDFLAGS="-static --static"
+	cd linux_perf/tools/perf && make LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1
 
 spectre-meltdown-checker:
 ifeq ("$(wildcard spectre-meltdown-checker)","")

--- a/tools/build.Dockerfile
+++ b/tools/build.Dockerfile
@@ -6,7 +6,7 @@
 # build output oss_source* will be in workdir
 # build image (from project root directory):
 #   $ docker build -f tools/build.Dockerfile --tag perfspect-tools:$TAG ./tools
-FROM ubuntu:18.04 AS builder
+FROM ubuntu:22.04 AS builder
 ENV http_proxy=${http_proxy}
 ENV https_proxy=${https_proxy}
 ENV LANG=en_US.UTF-8
@@ -14,9 +14,17 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y apt-utils locales wget curl git netcat-openbsd software-properties-common jq zip unzip
 RUN locale-gen en_US.UTF-8 &&  echo "LANG=en_US.UTF-8" > /etc/default/locale
 RUN add-apt-repository ppa:git-core/ppa -y
-RUN apt-get update && apt-get install -y git build-essential autotools-dev automake \
-    gawk zlib1g-dev libtool libaio-dev libaio1 pandoc pkgconf libcap-dev docbook-utils \
-    libreadline-dev default-jre default-jdk cmake flex bison libssl-dev
+RUN apt-get update && apt-get install -y \
+    automake autotools-dev binutils-dev bison build-essential clang cmake debuginfod \
+    default-jdk default-jre docbook-utils flex gawk git libaio-dev libaio1 \
+    libbabeltrace-dev libbpf-dev libc6 libcap-dev libdw-dev libdwarf-dev libelf-dev \
+    libiberty-dev liblzma-dev libnuma-dev libperl-dev libpfm4-dev libreadline-dev \
+    libslang2-dev libssl-dev libtool libtraceevent-dev libunwind-dev libzstd-dev \
+    libzstd1 llvm-13 pandoc pkgconf python-setuptools python2-dev python3 python3-dev \
+    python3-pip systemtap-sdt-dev zlib1g-dev
+
+RUN bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+ENV PATH="${PATH}:/usr/lib/llvm-18/bin"
 
 ENV JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64
 


### PR DESCRIPTION
bpf is required for new lock analysis functionality in the 'lock' command

This PR makes the required changes to the build image. The base image is moved to Ubuntu 22.04, so need to run tests across array of OS to verify compatibility.