### PR TITLE
make sure PMUs are not in use when running the metrics command

### DIFF
--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -806,6 +806,25 @@ func prepareTarget(targetContext *targetContext, targetTempRoot string, localTem
 		channelError <- targetError{target: myTarget, err: err}
 		return
 	}
+	// make sure PMUs are not in use on target
+	output, err := script.RunScript(myTarget, script.GetScriptByName(script.PMUBusyScriptName), localTempDir)
+	if err != nil {
+		err = fmt.Errorf("failed to check if PMUs are in use: %w", err)
+		_ = statusUpdate(myTarget.GetName(), fmt.Sprintf("Error: %v", err))
+		targetContext.err = err
+		channelError <- targetError{target: myTarget, err: err}
+		return
+	}
+	for _, line := range strings.Split(output.Stdout, "\n") {
+		// if one of the MSR registers is active (ignore cpu_cycles), then the PMU is in use
+		if strings.Contains(line, "Active") && !strings.Contains(line, "0x30a") {
+			err = fmt.Errorf("PMU in use on target: %s", line)
+			_ = statusUpdate(myTarget.GetName(), fmt.Sprintf("Error: %v", err))
+			targetContext.err = err
+			channelError <- targetError{target: myTarget, err: err}
+			return
+		}
+	}
 	// check if NMI watchdog is enabled and disable it if necessary
 	if !flagNoRoot {
 		var nmiWatchdogEnabled bool


### PR DESCRIPTION
If another tool is using the PMUs, PerfSpect metrics will not get accurate data.