### PR TITLE
support for GCP C4 instances

### DIFF
--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -883,7 +883,8 @@ func prepareMetrics(targetContext *targetContext, localTempDir string, channelEr
 		return
 	}
 	// load metric definitions
-	if targetContext.metricDefinitions, err = LoadMetricDefinitions(flagMetricFilePath, flagMetricsList, uncollectableEvents, targetContext.metadata); err != nil {
+	var loadedMetrics []MetricDefinition
+	if loadedMetrics, err = LoadMetricDefinitions(flagMetricFilePath, flagMetricsList, targetContext.metadata); err != nil {
 		err = fmt.Errorf("failed to load metric definitions: %w", err)
 		_ = statusUpdate(myTarget.GetName(), fmt.Sprintf("Error: %s", err.Error()))
 		targetContext.err = err
@@ -891,7 +892,7 @@ func prepareMetrics(targetContext *targetContext, localTempDir string, channelEr
 		return
 	}
 	// configure metrics
-	if err = ConfigureMetrics(targetContext.metricDefinitions, GetEvaluatorFunctions(), targetContext.metadata); err != nil {
+	if targetContext.metricDefinitions, err = ConfigureMetrics(loadedMetrics, uncollectableEvents, GetEvaluatorFunctions(), targetContext.metadata); err != nil {
 		err = fmt.Errorf("failed to configure metrics: %w", err)
 		_ = statusUpdate(myTarget.GetName(), fmt.Sprintf("Error: %s", err.Error()))
 		targetContext.err = err

--- a/cmd/metrics/summary.go
+++ b/cmd/metrics/summary.go
@@ -199,7 +199,7 @@ func (m *metricsFromCSV) getStats() (stats map[string]metricStats, err error) {
 		sum := 0.0
 		for _, row := range m.rows {
 			val := row.metrics[metricName]
-			if math.IsNaN(val) {
+			if math.IsNaN(val) || math.IsInf(val, 0) {
 				continue
 			}
 			if math.IsNaN(min) { // min was initialized to NaN


### PR DESCRIPTION
GCP c4-standard instances expose PMUs at different levels -- disabled, architectural, standard, enhanced. Only c4-standard-96 and 192 support enhanced.  See GCP docs for details on what each level includes.

This PR handles the issues we ran into when attempting to collect metrics on the above, e.g., unexpected "not supported" events and zero values causing expressions to evaluate as +Inf.  