### PR TITLE
enable indefinite duration for telemetry collection

### DIFF
--- a/cmd/telemetry/telemetry.go
+++ b/cmd/telemetry/telemetry.go
@@ -229,7 +229,11 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		panic("failed to get target flag")
 	}
-	if flagDuration == 0 && target != "" {
+	targets, err := cmd.Flags().GetString("targets")
+	if err != nil {
+		panic("failed to get targets flag")
+	}
+	if flagDuration == 0 && (target != "" || targets != "") {
 		err := fmt.Errorf("duration must be greater than 0 when collecting from a remote target")
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return err

--- a/cmd/telemetry/telemetry.go
+++ b/cmd/telemetry/telemetry.go
@@ -163,7 +163,7 @@ func getFlagGroups() []common.FlagGroup {
 		},
 		{
 			Name: flagDurationName,
-			Help: "number of seconds to run the collection. If 0, the collection will run indefinitely. Ctrl-C to stop.",
+			Help: "number of seconds to run the collection. If 0, the collection will run indefinitely. Ctrl+c to stop.",
 		},
 		{
 			Name: flagIntervalName,
@@ -220,8 +220,17 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	if flagDuration <= 0 {
-		err := fmt.Errorf("duration must be greater than 0")
+	if flagDuration < 0 {
+		err := fmt.Errorf("duration must be 0 or greater")
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return err
+	}
+	target, err := cmd.Flags().GetString("target")
+	if err != nil {
+		panic("failed to get target flag")
+	}
+	if flagDuration == 0 && target != "" {
+		err := fmt.Errorf("duration must be greater than 0 when collecting from a remote target")
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		return err
 	}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -403,8 +403,10 @@ func collectOnTarget(cmd *cobra.Command, duration int, myTarget target.Target, s
 	}
 	// run the scripts on the target
 	status := "collecting data"
-	if duration > 0 {
-		status = fmt.Sprintf("%s, duration=%ds", status, duration)
+	if cmd.Name() == "telemetry" && duration == 0 { // telemetry is the only command that uses this common code that can run indefinitely
+		status += ", press Ctrl+c to stop"
+	} else if duration != 0 {
+		status += fmt.Sprintf(" for %d seconds", duration)
 	}
 	_ = statusUpdate(myTarget.GetName(), status)
 	scriptOutputs, err := script.RunScripts(myTarget, scriptsToRun, true, localTempDir)


### PR DESCRIPTION
Add support for telemetry --duration=0. This will collect telemetry until the user interrupts it with e.g., ctrl-c.

Indefinite telemetry collection will only work when data is being collected on local host.