### PR TITLE
report tables associated with CPU models

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -41,6 +41,7 @@ type FlagGroup struct {
 type TargetScriptOutputs struct {
 	targetName    string
 	scriptOutputs map[string]script.ScriptOutput
+	tableNames    []string
 }
 
 const (
@@ -66,13 +67,6 @@ const (
 	FlagFormatName = "format"
 )
 
-func CreateOutputDir(outputDir string) error {
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return fmt.Errorf("failed to create output directory: %w", err)
-	}
-	return nil
-}
-
 type SummaryFunc func([]report.TableValues, map[string]script.ScriptOutput) report.TableValues
 type InsightsFunc SummaryFunc
 
@@ -86,6 +80,9 @@ type ReportingCommand struct {
 	InsightsFunc     InsightsFunc
 }
 
+// Run is the common flow/logic for all reporting commands, i.e., 'report', 'telemetry', 'flame', 'lock'
+// The individual commands populate the ReportingCommand struct with the details specific to the command
+// and then call this Run function.
 func (rc *ReportingCommand) Run() error {
 	// appContext is the application context that holds common data and resources.
 	appContext := rc.Cmd.Context().Value(AppContext{}).(AppContext)
@@ -101,116 +98,15 @@ func (rc *ReportingCommand) Run() error {
 		slog.Info("received signal", slog.String("signal", sig.String()))
 	}()
 	// get the data we need to generate reports
-	var orderedTargetScriptOutputs []TargetScriptOutputs
-	if FlagInput != "" {
-		// read the raw file(s) as JSON
-		rawReports, err := report.ReadRawReports(FlagInput)
-		if err != nil {
-			err = fmt.Errorf("failed to read raw file(s): %w", err)
-			fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
-			slog.Error(err.Error())
-			rc.Cmd.SilenceUsage = true
-			return err
-		}
-		rc.TableNames = []string{} // use the table names from the raw files
-		for _, rawReport := range rawReports {
-			for _, tableName := range rawReport.TableNames { // just in case someone tries to use the raw files that were collected with a different set of categories
-				// filter out tables that we add after processing
-				if tableName == TableNameInsights || tableName == TableNamePerfspect || tableName == rc.SummaryTableName {
-					continue
-				}
-				rc.TableNames = util.UniqueAppend(rc.TableNames, tableName)
-			}
-			orderedTargetScriptOutputs = append(orderedTargetScriptOutputs, TargetScriptOutputs{targetName: rawReport.TargetName, scriptOutputs: rawReport.ScriptOutputs})
-		}
-	} else {
-		// get the list of unique scripts to run and tables we're interested in
-		var scriptNames []string
-		for _, tableName := range rc.TableNames {
-			// add scripts to list of scripts to run
-			for _, scriptName := range report.GetScriptNamesForTable(tableName) {
-				scriptNames = util.UniqueAppend(scriptNames, scriptName)
-			}
-		}
-		// make a list of unique script definitions
-		var scriptsToRun []script.ScriptDefinition
-		for _, scriptName := range scriptNames {
-			scriptsToRun = append(scriptsToRun, script.GetParameterizedScriptByName(scriptName, rc.ScriptParams))
-		}
-		// do any of the scripts require elevated privileges?
-		elevated := false
-		for _, script := range scriptsToRun {
-			if script.Superuser {
-				elevated = true
-				break
-			}
-		}
-		// get the targets
-		myTargets, targetErrs, err := GetTargets(rc.Cmd, elevated, false, localTempDir)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			slog.Error(err.Error())
-			rc.Cmd.SilenceUsage = true
-			return err
-		}
-		// setup and start the progress indicator
-		multiSpinner := progress.NewMultiSpinner()
-		for _, target := range myTargets {
-			err := multiSpinner.AddSpinner(target.GetName())
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-				slog.Error(err.Error())
-				rc.Cmd.SilenceUsage = true
-				return err
-			}
-		}
-		multiSpinner.Start()
-		// check for errors in target creation
-		for i := range targetErrs {
-			if targetErrs[i] != nil {
-				_ = multiSpinner.Status(myTargets[i].GetName(), fmt.Sprintf("Error: %v", targetErrs[i]))
-				// remove target from targets list
-				myTargets = append(myTargets[:i], myTargets[i+1:]...)
-			}
-		}
-		// check if we have any targets to run the scripts on
-		if len(myTargets) == 0 {
-			err := fmt.Errorf("no targets specified")
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			slog.Error(err.Error())
-			rc.Cmd.SilenceUsage = true
-			return err
-		}
-		// run the scripts on the targets
-		channelTargetScriptOutputs := make(chan TargetScriptOutputs)
-		channelError := make(chan error)
-		for _, target := range myTargets {
-			go collectOnTarget(rc.Cmd, rc.ScriptParams.Duration, target, scriptsToRun, localTempDir, channelTargetScriptOutputs, channelError, multiSpinner.Status)
-		}
-		// wait for scripts to run on all targets
-		var allTargetScriptOutputs []TargetScriptOutputs
-		for range myTargets {
-			select {
-			case scriptOutputs := <-channelTargetScriptOutputs:
-				allTargetScriptOutputs = append(allTargetScriptOutputs, scriptOutputs)
-			case err := <-channelError:
-				slog.Error(err.Error())
-			}
-		}
-		// allTargetScriptOutputs is in the order of data collection completion
-		// reorder to match order of myTargets
-		for _, target := range myTargets {
-			for _, targetScriptOutputs := range allTargetScriptOutputs {
-				if targetScriptOutputs.targetName == target.GetName() {
-					orderedTargetScriptOutputs = append(orderedTargetScriptOutputs, targetScriptOutputs)
-					break
-				}
-			}
-		}
-		multiSpinner.Finish()
-		fmt.Println()
+	orderedTargetScriptOutputs, err := rc.retrieveScriptOutputs(localTempDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		slog.Error(err.Error())
+		rc.Cmd.SilenceUsage = true
+		return err
 	}
-	err := CreateOutputDir(outputDir)
+	// we have output data so create the output directory
+	err = CreateOutputDir(outputDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		slog.Error(err.Error())
@@ -218,6 +114,67 @@ func (rc *ReportingCommand) Run() error {
 		return err
 	}
 	// create the raw report before processing the data, so that we can save the raw data even if there is an error while processing
+	err = rc.createRawReports(appContext, orderedTargetScriptOutputs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		slog.Error(err.Error())
+		rc.Cmd.SilenceUsage = true
+		return err
+	}
+	// check report formats
+	formats := FlagFormat
+	if util.StringInList(report.FormatAll, formats) {
+		formats = report.FormatOptions
+	}
+	// process the collected data and create the requested report(s)
+	reportFilePaths, err := rc.createReports(appContext, orderedTargetScriptOutputs, formats)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		slog.Error(err.Error())
+		rc.Cmd.SilenceUsage = true
+		return err
+	}
+	if len(reportFilePaths) > 0 {
+		fmt.Println("Report files:")
+	}
+	for _, reportFilePath := range reportFilePaths {
+		fmt.Printf("  %s\n", reportFilePath)
+	}
+	return nil
+}
+
+// CreateOutputDir creates the output directory if it does not exist
+func CreateOutputDir(outputDir string) error {
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+	return nil
+}
+
+// DefaultInsightsFunc returns the insights table values from the table values
+func DefaultInsightsFunc(allTableValues []report.TableValues, scriptOutputs map[string]script.ScriptOutput) report.TableValues {
+	insightsTableValues := report.TableValues{
+		TableDefinition: report.TableDefinition{
+			Name:      TableNameInsights,
+			HasRows:   true,
+			MenuLabel: TableNameInsights,
+		},
+		Fields: []report.Field{
+			{Name: "Recommendation", Values: []string{}},
+			{Name: "Justification", Values: []string{}},
+		},
+	}
+	for _, tableValues := range allTableValues {
+		for _, insight := range tableValues.Insights {
+			insightsTableValues.Fields[0].Values = append(insightsTableValues.Fields[0].Values, insight.Recommendation)
+			insightsTableValues.Fields[1].Values = append(insightsTableValues.Fields[1].Values, insight.Justification)
+		}
+	}
+	return insightsTableValues
+}
+
+// createRawReports creates the raw report(s) from the collected data
+func (rc *ReportingCommand) createRawReports(appContext AppContext, orderedTargetScriptOutputs []TargetScriptOutputs) error {
 	for _, targetScriptOutputs := range orderedTargetScriptOutputs {
 		reportBytes, err := report.CreateRawReport(rc.TableNames, targetScriptOutputs.scriptOutputs, targetScriptOutputs.targetName)
 		if err != nil {
@@ -241,24 +198,19 @@ func (rc *ReportingCommand) Run() error {
 			return err
 		}
 	}
-	// check report formats
-	formats := FlagFormat
-	if util.StringInList(report.FormatAll, formats) {
-		formats = report.FormatOptions
-	}
-	// process the collected data and create the requested report(s)
+	return nil
+}
+
+// createReports processes the collected data and creates the requested report(s)
+func (rc *ReportingCommand) createReports(appContext AppContext, orderedTargetScriptOutputs []TargetScriptOutputs, formats []string) ([]string, error) {
+	reportFilePaths := []string{}
 	allTargetsTableValues := make([][]report.TableValues, 0)
-	var reportFilePaths []string
 	for _, targetScriptOutputs := range orderedTargetScriptOutputs {
-		scriptOutputs := targetScriptOutputs.scriptOutputs
 		// process the tables, i.e., get field values from script output
-		allTableValues, err := report.Process(rc.TableNames, scriptOutputs)
+		allTableValues, err := report.Process(targetScriptOutputs.tableNames, targetScriptOutputs.scriptOutputs)
 		if err != nil {
 			err = fmt.Errorf("failed to process collected data: %w", err)
-			fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
-			slog.Error(err.Error())
-			rc.Cmd.SilenceUsage = true
-			return err
+			return nil, err
 		}
 		// special case - the summary table is built from the post-processed data, i.e., table values
 		if rc.SummaryFunc != nil {
@@ -287,13 +239,10 @@ func (rc *ReportingCommand) Run() error {
 		})
 		// create the report(s)
 		for _, format := range formats {
-			reportBytes, err := report.Create(format, allTableValues, scriptOutputs, targetScriptOutputs.targetName)
+			reportBytes, err := report.Create(format, allTableValues, targetScriptOutputs.scriptOutputs, targetScriptOutputs.targetName)
 			if err != nil {
 				err = fmt.Errorf("failed to create report: %w", err)
-				fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
-				slog.Error(err.Error())
-				rc.Cmd.SilenceUsage = true
-				return err
+				return nil, err
 			}
 			if len(formats) == 1 && format == report.FormatTxt {
 				fmt.Printf("%s:\n", targetScriptOutputs.targetName)
@@ -307,10 +256,7 @@ func (rc *ReportingCommand) Run() error {
 			reportPath := filepath.Join(appContext.OutputDir, reportFilename)
 			if err = report.WriteReport(reportBytes, reportPath); err != nil {
 				err = fmt.Errorf("failed to write report: %w", err)
-				fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
-				slog.Error(err.Error())
-				rc.Cmd.SilenceUsage = true
-				return err
+				return nil, err
 			}
 			reportFilePaths = append(reportFilePaths, reportPath)
 		}
@@ -329,57 +275,164 @@ func (rc *ReportingCommand) Run() error {
 			if !util.StringInList(format, formats) {
 				continue
 			}
-			reportBytes, err := report.CreateMultiTarget(format, allTargetsTableValues, targetNames)
+			reportBytes, err := report.CreateMultiTarget(format, allTargetsTableValues, targetNames, rc.TableNames)
 			if err != nil {
 				err = fmt.Errorf("failed to create multi-target %s report: %w", format, err)
-				fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
-				slog.Error(err.Error())
-				rc.Cmd.SilenceUsage = true
-				return err
+				return nil, err
 			}
 			reportFilename := fmt.Sprintf("%s.%s", "all_hosts", format)
 			reportPath := filepath.Join(appContext.OutputDir, reportFilename)
 			if err = report.WriteReport(reportBytes, reportPath); err != nil {
 				err = fmt.Errorf("failed to write multi-target %s report: %w", format, err)
-				fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
-				slog.Error(err.Error())
-				rc.Cmd.SilenceUsage = true
-				return err
+				return nil, err
 			}
 			reportFilePaths = append(reportFilePaths, reportPath)
 		}
 	}
-	if len(reportFilePaths) > 0 {
-		fmt.Println("Report files:")
-	}
-	for _, reportFilePath := range reportFilePaths {
-		fmt.Printf("  %s\n", reportFilePath)
-	}
-	return nil
-
+	return reportFilePaths, nil
 }
 
-func DefaultInsightsFunc(allTableValues []report.TableValues, scriptOutputs map[string]script.ScriptOutput) report.TableValues {
-	insightsTableValues := report.TableValues{
-		TableDefinition: report.TableDefinition{
-			Name:      TableNameInsights,
-			HasRows:   true,
-			MenuLabel: TableNameInsights,
-		},
-		Fields: []report.Field{
-			{Name: "Recommendation", Values: []string{}},
-			{Name: "Justification", Values: []string{}},
-		},
+// retrieveScriptOutputs gets the data from the targets or from the input file(s)
+func (rc *ReportingCommand) retrieveScriptOutputs(localTempDir string) ([]TargetScriptOutputs, error) {
+	var orderedTargetScriptOutputs []TargetScriptOutputs
+	// check if we are reading from a file or running on targets
+	if FlagInput != "" {
+		var err error
+		orderedTargetScriptOutputs, err = outputsFromInput(rc.SummaryTableName)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// get the targets
+		myTargets, targetErrs, err := GetTargets(rc.Cmd, elevatedPrivilegesRequired(rc.TableNames), false, localTempDir)
+		if err != nil {
+			return nil, err
+		}
+		// setup and start the progress indicator
+		multiSpinner := progress.NewMultiSpinner()
+		for _, target := range myTargets {
+			err := multiSpinner.AddSpinner(target.GetName())
+			if err != nil {
+				return nil, err
+			}
+		}
+		multiSpinner.Start()
+		// check for errors in target creation
+		for i := range targetErrs {
+			if targetErrs[i] != nil {
+				_ = multiSpinner.Status(myTargets[i].GetName(), fmt.Sprintf("Error: %v", targetErrs[i]))
+				// remove target from targets list
+				myTargets = append(myTargets[:i], myTargets[i+1:]...)
+			}
+		}
+		// check if we have any remaining targets to run the scripts on
+		if len(myTargets) == 0 {
+			err := fmt.Errorf("no targets available to collect data on")
+			return nil, err
+		}
+		orderedTargetScriptOutputs, err = outputsFromTargets(myTargets, rc, multiSpinner.Status, localTempDir)
+		if err != nil {
+			return nil, err
+		}
+		multiSpinner.Finish()
+		fmt.Println()
 	}
-	for _, tableValues := range allTableValues {
-		for _, insight := range tableValues.Insights {
-			insightsTableValues.Fields[0].Values = append(insightsTableValues.Fields[0].Values, insight.Recommendation)
-			insightsTableValues.Fields[1].Values = append(insightsTableValues.Fields[1].Values, insight.Justification)
+	return orderedTargetScriptOutputs, nil
+}
+
+// outputsFromInput reads the raw file(s) and returns the data in the order of the raw files
+func outputsFromInput(summaryTableName string) ([]TargetScriptOutputs, error) {
+	orderedTargetScriptOutputs := []TargetScriptOutputs{}
+	tableNames := []string{} // use the table names from the raw files
+	// read the raw file(s) as JSON
+	rawReports, err := report.ReadRawReports(FlagInput)
+	if err != nil {
+		err = fmt.Errorf("failed to read raw file(s): %w", err)
+		return nil, err
+	}
+	for _, rawReport := range rawReports {
+		for _, tableName := range rawReport.TableNames { // just in case someone tries to use the raw files that were collected with a different set of categories
+			// filter out tables that we add after processing
+			if tableName == TableNameInsights || tableName == TableNamePerfspect || tableName == summaryTableName {
+				continue
+			}
+			tableNames = util.UniqueAppend(tableNames, tableName)
+		}
+		orderedTargetScriptOutputs = append(orderedTargetScriptOutputs, TargetScriptOutputs{targetName: rawReport.TargetName, scriptOutputs: rawReport.ScriptOutputs, tableNames: tableNames})
+	}
+	return orderedTargetScriptOutputs, nil
+}
+
+// outputsFromTargets runs the scripts on the targets and returns the data in the order of the targets
+func outputsFromTargets(myTargets []target.Target, rc *ReportingCommand, statusUpdate progress.MultiSpinnerUpdateFunc, localTempDir string) ([]TargetScriptOutputs, error) {
+	orderedTargetScriptOutputs := []TargetScriptOutputs{}
+	// create the list of tables and scripts to run and then run them on the targets
+	channelTargetScriptOutputs := make(chan TargetScriptOutputs)
+	channelError := make(chan error)
+	targetTableNames := [][]string{}
+	targetScriptNames := [][]string{}
+	for targetIdx, target := range myTargets {
+		targetTableNames = append(targetTableNames, []string{})
+		targetScriptNames = append(targetScriptNames, []string{})
+		for _, tableName := range rc.TableNames {
+			if report.TableForTarget(tableName, target) {
+				// add table to list of tables to collect
+				targetTableNames[targetIdx] = util.UniqueAppend(targetTableNames[targetIdx], tableName)
+				// add scripts to list of scripts to run
+				for _, scriptName := range report.GetScriptNamesForTable(tableName) {
+					targetScriptNames[targetIdx] = util.UniqueAppend(targetScriptNames[targetIdx], scriptName)
+				}
+			} else {
+				slog.Info("table not supported for target", slog.String("table", tableName), slog.String("target", target.GetName()))
+			}
+		}
+		scriptsToRunOnTarget := []script.ScriptDefinition{}
+		for _, scriptName := range targetScriptNames[targetIdx] {
+			script := script.GetParameterizedScriptByName(scriptName, rc.ScriptParams)
+			scriptsToRunOnTarget = append(scriptsToRunOnTarget, script)
+		}
+		// run the selected scripts on the target
+		go collectOnTarget(rc.Cmd, rc.ScriptParams.Duration, target, scriptsToRunOnTarget, localTempDir, channelTargetScriptOutputs, channelError, statusUpdate)
+	}
+	// wait for scripts to run on all targets
+	var allTargetScriptOutputs []TargetScriptOutputs
+	for range myTargets {
+		select {
+		case scriptOutputs := <-channelTargetScriptOutputs:
+			allTargetScriptOutputs = append(allTargetScriptOutputs, scriptOutputs)
+		case err := <-channelError:
+			slog.Error(err.Error())
 		}
 	}
-	return insightsTableValues
+	// allTargetScriptOutputs is in the order of data collection completion
+	// reorder to match order of myTargets
+	for targetIdx, target := range myTargets {
+		for _, targetScriptOutputs := range allTargetScriptOutputs {
+			if targetScriptOutputs.targetName == target.GetName() {
+				targetScriptOutputs.tableNames = targetTableNames[targetIdx]
+				orderedTargetScriptOutputs = append(orderedTargetScriptOutputs, targetScriptOutputs)
+				break
+			}
+		}
+	}
+	return orderedTargetScriptOutputs, nil
 }
 
+// elevatedPrivilegesRequired returns true if any of the scripts needed for the tables require elevated privileges
+func elevatedPrivilegesRequired(tableNames []string) bool {
+	for _, tableName := range tableNames {
+		// add scripts to list of scripts to run
+		for _, scriptName := range report.GetScriptNamesForTable(tableName) {
+			script := script.GetScriptByName(scriptName)
+			if script.Superuser {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// collectOnTarget runs the scripts on the target and sends the results to the appropriate channels
 func collectOnTarget(cmd *cobra.Command, duration int, myTarget target.Target, scriptsToRun []script.ScriptDefinition, localTempDir string, channelTargetScriptOutputs chan TargetScriptOutputs, channelError chan error, statusUpdate progress.MultiSpinnerUpdateFunc) {
 	// create a temporary directory on the target
 	var targetTempDir string

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -17,6 +17,8 @@ import (
 
 	"perfspect/internal/cpudb"
 	"perfspect/internal/script"
+	"perfspect/internal/target"
+	"perfspect/internal/util"
 
 	"github.com/xuri/excelize/v2"
 )
@@ -34,8 +36,11 @@ type TextTableRenderer func(TableValues) string
 type XlsxTableRenderer func(TableValues, *excelize.File, string, *int)
 
 type TableDefinition struct {
-	Name        string
-	ScriptNames []string
+	Name          string
+	ScriptNames   []string
+	Architectures []string // architectures, i.e., x86_64, arm64. If empty, it will be present for all architectures.
+	Families      []string // families, e.g., 6, 7. If empty, it will be present for all families.
+	Models        []string // models, e.g., 62, 63. If empty, it will be present for all models.
 	// Fields function is called to retrieve field values from the script outputs
 	FieldsFunc  FieldsRetriever
 	MenuLabel   string // add to tables that will be displayed in the menu
@@ -116,14 +121,13 @@ const (
 	NetworkStatsTableName          = "Network Stats"
 	MemoryStatsTableName           = "Memory Stats"
 	PowerStatsTableName            = "Power Stats"
+	InstructionMixTableName        = "Instruction Mix"
 	// config  table names
 	ConfigurationTableName = "Configuration"
 	// flamegraph table names
 	CodePathFrequencyTableName = "Code Path Frequency"
 	// lock table names
 	KernelLockAnalysisTableName = "Kernel Lock Analysis"
-	// process watch instruction mix table names
-	InstructionMixTableName = "Instruction Mix"
 )
 
 const (
@@ -141,6 +145,44 @@ const (
 	LogsMenuLabel          = "Logs"
 	SystemSummaryMenuLabel = "System Summary"
 )
+
+func GetTableByName(name string) TableDefinition {
+	if table, ok := tableDefinitions[name]; ok {
+		return table
+	}
+	panic(fmt.Sprintf("table not found: %s", name))
+}
+
+func TableForTarget(name string, myTarget target.Target) bool {
+	table := GetTableByName(name)
+	var err error
+	var architecture, family, model string
+	architecture, err = myTarget.GetArchitecture()
+	if err != nil {
+		slog.Error("failed to get architecture for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
+		return false
+	}
+	family, err = myTarget.GetFamily()
+	if err != nil {
+		slog.Error("failed to get family for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
+		return false
+	}
+	model, err = myTarget.GetModel()
+	if err != nil {
+		slog.Error("failed to get model for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
+		return false
+	}
+	if len(table.Architectures) > 0 && !util.StringInList(architecture, table.Architectures) {
+		return false
+	}
+	if len(table.Families) > 0 && !util.StringInList(family, table.Families) {
+		return false
+	}
+	if len(table.Models) > 0 && !util.StringInList(model, table.Models) {
+		return false
+	}
+	return true
+}
 
 var tableDefinitions = map[string]TableDefinition{
 	//
@@ -208,8 +250,10 @@ var tableDefinitions = map[string]TableDefinition{
 		ScriptNames: []string{script.CpuidScriptName},
 		FieldsFunc:  isaTableValues},
 	AcceleratorTableName: {
-		Name:    AcceleratorTableName,
-		HasRows: true,
+		Name:          AcceleratorTableName,
+		Architectures: []string{"x86_64"},
+		Families:      []string{"6"}, // Intel CPUs only
+		HasRows:       true,
 		ScriptNames: []string{
 			script.LshwScriptName,
 			script.IaaDevicesScriptName,
@@ -217,9 +261,11 @@ var tableDefinitions = map[string]TableDefinition{
 		FieldsFunc:   acceleratorTableValues,
 		InsightsFunc: acceleratorTableInsights},
 	PowerTableName: {
-		Name:      PowerTableName,
-		HasRows:   false,
-		MenuLabel: PowerMenuLabel,
+		Name:          PowerTableName,
+		Architectures: []string{"x86_64"},
+		Families:      []string{"6"}, // Intel CPUs only
+		HasRows:       false,
+		MenuLabel:     PowerMenuLabel,
 		ScriptNames: []string{
 			script.PackagePowerLimitName,
 			script.EpbSourceScriptName,
@@ -253,8 +299,10 @@ var tableDefinitions = map[string]TableDefinition{
 		FieldsFunc:            coreTurboFrequencyTableValues,
 		HTMLTableRendererFunc: coreTurboFrequencyTableHTMLRenderer},
 	UncoreTableName: {
-		Name:    UncoreTableName,
-		HasRows: false,
+		Name:          UncoreTableName,
+		Architectures: []string{"x86_64"},
+		Families:      []string{"6"}, // Intel CPUs only
+		HasRows:       false,
 		ScriptNames: []string{
 			script.UncoreMaxFromMSRScriptName,
 			script.UncoreMinFromMSRScriptName,
@@ -267,23 +315,30 @@ var tableDefinitions = map[string]TableDefinition{
 			script.LspciDevicesScriptName},
 		FieldsFunc: uncoreTableValues},
 	ElcTableName: {
-		Name:    ElcTableName,
-		HasRows: true,
+		Name:          ElcTableName,
+		Architectures: []string{"x86_64"},
+		Families:      []string{"6"},          // Intel CPUs only
+		Models:        []string{"173", "175"}, // Granite Rapids, Sierra Forest
+		HasRows:       true,
 		ScriptNames: []string{
 			script.ElcScriptName,
 		},
 		FieldsFunc:   elcTableValues,
 		InsightsFunc: elcTableInsights},
 	SSTTFHPTableName: {
-		Name:    SSTTFHPTableName,
-		HasRows: true,
+		Name:          SSTTFHPTableName,
+		Architectures: []string{"x86_64"},
+		Families:      []string{"6"}, // Intel CPUs only
+		HasRows:       true,
 		ScriptNames: []string{
 			script.SstTfHighPriorityCoreFrequenciesScriptName,
 		},
 		FieldsFunc: sstTFHPTableValues},
 	SSTTFLPTableName: {
-		Name:    SSTTFLPTableName,
-		HasRows: true,
+		Name:          SSTTFLPTableName,
+		Architectures: []string{"x86_64"},
+		Families:      []string{"6"}, // Intel CPUs only
+		HasRows:       true,
 		ScriptNames: []string{
 			script.SstTfLowPriorityCoreFrequenciesScriptName,
 		},
@@ -412,8 +467,10 @@ var tableDefinitions = map[string]TableDefinition{
 		},
 		FieldsFunc: chassisStatusTableValues},
 	PMUTableName: {
-		Name:    PMUTableName,
-		HasRows: false,
+		Name:          PMUTableName,
+		Architectures: []string{"x86_64"},
+		Families:      []string{"6"}, // Intel CPUs only
+		HasRows:       false,
 		ScriptNames: []string{
 			script.PMUBusyScriptName,
 			script.PMUDriverVersionScriptName,
@@ -478,8 +535,10 @@ var tableDefinitions = map[string]TableDefinition{
 	// configuration set table
 	//
 	ConfigurationTableName: {
-		Name:    ConfigurationTableName,
-		HasRows: false,
+		Name:          ConfigurationTableName,
+		Architectures: []string{"x86_64"},
+		Families:      []string{"6"}, // Intel CPUs only
+		HasRows:       false,
 		ScriptNames: []string{
 			script.LscpuScriptName,
 			script.LspciBitsScriptName,


### PR DESCRIPTION
Some report tables are only relevant to certain CPUs. This change allows us to associate tables with a limited set of CPUs, similar to how the report scripts work.
