### PR TITLE
assume events not supported on failure when loading metadata for metrics command

### DIFF
--- a/cmd/metrics/metadata.go
+++ b/cmd/metrics/metadata.go
@@ -206,7 +206,7 @@ func LoadMetadata(myTarget target.Target, noRoot bool, perfPath string, localTem
 		errs = append(errs, <-slowFuncChannel)
 		for _, errInside := range errs {
 			if errInside != nil {
-				slog.Warn("error loading metadata", slog.String("error", errInside.Error()), slog.String("target", myTarget.GetName()))
+				slog.Error("error loading metadata", slog.String("error", errInside.Error()), slog.String("target", myTarget.GetName()))
 				err = fmt.Errorf("target not supported, see log for details")
 			}
 		}

--- a/cmd/metrics/metadata.go
+++ b/cmd/metrics/metadata.go
@@ -101,7 +101,7 @@ func LoadMetadata(myTarget target.Target, noRoot bool, perfPath string, localTem
 		err = fmt.Errorf("failed to retrieve PMU driver version: %v", err)
 		return
 	}
-	// reduce startup time by running the three perf commands in their own threads
+	// reduce startup time by running the perf commands in their own threads
 	slowFuncChannel := make(chan error)
 	// perf list
 	go func() {
@@ -116,7 +116,8 @@ func LoadMetadata(myTarget target.Target, noRoot bool, perfPath string, localTem
 		var err error
 		var output string
 		if metadata.SupportsRefCycles, output, err = getSupportsRefCycles(myTarget, noRoot, perfPath, localTempDir); err != nil {
-			err = fmt.Errorf("failed to determine if ref_cycles is supported: %v", err)
+			slog.Warn("failed to determine if ref_cycles is supported, assuming not supported", slog.String("error", err.Error()))
+			err = nil
 		} else {
 			if !metadata.SupportsRefCycles {
 				slog.Warn("ref-cycles not supported", slog.String("output", output))
@@ -129,7 +130,8 @@ func LoadMetadata(myTarget target.Target, noRoot bool, perfPath string, localTem
 		var err error
 		var output string
 		if metadata.SupportsFixedTMA, output, err = getSupportsFixedTMA(myTarget, noRoot, perfPath, localTempDir); err != nil {
-			err = fmt.Errorf("failed to determine if fixed-counter TMA is supported: %v", err)
+			slog.Warn("failed to determine if fixed-counter TMA is supported, assuming not supported", slog.String("error", err.Error()))
+			err = nil
 		} else {
 			if !metadata.SupportsFixedTMA {
 				slog.Warn("Fixed-counter TMA events not supported", slog.String("output", output))
@@ -142,7 +144,8 @@ func LoadMetadata(myTarget target.Target, noRoot bool, perfPath string, localTem
 		var err error
 		var output string
 		if metadata.SupportsFixedCycles, output, err = getSupportsFixedEvent(myTarget, "cpu-cycles", cpu.MicroArchitecture, noRoot, perfPath, localTempDir); err != nil {
-			err = fmt.Errorf("failed to determine if fixed-counter 'cpu-cycles' is supported: %v", err)
+			slog.Warn("failed to determine if fixed-counter 'cpu-cycles' is supported, assuming not supported", slog.String("error", err.Error()))
+			err = nil
 		} else {
 			if !metadata.SupportsFixedCycles {
 				slog.Warn("Fixed-counter 'cpu-cycles' events not supported", slog.String("output", output))
@@ -155,7 +158,8 @@ func LoadMetadata(myTarget target.Target, noRoot bool, perfPath string, localTem
 		var err error
 		var output string
 		if metadata.SupportsFixedInstructions, output, err = getSupportsFixedEvent(myTarget, "instructions", cpu.MicroArchitecture, noRoot, perfPath, localTempDir); err != nil {
-			err = fmt.Errorf("failed to determine if fixed-counter 'instructions' is supported: %v", err)
+			slog.Warn("failed to determine if fixed-counter 'instructions' is supported, assuming not supported", slog.String("error", err.Error()))
+			err = nil
 		} else {
 			if !metadata.SupportsFixedInstructions {
 				slog.Warn("Fixed-counter 'instructions' events not supported", slog.String("output", output))
@@ -168,7 +172,8 @@ func LoadMetadata(myTarget target.Target, noRoot bool, perfPath string, localTem
 		var err error
 		var output string
 		if metadata.SupportsPEBS, output, err = getSupportsPEBS(myTarget, noRoot, perfPath, localTempDir); err != nil {
-			err = fmt.Errorf("failed to determine if 'PEBS' is supported: %v", err)
+			slog.Warn("failed to determine if 'PEBS' is supported, assuming not supported", slog.String("error", err.Error()))
+			err = nil
 		} else {
 			if !metadata.SupportsPEBS {
 				slog.Warn("'PEBS' events not supported", slog.String("output", output))
@@ -181,7 +186,8 @@ func LoadMetadata(myTarget target.Target, noRoot bool, perfPath string, localTem
 		var err error
 		var output string
 		if metadata.SupportsOCR, output, err = getSupportsOCR(myTarget, noRoot, perfPath, localTempDir); err != nil {
-			err = fmt.Errorf("failed to determine if 'OCR' is supported: %v", err)
+			slog.Warn("failed to determine if 'OCR' is supported, assuming not supported", slog.String("error", err.Error()))
+			err = nil
 		} else {
 			if !metadata.SupportsOCR {
 				slog.Warn("'OCR' events not supported", slog.String("output", output))
@@ -200,8 +206,8 @@ func LoadMetadata(myTarget target.Target, noRoot bool, perfPath string, localTem
 		errs = append(errs, <-slowFuncChannel)
 		for _, errInside := range errs {
 			if errInside != nil {
-				slog.Error("error loading metadata", slog.String("error", errInside.Error()), slog.String("target", myTarget.GetName()))
-				err = fmt.Errorf("target not supported, see log for details")
+				slog.Warn("error loading metadata", slog.String("error", errInside.Error()), slog.String("target", myTarget.GetName()))
+				err = nil //err = fmt.Errorf("target not supported, see log for details")
 			}
 		}
 	}()

--- a/cmd/metrics/metadata.go
+++ b/cmd/metrics/metadata.go
@@ -207,7 +207,7 @@ func LoadMetadata(myTarget target.Target, noRoot bool, perfPath string, localTem
 		for _, errInside := range errs {
 			if errInside != nil {
 				slog.Warn("error loading metadata", slog.String("error", errInside.Error()), slog.String("target", myTarget.GetName()))
-				err = nil //err = fmt.Errorf("target not supported, see log for details")
+				err = fmt.Errorf("target not supported, see log for details")
 			}
 		}
 	}()


### PR DESCRIPTION
If an error is encountered when checking for various event types, continue with a warning and assume that the event type is not supported.