### PR TITLE
fix regression in metrics command causing error on some AWS m5 and m6 instance types

### DIFF
--- a/cmd/metrics/event_defs.go
+++ b/cmd/metrics/event_defs.go
@@ -144,7 +144,7 @@ func isCollectableEvent(event EventDefinition, metadata Metadata) bool {
 	}
 	// off-core response events
 	if event.Device == "cpu" && (strings.HasPrefix(event.Name, "OCR") || strings.HasPrefix(event.Name, "OFFCORE_REQUESTS_OUTSTANDING")) {
-		if !metadata.SupportsOCR {
+		if !(metadata.SupportsOCR && metadata.SupportsUncore) {
 			slog.Debug("Off-core response events not supported on target", slog.String("event", event.Name))
 			return false
 		} else if flagScope == scopeProcess || flagScope == scopeCgroup {


### PR DESCRIPTION
This is a regression introduced in v3.2. OCR events are not available when uncore events are not available.