### PR TITLE
perfspect report flag 'all' is true by default

### DIFF
--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -182,7 +182,7 @@ func init() {
 	}
 	// set up other flags
 	Cmd.Flags().StringVar(&common.FlagInput, common.FlagInputName, "", "")
-	Cmd.Flags().BoolVar(&flagAll, flagAllName, false, "")
+	Cmd.Flags().BoolVar(&flagAll, flagAllName, true, "")
 	Cmd.Flags().StringSliceVar(&common.FlagFormat, common.FlagFormatName, []string{report.FormatAll}, "")
 	Cmd.Flags().StringSliceVar(&flagBenchmark, flagBenchmarkName, []string{}, "")
 
@@ -263,17 +263,13 @@ func getFlagGroups() []common.FlagGroup {
 }
 
 func validateFlags(cmd *cobra.Command, args []string) error {
-	// set flagAll if all categories are selected or if none are selected
-	if !flagAll {
-		numCategoriesTrue := 0
+	// clear flagAll if any categories are selected
+	if flagAll {
 		for _, cat := range categories {
-			if *cat.FlagVar {
-				numCategoriesTrue++
+			if cat.FlagVar != nil && *cat.FlagVar {
+				flagAll = false
 				break
 			}
-		}
-		if numCategoriesTrue == len(categories) || numCategoriesTrue == 0 {
-			flagAll = true
 		}
 	}
 	// validate format options


### PR DESCRIPTION
With no category flags specified, 'all' is true by default.  If any categories are selected, all will be dynamically changed to false.

This change eliminates some confusion in the help text.