### PR TITLE
change flame and lock help to show 'all' is default format option

### DIFF
--- a/cmd/flame/flame.go
+++ b/cmd/flame/flame.go
@@ -48,7 +48,7 @@ const (
 
 func init() {
 	Cmd.Flags().StringVar(&common.FlagInput, common.FlagInputName, "", "")
-	Cmd.Flags().StringSliceVar(&common.FlagFormat, common.FlagFormatName, []string{report.FormatHtml}, "")
+	Cmd.Flags().StringSliceVar(&common.FlagFormat, common.FlagFormatName, []string{report.FormatAll}, "")
 	Cmd.Flags().IntVar(&flagDuration, flagDurationName, 30, "")
 	Cmd.Flags().IntVar(&flagFrequency, flagFrequencyName, 11, "")
 

--- a/cmd/lock/lock.go
+++ b/cmd/lock/lock.go
@@ -47,7 +47,7 @@ const (
 
 func init() {
 	Cmd.Flags().StringVar(&common.FlagInput, common.FlagInputName, "", "")
-	Cmd.Flags().StringSliceVar(&common.FlagFormat, common.FlagFormatName, []string{report.FormatHtml}, "")
+	Cmd.Flags().StringSliceVar(&common.FlagFormat, common.FlagFormatName, []string{report.FormatAll}, "")
 	Cmd.Flags().IntVar(&flagDuration, flagDurationName, 10, "")
 	Cmd.Flags().IntVar(&flagFrequency, flagFrequencyName, 11, "")
 


### PR DESCRIPTION
fix bug in help output for flame and lock commands