### PR TITLE
add instruction mix reporting to telemetry command

### DIFF
--- a/cmd/flame/flame.go
+++ b/cmd/flame/flame.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"perfspect/internal/common"
 	"perfspect/internal/report"
+	"perfspect/internal/script"
 	"perfspect/internal/util"
 	"strings"
 
@@ -138,8 +139,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	reportingCommand := common.ReportingCommand{
 		Cmd:            cmd,
 		ReportNamePost: "flame",
-		Frequency:      flagFrequency,
-		Duration:       flagDuration,
+		ScriptParams:   script.ScriptParams{Frequency: flagFrequency, Duration: flagDuration},
 		TableNames:     []string{report.CodePathFrequencyTableName},
 	}
 	return reportingCommand.Run()

--- a/cmd/lock/lock.go
+++ b/cmd/lock/lock.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"perfspect/internal/common"
 	"perfspect/internal/report"
+	"perfspect/internal/script"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -115,8 +116,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	reportingCommand := common.ReportingCommand{
 		Cmd:            cmd,
 		ReportNamePost: "lock",
-		Frequency:      flagFrequency,
-		Duration:       flagDuration,
+		ScriptParams:   script.ScriptParams{Frequency: flagFrequency, Duration: flagDuration},
 		TableNames:     []string{report.KernelLockAnalysisTableName},
 	}
 	return reportingCommand.Run()

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -333,7 +333,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	}
 	reportingCommand := common.ReportingCommand{
 		Cmd:              cmd,
-		StorageDir:       flagStorageDir,
+		ScriptParams:     script.ScriptParams{StorageDir: flagStorageDir},
 		TableNames:       tableNames,
 		SummaryFunc:      summaryFunc,
 		SummaryTableName: benchmarkSummaryTableName,

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -80,10 +80,7 @@ type ReportingCommand struct {
 	Cmd              *cobra.Command
 	ReportNamePost   string
 	TableNames       []string
-	Duration         int
-	Interval         int
-	Frequency        int
-	StorageDir       string
+	ScriptParams     script.ScriptParams
 	SummaryFunc      SummaryFunc
 	SummaryTableName string
 	InsightsFunc     InsightsFunc
@@ -138,7 +135,7 @@ func (rc *ReportingCommand) Run() error {
 		// make a list of unique script definitions
 		var scriptsToRun []script.ScriptDefinition
 		for _, scriptName := range scriptNames {
-			scriptsToRun = append(scriptsToRun, script.GetParameterizedScriptByName(scriptName, rc.Duration, rc.Interval, rc.Frequency, rc.StorageDir))
+			scriptsToRun = append(scriptsToRun, script.GetParameterizedScriptByName(scriptName, rc.ScriptParams))
 		}
 		// do any of the scripts require elevated privileges?
 		elevated := false
@@ -188,7 +185,7 @@ func (rc *ReportingCommand) Run() error {
 		channelTargetScriptOutputs := make(chan TargetScriptOutputs)
 		channelError := make(chan error)
 		for _, target := range myTargets {
-			go collectOnTarget(rc.Cmd, rc.Duration, target, scriptsToRun, localTempDir, channelTargetScriptOutputs, channelError, multiSpinner.Status)
+			go collectOnTarget(rc.Cmd, rc.ScriptParams.Duration, target, scriptsToRun, localTempDir, channelTargetScriptOutputs, channelError, multiSpinner.Status)
 		}
 		// wait for scripts to run on all targets
 		var allTargetScriptOutputs []TargetScriptOutputs

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -1065,7 +1065,7 @@ func kernelLockAnalysisHTMLRenderer(tableValues TableValues, targetName string) 
 func instructionMixTableHTMLRenderer(tableValues TableValues, targetname string) string {
 	data := [][]scatterPoint{}
 	datasetNames := []string{}
-	for _, field := range tableValues.Fields {
+	for _, field := range tableValues.Fields[1:] {
 		points := []scatterPoint{}
 		for i, val := range field.Values {
 			if val == "" {

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -743,7 +743,7 @@ func cpuUtilizationTableHTMLRenderer(tableValues TableValues, targetName string)
 	}
 	chartConfig := scatterChartTemplateStruct{
 		ID:            fmt.Sprintf("cpuUtilization%d", rand.Intn(10000)),
-		XaxisText:     "Time/Samples",
+		XaxisText:     "Time",
 		YaxisText:     "% Utilization",
 		TitleText:     "",
 		DisplayTitle:  "false",
@@ -778,7 +778,7 @@ func averageCPUUtilizationTableHTMLRenderer(tableValues TableValues, targetName 
 	}
 	chartConfig := scatterChartTemplateStruct{
 		ID:            fmt.Sprintf("avgCPUUtil%d", rand.Intn(10000)),
-		XaxisText:     "Time/Samples",
+		XaxisText:     "Time",
 		YaxisText:     "% Utilization",
 		TitleText:     "",
 		DisplayTitle:  "false",
@@ -819,7 +819,7 @@ func irqRateTableHTMLRenderer(tableValues TableValues, targetName string) string
 	}
 	chartConfig := scatterChartTemplateStruct{
 		ID:            fmt.Sprintf("irqRate%d", rand.Intn(10000)),
-		XaxisText:     "Time/Samples",
+		XaxisText:     "Time",
 		YaxisText:     "IRQ/s",
 		TitleText:     "",
 		DisplayTitle:  "false",
@@ -875,7 +875,7 @@ func driveStatsTableHTMLRenderer(tableValues TableValues, targetName string) str
 		}
 		chartConfig := scatterChartTemplateStruct{
 			ID:            fmt.Sprintf("driveStats%d", rand.Intn(10000)),
-			XaxisText:     "Time/Samples",
+			XaxisText:     "Time",
 			YaxisText:     "",
 			TitleText:     drive,
 			DisplayTitle:  "true",
@@ -933,7 +933,7 @@ func networkStatsTableHTMLRenderer(tableValues TableValues, targetName string) s
 		}
 		chartConfig := scatterChartTemplateStruct{
 			ID:            fmt.Sprintf("nicStats%d", rand.Intn(10000)),
-			XaxisText:     "Time/Samples",
+			XaxisText:     "Time",
 			YaxisText:     "",
 			TitleText:     nic,
 			DisplayTitle:  "true",
@@ -970,7 +970,7 @@ func memoryStatsTableHTMLRenderer(tableValues TableValues, targetName string) st
 	}
 	chartConfig := scatterChartTemplateStruct{
 		ID:            fmt.Sprintf("memoryStats%d", rand.Intn(10000)),
-		XaxisText:     "Time/Samples",
+		XaxisText:     "Time",
 		YaxisText:     "kilobytes",
 		TitleText:     "",
 		DisplayTitle:  "false",
@@ -1005,7 +1005,7 @@ func powerStatsTableHTMLRenderer(tableValues TableValues, targetName string) str
 	}
 	chartConfig := scatterChartTemplateStruct{
 		ID:            fmt.Sprintf("powerStats%d", rand.Intn(10000)),
-		XaxisText:     "Time/Samples",
+		XaxisText:     "Time",
 		YaxisText:     "Watts",
 		TitleText:     "",
 		DisplayTitle:  "false",
@@ -1060,4 +1060,39 @@ func kernelLockAnalysisHTMLRenderer(tableValues TableValues, targetName string) 
 		tableValueStyles = append(tableValueStyles, rowStyles)
 	}
 	return renderHTMLTable([]string{}, values, "pure-table pure-table-striped", tableValueStyles)
+}
+
+func instructionMixTableHTMLRenderer(tableValues TableValues, targetname string) string {
+	data := [][]scatterPoint{}
+	datasetNames := []string{}
+	for _, field := range tableValues.Fields {
+		points := []scatterPoint{}
+		for i, val := range field.Values {
+			if val == "" {
+				break
+			}
+			stat, err := strconv.ParseFloat(val, 64)
+			if err != nil {
+				slog.Error("error parsing stat", slog.String("error", err.Error()))
+				return ""
+			}
+			points = append(points, scatterPoint{float64(i), stat})
+		}
+		if len(points) > 0 {
+			data = append(data, points)
+			datasetNames = append(datasetNames, field.Name)
+		}
+	}
+	chartConfig := scatterChartTemplateStruct{
+		ID:            fmt.Sprintf("instrMix%d", rand.Intn(10000)),
+		XaxisText:     "Time",
+		YaxisText:     "% Samples",
+		TitleText:     "",
+		DisplayTitle:  "false",
+		DisplayLegend: "true",
+		AspectRatio:   "2",
+		SuggestedMin:  "0",
+		SuggestedMax:  "0",
+	}
+	return renderScatterChart(data, datasetNames, chartConfig)
 }

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -1101,6 +1101,7 @@ fi
 		{
 			Name: InstructionMixScriptName,
 			Script: func() string {
+				script := fmt.Sprintf("echo TIME: $(date +\"%%H:%%M:%%S\")\necho INTERVAL: %d\n", params.Interval)
 				scriptParts := []string{
 					"processwatch -c",
 				}
@@ -1120,7 +1121,7 @@ fi
 				if params.Interval != 0 {
 					scriptParts = append(scriptParts, fmt.Sprintf("-i %d", params.Interval))
 				}
-				return strings.Join(scriptParts, " ")
+				return script + strings.Join(scriptParts, " ")
 			}(),
 			Superuser: true,
 			Lkms:      []string{"msr"},

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -1104,7 +1104,7 @@ fi
 				scriptParts := []string{
 					"processwatch -c",
 				}
-				// if no PID specified, increase the sampling interval (defaults to 10,000) to reduce overhead
+				// if no PID specified, increase the sampling interval (defaults to 100,000) to reduce overhead
 				if params.PID == 0 {
 					scriptParts = append(scriptParts, fmt.Sprintf("-s %d", 1000000))
 				} else {

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -167,8 +167,9 @@ processwatch:
 ifeq ("$(wildcard processwatch)","")
 	git clone --recursive https://github.com/intel/processwatch.git
 else
-	cd processwatch && git checkout master && git pull
+	cd processwatch && git checkout main && git pull
 endif
+	cd processwatch && git checkout c394065 # this commit id has been tested
 	cd processwatch && ./build.sh
 	mkdir -p bin
 	cp processwatch/processwatch bin/

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,7 +5,7 @@
 #
 
 default: tools
-.PHONY: default tools async-profiler avx-turbo cpuid dmidecode ethtool fio flamegraph ipmitool lshw lspci msr-tools pcm perf spectre-meltdown-checker sshpass stress-ng sysstat tsc turbostat
+.PHONY: default tools async-profiler avx-turbo cpuid dmidecode ethtool fio flamegraph ipmitool lshw lspci msr-tools pcm perf processwatch spectre-meltdown-checker sshpass stress-ng sysstat tsc turbostat
 
 tools: async-profiler avx-turbo cpuid dmidecode ethtool fio flamegraph ipmitool lshw lspci msr-tools pcm spectre-meltdown-checker sshpass stress-ng sysstat tsc turbostat
 	mkdir -p bin
@@ -162,6 +162,17 @@ perf:
 	mkdir -p bin
 	cp linux_perf/tools/perf/perf bin/
 	strip --strip-unneeded bin/perf
+
+processwatch:
+ifeq ("$(wildcard processwatch)","")
+	git clone --recursive https://github.com/intel/processwatch.git
+else
+	cd processwatch && git checkout master && git pull
+endif
+	cd processwatch && ./build.sh
+	mkdir -p bin
+	cp processwatch/processwatch bin/
+	strip --strip-unneeded bin/processwatch
 
 spectre-meltdown-checker:
 ifeq ("$(wildcard spectre-meltdown-checker)","")

--- a/tools/build.Dockerfile
+++ b/tools/build.Dockerfile
@@ -52,6 +52,7 @@ RUN mkdir workdir
 ADD . /workdir
 WORKDIR /workdir
 RUN make perf
+RUN make processwatch
 
 FROM scratch AS output
 COPY --from=builder workdir/bin /bin


### PR DESCRIPTION
Use Intel [ProcessWatch ](https://github.com/intel/processwatch) to report instruction mix within the PerfSpect telemetry command.

![image](https://github.com/user-attachments/assets/4351d2f5-eea5-4861-8fde-c3edfed11af6)
