### PR TITLE
Enable interruption of PerfSpect with SIGINT (ctrl-c) when collecting data over SSH

### DIFF
--- a/cmd/metrics/metadata.go
+++ b/cmd/metrics/metadata.go
@@ -343,7 +343,7 @@ func getUncoreDeviceIDs(myTarget target.Target, localTempDir string) (IDs map[st
 // getCPUInfo - reads and returns all data from /proc/cpuinfo
 func getCPUInfo(myTarget target.Target) (cpuInfo []map[string]string, err error) {
 	cmd := exec.Command("cat", "/proc/cpuinfo")
-	stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0)
+	stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0, true)
 	if err != nil {
 		err = fmt.Errorf("failed to get cpuinfo: %s, %d, %v", stderr, exitcode, err)
 		return
@@ -369,7 +369,7 @@ func getCPUInfo(myTarget target.Target) (cpuInfo []map[string]string, err error)
 // 'perf list'
 func getPerfSupportedEvents(myTarget target.Target, perfPath string) (supportedEvents string, err error) {
 	cmd := exec.Command(perfPath, "list")
-	stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0)
+	stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0, true)
 	if err != nil {
 		err = fmt.Errorf("failed to get perf list: %s, %d, %v", stderr, exitcode, err)
 		return

--- a/cmd/metrics/nmi_watchdog.go
+++ b/cmd/metrics/nmi_watchdog.go
@@ -48,7 +48,7 @@ func getNMIWatchdog(myTarget target.Target) (setting string, err error) {
 		return
 	}
 	cmd := exec.Command(sysctl, "kernel.nmi_watchdog")
-	stdout, _, _, err := myTarget.RunCommand(cmd, 0)
+	stdout, _, _, err := myTarget.RunCommand(cmd, 0, true)
 	if err != nil {
 		return
 	}
@@ -86,7 +86,7 @@ func setNMIWatchdog(myTarget target.Target, setting string, localTempDir string)
 // findSysctl - gets a useable path to sysctl or error
 func findSysctl(myTarget target.Target) (path string, err error) {
 	cmd := exec.Command("which", "sysctl")
-	stdout, _, _, err := myTarget.RunCommand(cmd, 0)
+	stdout, _, _, err := myTarget.RunCommand(cmd, 0, true)
 	if err == nil {
 		//found it
 		path = strings.TrimSpace(stdout)
@@ -95,7 +95,7 @@ func findSysctl(myTarget target.Target) (path string, err error) {
 	// didn't find it on the path, try being specific
 	sbinPath := "/usr/sbin/sysctl"
 	cmd = exec.Command("which", sbinPath)
-	_, _, _, err = myTarget.RunCommand(cmd, 0)
+	_, _, _, err = myTarget.RunCommand(cmd, 0, true)
 	if err == nil {
 		// found it
 		path = sbinPath

--- a/cmd/metrics/process.go
+++ b/cmd/metrics/process.go
@@ -63,7 +63,7 @@ func GetCgroups(myTarget target.Target, cids []string, localTempDir string) (cgr
 func GetHotProcesses(myTarget target.Target, maxProcesses int, filter string) (processes []Process, err error) {
 	// run ps to get list of processes sorted by cpu utilization (descending)
 	cmd := exec.Command("ps", "-a", "-x", "-h", "-o", "pid,ppid,comm,cmd", "--sort=-%cpu")
-	stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0)
+	stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0, true)
 	if err != nil {
 		err = fmt.Errorf("failed to get hot processes: %s, %d, %v", stderr, exitcode, err)
 		return
@@ -173,7 +173,7 @@ done | sort -nr | head -n %d
 
 func processExists(myTarget target.Target, pid string) (exists bool) {
 	cmd := exec.Command("ps", "-p", pid)
-	_, _, _, err := myTarget.RunCommand(cmd, 0)
+	_, _, _, err := myTarget.RunCommand(cmd, 0, true)
 	if err != nil {
 		exists = false
 		return
@@ -184,7 +184,7 @@ func processExists(myTarget target.Target, pid string) (exists bool) {
 
 func getProcess(myTarget target.Target, pid string) (process Process, err error) {
 	cmd := exec.Command("ps", "-q", pid, "h", "-o", "pid,ppid,comm,cmd", "ww")
-	stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0)
+	stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0, true)
 	if err != nil {
 		err = fmt.Errorf("failed to get process: %s, %d, %v", stderr, exitcode, err)
 		return

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -160,7 +160,7 @@ func RunScripts(myTarget target.Target, scripts []ScriptDefinition, ignoreScript
 		} else {
 			cmd = exec.Command("bash", path.Join(myTarget.GetTempDirectory(), masterScriptName))
 		}
-		stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0)
+		stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0, false) // don't reuse ssh connection on long-running commands, makes it difficult to kill the command
 		if err != nil {
 			slog.Error("error running master script on target", slog.String("stdout", stdout), slog.String("stderr", stderr), slog.Int("exitcode", exitcode), slog.String("error", err.Error()))
 			return nil, err
@@ -183,7 +183,7 @@ func RunScripts(myTarget target.Target, scripts []ScriptDefinition, ignoreScript
 	// run sequential scripts
 	for _, script := range sequentialScripts {
 		cmd := prepareCommand(script, myTarget.GetTempDirectory())
-		stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0)
+		stdout, stderr, exitcode, err := myTarget.RunCommand(cmd, 0, false)
 		if err != nil {
 			slog.Error("error running script on target", slog.String("script", script.Script), slog.String("stdout", stdout), slog.String("stderr", stderr), slog.Int("exitcode", exitcode), slog.String("error", err.Error()))
 		}
@@ -241,7 +241,7 @@ func RunScriptAsync(myTarget target.Target, script ScriptDefinition, localTempDi
 		}()
 	}
 	cmd := prepareCommand(script, myTarget.GetTempDirectory())
-	err = myTarget.RunCommandAsync(cmd, stdoutChannel, stderrChannel, exitcodeChannel, 0, cmdChannel)
+	err = myTarget.RunCommandAsync(cmd, 0, false, stdoutChannel, stderrChannel, exitcodeChannel, cmdChannel)
 	errorChannel <- err
 }
 


### PR DESCRIPTION
Changed the target RunCommand interface to accept a boolean that indicates if the SSH connection can be re-used, i.e., use SSH control master.

Changed long running commands, e.g., the report collection master script, to NOT use the SSH control master. This allows SIGINT to stop child processes, e.g., ssh.

Now, if collecting remote data using the 'report' command, ctrl-c will interrupt, and stop, PerfSpect.