### PR TITLE
fix GNR_X* microarchitecture detection

### DIFF
--- a/internal/cpudb/cpu_test.go
+++ b/internal/cpudb/cpu_test.go
@@ -56,7 +56,7 @@ func TestGetCPU(t *testing.T) {
 		t.Fatal(fmt.Errorf("Found the wrong CPU: %s", cpu.MicroArchitecture))
 	}
 
-	cpu, err = cpudb.GetCPUExtended("6", "173", "", "", "2", "10") // GNR_X3
+	cpu, err = cpudb.GetCPUExtended("6", "173", "", "", "10") // GNR_X3
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestGetCPU(t *testing.T) {
 		t.Fatal(fmt.Errorf("Incorrect channel count: %d", cpu.MemoryChannelCount))
 	}
 
-	cpu, err = cpudb.GetCPUExtended("6", "173", "", "", "2", "8") // GNR_X2
+	cpu, err = cpudb.GetCPUExtended("6", "173", "", "", "8") // GNR_X2
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestGetCPU(t *testing.T) {
 		t.Fatal(fmt.Errorf("Incorrect channel count: %d", cpu.MemoryChannelCount))
 	}
 
-	cpu, err = cpudb.GetCPUExtended("6", "173", "", "", "2", "6") // GNR_X1
+	cpu, err = cpudb.GetCPUExtended("6", "173", "", "", "6") // GNR_X1
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestGetCPU(t *testing.T) {
 		t.Fatal(fmt.Errorf("Found the wrong CPU: %s", cpu.MicroArchitecture))
 	}
 
-	cpu, err = cpudb.GetCPUExtended("6", "207", "", "c0", "", "") // EMR XCC
+	cpu, err = cpudb.GetCPUExtended("6", "207", "", "c0", "") // EMR XCC
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestGetCPU(t *testing.T) {
 		t.Fatal(fmt.Errorf("Incorrect channel count: %d", cpu.MemoryChannelCount))
 	}
 
-	cpu, err = cpudb.GetCPUExtended("6", "207", "", "40", "", "") // EMR MCC
+	cpu, err = cpudb.GetCPUExtended("6", "207", "", "40", "") // EMR MCC
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/report/table_helpers.go
+++ b/internal/report/table_helpers.go
@@ -136,17 +136,16 @@ func getDmiDecodeEntries(dmiDecodeOutput string, dmiType string) (entries [][]st
 	return
 }
 
-// uarchFromOutput returns the architecture of the CPU that matches family, model, stepping, sockets,
+// uarchFromOutput returns the architecture of the CPU that matches family, model, stepping,
 // capid4, and devices information from the output or an empty string, if no match is found.
 func uarchFromOutput(outputs map[string]script.ScriptOutput) string {
 	family := valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU family:\s*(.+)$`)
 	model := valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Model:\s*(.+)$`)
 	stepping := valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Stepping:\s*(.+)$`)
-	sockets := valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(s\):\s*(.+)$`)
 	capid4 := valFromRegexSubmatch(outputs[script.LspciBitsScriptName].Stdout, `^([0-9a-fA-F]+)`)
 	devices := valFromRegexSubmatch(outputs[script.LspciDevicesScriptName].Stdout, `^([0-9]+)`)
 	CPUdb := cpudb.NewCPUDB()
-	cpu, err := CPUdb.GetCPUExtended(family, model, stepping, capid4, sockets, devices)
+	cpu, err := CPUdb.GetCPUExtended(family, model, stepping, capid4, devices)
 	if err == nil {
 		return cpu.MicroArchitecture
 	}
@@ -305,7 +304,7 @@ func hyperthreadingFromOutput(outputs map[string]script.ScriptOutput) string {
 		return ""
 	}
 	CPUdb := cpudb.NewCPUDB()
-	cpu, err := CPUdb.GetCPUExtended(family, model, stepping, "", sockets, "")
+	cpu, err := CPUdb.GetCPUExtended(family, model, stepping, "", "")
 	if err != nil {
 		return ""
 	}
@@ -349,11 +348,10 @@ func channelsFromOutput(outputs map[string]script.ScriptOutput) string {
 	family := valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU family:\s*(.+)$`)
 	model := valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Model:\s*(.+)$`)
 	stepping := valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Stepping:\s*(.+)$`)
-	sockets := valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(.*:\s*(.+?)$`)
 	capid4 := valFromRegexSubmatch(outputs[script.LspciBitsScriptName].Stdout, `^([0-9a-fA-F]+)`)
 	devices := valFromRegexSubmatch(outputs[script.LspciDevicesScriptName].Stdout, `^([0-9]+)`)
 	CPUdb := cpudb.NewCPUDB()
-	cpu, err := CPUdb.GetCPUExtended(family, model, stepping, capid4, sockets, devices)
+	cpu, err := CPUdb.GetCPUExtended(family, model, stepping, capid4, devices)
 	if err != nil {
 		slog.Error("error getting CPU from CPUdb", slog.String("error", err.Error()))
 		return ""


### PR DESCRIPTION
Perfspect was incorrectly identifying GNR_X* when sockets are disabled via BIOS.