### PR TITLE
don't use bc in script as it is not available, by default, on some Linux OS distributions

### DIFF
--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -703,9 +703,9 @@ done`,
 #  need at least 2 GB (2,097,152 KB) of huge pages per NUMA node
 min_kb=2097152
 numa_nodes=$( lscpu | grep "NUMA node(s):" | awk '{print $3}' )
-size_huge_pages_kb=$( cat /proc/meminfo | grep Hugepagesize | awk '{print $2}' )
+size_huge_pages_kb=$( grep Hugepagesize /proc/meminfo | awk '{print $2}' )
 orig_num_huge_pages=$( cat /proc/sys/vm/nr_hugepages )
-needed_num_huge_pages=$( echo "$numa_nodes * $min_kb / $size_huge_pages_kb" | bc )
+needed_num_huge_pages=$((numa_nodes * min_kb / size_huge_pages_kb))
 if [ $needed_num_huge_pages -gt $orig_num_huge_pages ]; then
   echo $needed_num_huge_pages > /proc/sys/vm/nr_hugepages
 fi
@@ -723,9 +723,9 @@ echo $orig_num_huge_pages > /proc/sys/vm/nr_hugepages`,
 #  need at least 2 GB (2,097,152 KB) of huge pages per NUMA node
 min_kb=2097152
 numa_nodes=$( lscpu | grep "NUMA node(s):" | awk '{print $3}' )
-size_huge_pages_kb=$( cat /proc/meminfo | grep Hugepagesize | awk '{print $2}' )
+size_huge_pages_kb=$( grep Hugepagesize /proc/meminfo | awk '{print $2}' )
 orig_num_huge_pages=$( cat /proc/sys/vm/nr_hugepages )
-needed_num_huge_pages=$( echo "$numa_nodes * $min_kb / $size_huge_pages_kb" | bc )
+needed_num_huge_pages=$((numa_nodes * min_kb / size_huge_pages_kb))
 if [ $needed_num_huge_pages -gt $orig_num_huge_pages ]; then
   echo $needed_num_huge_pages > /proc/sys/vm/nr_hugepages
 fi


### PR DESCRIPTION
replace bc in scripts, now runs on Ubuntu 22.04 AWS images:

```
$ ./perfspect report --target 10.114.163.29 --user ubuntu --key ~/config/tools-cicd-us-west-2.pem --benchmark numa,memory --debug --host --format txt --os
10.114.163.29         ⣯  collection complete                     

10.114.163.29:
Host
====
Host Name: ip-10-114-163-29
Time:      Wed Jan 29 23:22:48 UTC 2025
System:    Amazon EC2 m7a.8xlarge
Baseboard: Amazon EC2 Not Specified
Chassis:   Amazon EC2 Other

Operating System
================
OS:              Ubuntu 22.04.5 LTS
Kernel:          6.8.0-1021-aws
Boot Parameters: BOOT_IMAGE=/boot/vmlinuz-6.8.0-1021-aws root=PARTUUID=7e653fbc-1bf4-4ca7-905a-3ed95c2fd3f9 ro console=tty1 console=ttyS0 nvme_core.io_timeout=4294967295 panic=-1
Microcode:       0xa101154

NUMA Bandwidth
==============
Node   0  
----   -  
0      154.1

Memory Latency
==============
Latency (ns)   Bandwidth (GB/s)
------------   ----------------
150.01         1.9
150.04         3.6
150.31         6.2
150.69         8.7
151.66         11.9
152.45         17.3
157.18         22.4
158.10         28.8
159.38         40.4
160.84         55.6
162.10         68.5
164.14         94.6
169.10         140.1
599.37         154.0
605.32         154.1
608.48         154.0
609.30         154.1
608.52         154.0
608.65         154.1

PerfSpect Version
=================
Version: 3.2.0_2025-01-25_7780f872

Report files:
  /home/xxxxxxxx/dev/perfspect/perfspect_2025-01-29_15-22-43/10.114.163.29.txt
```