### PR TITLE
Get and set compute and I/O die max/min frequencies independently

### DIFF
--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -1030,10 +1030,12 @@ func uncoreTableValues(outputs map[string]script.ScriptOutput) []Field {
 			{Name: "Max Frequency (I/O)", Values: []string{uncoreMinMaxDieFrequencyFromOutput(true, false, outputs)}},
 			{Name: "CHA Count", Values: []string{chaCountFromOutput(outputs)}},
 		}
-	} else {
+	} else { // field counts need to match for the all_hosts reports to work properly
 		return []Field{
 			{Name: "Min Frequency", Values: []string{uncoreMinFrequencyFromOutput(outputs)}},
+			{Name: "N/A", Values: []string{""}},
 			{Name: "Max Frequency", Values: []string{uncoreMaxFrequencyFromOutput(outputs)}},
+			{Name: "N/A", Values: []string{""}},
 			{Name: "CHA Count", Values: []string{chaCountFromOutput(outputs)}},
 		}
 	}

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -81,6 +81,7 @@ const (
 	UncoreMinFromMSRScriptName                  = "uncore min from msr"
 	UncoreMaxFromTPMIScriptName                 = "uncore max from tpmi"
 	UncoreMinFromTPMIScriptName                 = "uncore min from tpmi"
+	UncoreDieTypesFromTPMIScriptName            = "uncore die types from tpmi"
 	ElcScriptName                               = "efficiency latency control"
 	SstTfHighPriorityCoreFrequenciesScriptName  = "sst tf high priority core frequencies"
 	SstTfLowPriorityCoreFrequenciesScriptName   = "sst tf low priority core frequencies"
@@ -425,7 +426,8 @@ rdmsr 0x1ad # MSR_TURBO_RATIO_LIMIT: Maximum Ratio Limit of Turbo Mode
 			Name:          UncoreMaxFromTPMIScriptName,
 			Script:        "pcm-tpmi 2 0x18 -d -b 8:14",
 			Architectures: []string{x86_64},
-			Families:      []string{"6"}, // Intel
+			Families:      []string{"6"},          // Intel
+			Models:        []string{"173", "175"}, // GNR, SRF
 			Depends:       []string{"pcm-tpmi"},
 			Superuser:     true,
 		},
@@ -433,7 +435,17 @@ rdmsr 0x1ad # MSR_TURBO_RATIO_LIMIT: Maximum Ratio Limit of Turbo Mode
 			Name:          UncoreMinFromTPMIScriptName,
 			Script:        "pcm-tpmi 2 0x18 -d -b 15:21",
 			Architectures: []string{x86_64},
-			Families:      []string{"6"}, // Intel
+			Families:      []string{"6"},          // Intel
+			Models:        []string{"173", "175"}, // GNR, SRF
+			Depends:       []string{"pcm-tpmi"},
+			Superuser:     true,
+		},
+		{
+			Name:          UncoreDieTypesFromTPMIScriptName,
+			Script:        "pcm-tpmi 2 0x10 -d -b 26:26",
+			Architectures: []string{x86_64},
+			Families:      []string{"6"},          // Intel
+			Models:        []string{"173", "175"}, // GNR, SRF
 			Depends:       []string{"pcm-tpmi"},
 			Superuser:     true,
 		},
@@ -506,7 +518,8 @@ for die in "${!die_types[@]}"; do
 done
 			`,
 			Architectures: []string{x86_64},
-			Families:      []string{"6"}, // Intel
+			Families:      []string{"6"},          // Intel
+			Models:        []string{"173", "175"}, // GNR, SRF
 			Depends:       []string{"pcm-tpmi"},
 			Superuser:     true,
 		},


### PR DESCRIPTION
On newer architectures (SRF, GNR, ...) the max/min die frequencies can be set independently. This PR updates the report command to read them independently and the config command to set them independently.