### PR TITLE
Refactor metric definitions by removing unused fields and simplifying…

### DIFF
--- a/cmd/metrics/metric_defs_test.go
+++ b/cmd/metrics/metric_defs_test.go
@@ -55,7 +55,7 @@ func TestTransformConditional(t *testing.T) {
 		t.Errorf("improper transform: [%s] -> [%s]", in, out)
 	}
 
-	// from SPR metrics -- metric_TMA_....DRAM_Bound(%)
+	// from SPR metrics -- TMA_....DRAM_Bound(%)
 	in = "100 * ( min( ( ( ( a / ( b ) ) - ( min( ( ( ( ( 1 - ( ( ( 19 * ( c * ( 1 + ( d / e ) ) ) + 10 * ( ( f * ( 1 + ( d / e ) ) ) + ( g * ( 1 + ( d / e ) ) ) + ( h * ( 1 + ( d / e ) ) ) ) ) / ( ( 19 * ( c * ( 1 + ( d / e ) ) ) + 10 * ( ( f * ( 1 + ( d / e ) ) ) + ( g * ( 1 + ( d / e ) ) ) + ( h * ( 1 + ( d / e ) ) ) ) ) + ( 25 * ( ( i * ( 1 + ( d / e ) ) ) ) + 33 * ( ( j * ( 1 + ( d / e ) ) ) ) ) ) ) ) ) * ( a / ( b ) ) ) if ( ( 1000000 ) * ( j + i ) > e ) else 0 ) ) , ( 1 ) ) ) ) ) , ( 1 ) ) )"
 	if out, err = transformConditional(in); err != nil {
 		t.Error(err)
@@ -64,7 +64,7 @@ func TestTransformConditional(t *testing.T) {
 		t.Errorf("improper transform: [%s] -> [%s]", in, out)
 	}
 
-	// from SPR metrics -- metric_TMA_....Ports_Utilization(%)
+	// from SPR metrics -- TMA_....Ports_Utilization(%)
 	in = "100 * ( ( a + ( b / ( c ) ) * ( d - e ) + ( f + ( g / ( h + i + g + j ) ) * k ) ) / ( c ) if ( l < ( d - e ) ) else ( f + ( g / ( h + i + g + j ) ) * k ) / ( c ) )"
 	if out, err = transformConditional(in); err != nil {
 		t.Error(err)

--- a/cmd/metrics/resources/metrics/x86_64/AuthenticAMD/bergamo.json
+++ b/cmd/metrics/resources/metrics/x86_64/AuthenticAMD/bergamo.json
@@ -1,299 +1,298 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ls_not_halted_p0_cyc] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "(100 * [ls_not_halted_p0_cyc]) / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
+        "name": "CPU utilization% in kernel mode",
         "expression": "(100 * [ls_not_halted_p0_cyc:k]) / [TSC]"
     },
     {
-        "name": "metric_CPI",
+        "name": "CPI",
         "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
+        "name": "kernel_CPI",
         "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_IPC",
+        "name": "IPC",
         "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_giga_instructions_per_sec",
+        "name": "giga_instructions_per_sec",
         "expression": "[instructions] / 1000000000"
     },
     {
-        "name": "metric_Branch Misprediction Ratio",
+        "name": "Branch Misprediction Ratio",
         "expression": "[ex_ret_brn_misp] / [ex_ret_brn]"
     },
     {
-        "name": "metric_All Data Cache Accesses",
+        "name": "All Data Cache Accesses",
         "expression": "[ls_dispatch.any]"
     },
     {
-        "name": "metric_All L2 Cache Accesses",
+        "name": "All L2 Cache Accesses",
         "expression": "[l2_request_g1.all_no_prefetch] + [l2_pf_hit_l2.all] + [l2_pf_miss_l2_hit_l3.all] + [l2_pf_miss_l2_l3.all]"
     },
     {
-        "name": "metric_L2 Cache Accesses from L1 Instruction Cache Misses",
+        "name": "L2 Cache Accesses from L1 Instruction Cache Misses",
         "expression": "[l2_request_g1.cacheable_ic_read]"
     },
     {
-        "name": "metric_L2 Cache Accesses from L1 Data Cache Misses",
+        "name": "L2 Cache Accesses from L1 Data Cache Misses",
         "expression": "[ic_tag_hit_miss.miss] / [instructions]"
     },
     {
-        "name": "metric_L2 Cache Accesses from L2 Cache Hardware Prefetches",
+        "name": "L2 Cache Accesses from L2 Cache Hardware Prefetches",
         "expression": "[l2_pf_hit_l2.all] + [l2_pf_miss_l2_hit_l3.all] + [l2_pf_miss_l2_l3.all]"
     },
     {
-        "name": "metric_All L2 Cache Misses",
+        "name": "All L2 Cache Misses",
         "expression": "[l2_cache_req_stat.ic_dc_miss_in_l2] + [l2_pf_miss_l2_hit_l3.all] + [l2_pf_miss_l2_l3.all]"
     },
     {
-        "name": "metric_L2 Cache Misses from L1 Instruction Cache Misses",
+        "name": "L2 Cache Misses from L1 Instruction Cache Misses",
         "expression": "[l2_cache_req_stat.ic_fill_miss]"
     },
     {
-        "name": "metric_L2 Cache Misses from L1 Data Cache Misses",
+        "name": "L2 Cache Misses from L1 Data Cache Misses",
         "expression": "[l2_cache_req_stat.ls_rd_blk_c]"
     },
     {
-        "name": "metric_L2 Cache Misses from L2 Cache Hardware Prefetches",
+        "name": "L2 Cache Misses from L2 Cache Hardware Prefetches",
         "expression": "[l2_pf_miss_l2_hit_l3.all] + [l2_pf_miss_l2_l3.all]"
     },
     {
-        "name": "metric_All L2 Cache Hits",
+        "name": "All L2 Cache Hits",
         "expression": "[l2_cache_req_stat.ic_dc_hit_in_l2] + [l2_pf_hit_l2.all]"
     },
     {
-        "name": "metric_L2 Cache Hits from L1 Instruction Cache Misses",
+        "name": "L2 Cache Hits from L1 Instruction Cache Misses",
         "expression": "[l2_cache_req_stat.ic_hit_in_l2]"
     },
     {
-        "name": "metric_L2 Cache Hits from L1 Data Cache Misses",
+        "name": "L2 Cache Hits from L1 Data Cache Misses",
         "expression": "[l2_cache_req_stat.dc_hit_in_l2]"
     },
     {
-        "name": "metric_L2 Cache Hits from L2 Cache Hardware Prefetches",
+        "name": "L2 Cache Hits from L2 Cache Hardware Prefetches",
         "expression": "[l2_pf_hit_l2.all]"
     },
     {
-        "name": "metric_L3 Cache Accesses",
+        "name": "L3 Cache Accesses",
         "expression": "[l3_lookup_state.all_coherent_accesses_to_l3]"
     },
     {
-        "name": "metric_L3 Cache Misses",
+        "name": "L3 Cache Misses",
         "expression": "[l3_lookup_state.l3_miss]"
     },
     {
-        "name": "metric_L3 Cache Hits",
+        "name": "L3 Cache Hits",
         "expression": "[l3_lookup_state.l3_hit]"
     },
     {
-        "name": "metric_Average L3 Cache Read Miss Latency (in ns)",
+        "name": "Average L3 Cache Read Miss Latency (in ns)",
         "expression": "([l3_xi_sampled_latency.all] * 30) / [l3_xi_sampled_latency_requests.all]"
     },
     {
-        "name": "metric_Op Cache Fetch Miss Ratio",
+        "name": "Op Cache Fetch Miss Ratio",
         "expression": "[op_cache_hit_miss.miss] / [op_cache_hit_miss.all]"
     },
     {
-        "name": "metric_Instruction Cache Fetch Miss Ratio",
+        "name": "Instruction Cache Fetch Miss Ratio",
         "expression": "[ic_tag_hit_miss.miss] / [ic_tag_hit_miss.all]"
     },
     {
-        "name": "metric_L1 Data Cache Fills from DRAM or IO in any NUMA node",
+        "name": "L1 Data Cache Fills from DRAM or IO in any NUMA node",
         "expression": "[ls_any_fills_from_sys.dram_io_all]"
     },
     {
-        "name": "metric_L1 Data Cache Fills from a different NUMA node",
+        "name": "L1 Data Cache Fills from a different NUMA node",
         "expression": "[ls_any_fills_from_sys.far_all]"
     },
     {
-        "name": "metric_L1 Data Cache Fills from within the same CCX",
+        "name": "L1 Data Cache Fills from within the same CCX",
         "expression": "[ls_any_fills_from_sys.local_all]"
     },
     {
-        "name": "metric_L1 Data Cache Fills from another CCX cache in any NUMA node",
+        "name": "L1 Data Cache Fills from another CCX cache in any NUMA node",
         "expression": "[ls_any_fills_from_sys.remote_cache]"
     },
     {
-        "name": "metric_All L1 Data Cache Fills",
+        "name": "All L1 Data Cache Fills",
         "expression": "[ls_any_fills_from_sys.all]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from local L2",
+        "name": "Demand L1 Data Cache Fills from local L2",
         "expression": "[ls_dmnd_fills_from_sys.local_l2]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from local L3 or different L2 in same CCX",
+        "name": "Demand L1 Data Cache Fills from local L3 or different L2 in same CCX",
         "expression": "[ls_dmnd_fills_from_sys.local_ccx]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from another CCX cache in the same NUMA node",
+        "name": "Demand L1 Data Cache Fills from another CCX cache in the same NUMA node",
         "expression": "[ls_dmnd_fills_from_sys.near_cache]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from DRAM or MMIO in the same NUMA node",
+        "name": "Demand L1 Data Cache Fills from DRAM or MMIO in the same NUMA node",
         "expression": "[ls_dmnd_fills_from_sys.dram_io_near]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from another CCX cache in a different NUMA node",
+        "name": "Demand L1 Data Cache Fills from another CCX cache in a different NUMA node",
         "expression": "[ls_dmnd_fills_from_sys.far_cache]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from DRAM or MMIO in a different NUMA node",
+        "name": "Demand L1 Data Cache Fills from DRAM or MMIO in a different NUMA node",
         "expression": "[ls_dmnd_fills_from_sys.dram_io_far]"
     },
     {
-        "name": "metric_Lines written per Write Combining Buffer close",
+        "name": "Lines written per Write Combining Buffer close",
         "expression": "[ls_wcb_close_flush.full_line_64b] / [l2_wcb_req.wcb_close]"
     },
     {
-        "name": "metric_L1 ITLB Misses",
+        "name": "L1 ITLB Misses",
         "expression": "[bp_l1_tlb_miss_l2_tlb_hit] + [bp_l1_tlb_miss_l2_tlb_miss.all]"
     },
     {
-        "name": "metric_L2 ITLB Misses and Instruction Page Walks",
+        "name": "L2 ITLB Misses and Instruction Page Walks",
         "expression": "[bp_l1_tlb_miss_l2_tlb_miss.all]"
     },
     {
-        "name": "metric_L1 DTLB Misses",
+        "name": "L1 DTLB Misses",
         "expression": "[ls_l1_d_tlb_miss.all]"
     },
     {
-        "name": "metric_L2 DTLB Misses and Data Page Walks",
+        "name": "L2 DTLB Misses and Data Page Walks",
         "expression": "[ls_l1_d_tlb_miss.all_l2_miss]"
     },
     {
-        "name": "metric_All TLBs Flushed",
+        "name": "All TLBs Flushed",
         "expression": "[ls_tlb_flush.all]"
     },
     {
-        "name": "metric_Macro-ops Dispatched",
+        "name": "Macro-ops Dispatched",
         "expression": "[de_src_op_disp.all]"
     },
     {
-        "name": "metric_Mixed SSE and AVX Stalls",
+        "name": "Mixed SSE and AVX Stalls",
         "expression": "[fp_disp_faults.sse_avx_all]"
     },
     {
-        "name": "metric_Macro-ops Retired",
+        "name": "Macro-ops Retired",
         "expression": "[ex_ret_ops]"
     },
     {
-        "name": "metric_DRAM read bandwidth for local processor",
+        "name": "DRAM read bandwidth for local processor",
         "expression": "(64 * ([local_processor_read_data_beats_cs0] + [local_processor_read_data_beats_cs1] + [local_processor_read_data_beats_cs2] + [local_processor_read_data_beats_cs3] + [local_processor_read_data_beats_cs4] + [local_processor_read_data_beats_cs5] + [local_processor_read_data_beats_cs6] + [local_processor_read_data_beats_cs7] + [local_processor_read_data_beats_cs8] + [local_processor_read_data_beats_cs9] + [local_processor_read_data_beats_cs10] + [local_processor_read_data_beats_cs11]) / 1000000) / 1"
     },
     {
-        "name": "metric_DRAM write bandwidth for local processor",
+        "name": "DRAM write bandwidth for local processor",
         "expression": "(64 * ([local_processor_write_data_beats_cs0] + [local_processor_write_data_beats_cs1] + [local_processor_write_data_beats_cs2] + [local_processor_write_data_beats_cs3] + [local_processor_write_data_beats_cs4] + [local_processor_write_data_beats_cs5] + [local_processor_write_data_beats_cs6] + [local_processor_write_data_beats_cs7] + [local_processor_write_data_beats_cs8] + [local_processor_write_data_beats_cs9] + [local_processor_write_data_beats_cs10] + [local_processor_write_data_beats_cs11]) / 1000000) / 1"
     },
     {
-        "name": "metric_DRAM read bandwidth for remote processor",
+        "name": "DRAM read bandwidth for remote processor",
         "expression": "(64 * ([remote_processor_read_data_beats_cs0] + [remote_processor_read_data_beats_cs1] + [remote_processor_read_data_beats_cs2] + [remote_processor_read_data_beats_cs3] + [remote_processor_read_data_beats_cs4] + [remote_processor_read_data_beats_cs5] + [remote_processor_read_data_beats_cs6] + [remote_processor_read_data_beats_cs7] + [remote_processor_read_data_beats_cs8] + [remote_processor_read_data_beats_cs9] + [remote_processor_read_data_beats_cs10] + [remote_processor_read_data_beats_cs11]) / 1000000) / 1"
     },
     {
-        "name": "metric_DRAM write bandwidth for remote processor",
+        "name": "DRAM write bandwidth for remote processor",
         "expression": "(64 * ([remote_processor_write_data_beats_cs0] + [remote_processor_write_data_beats_cs1] + [remote_processor_write_data_beats_cs2] + [remote_processor_write_data_beats_cs3] + [remote_processor_write_data_beats_cs4] + [remote_processor_write_data_beats_cs5] + [remote_processor_write_data_beats_cs6] + [remote_processor_write_data_beats_cs7] + [remote_processor_write_data_beats_cs8] + [remote_processor_write_data_beats_cs9] + [remote_processor_write_data_beats_cs10] + [remote_processor_write_data_beats_cs11]) / 1000000) / 1"
     },
     {
-        "name": "metric_Local socket upstream DMA read bandwidth",
+        "name": "Local socket upstream DMA read bandwidth",
         "expression": "(64 * ([local_socket_upstream_read_beats_iom0] + [local_socket_upstream_read_beats_iom1] + [local_socket_upstream_read_beats_iom2] + [local_socket_upstream_read_beats_iom3]) / 1000000) / 1"
     },
     {
-        "name": "metric_Local socket upstream DMA write bandwidth",
+        "name": "Local socket upstream DMA write bandwidth",
         "expression": "(64 * ([local_socket_upstream_write_beats_iom0] + [local_socket_upstream_write_beats_iom1] + [local_socket_upstream_write_beats_iom2] + [local_socket_upstream_write_beats_iom3]) / 1000000) / 1"
     },
     {
-        "name": "metric_Remote socket upstream DMA read bandwidth",
+        "name": "Remote socket upstream DMA read bandwidth",
         "expression": "(64 * ([remote_socket_upstream_read_beats_iom0] + [remote_socket_upstream_read_beats_iom1] + [remote_socket_upstream_read_beats_iom2] + [remote_socket_upstream_read_beats_iom3]) / 1000000) / 1"
     },
     {
-        "name": "metric_Remote socket upstream DMA write bandwidth",
+        "name": "Remote socket upstream DMA write bandwidth",
         "expression": "(64 * ([remote_socket_upstream_write_beats_iom0] + [remote_socket_upstream_write_beats_iom1] + [remote_socket_upstream_write_beats_iom2] + [remote_socket_upstream_write_beats_iom3]) / 1000000) / 1"
     },
     {
-        "name": "metric_Local socket inbound bandwidth to the CPU",
+        "name": "Local socket inbound bandwidth to the CPU",
         "expression": "(32 * ([local_socket_inf0_inbound_data_beats_ccm0] + [local_socket_inf1_inbound_data_beats_ccm0] + [local_socket_inf0_inbound_data_beats_ccm1] + [local_socket_inf1_inbound_data_beats_ccm1] + [local_socket_inf0_inbound_data_beats_ccm2] + [local_socket_inf1_inbound_data_beats_ccm2] + [local_socket_inf0_inbound_data_beats_ccm3] + [local_socket_inf1_inbound_data_beats_ccm3] + [local_socket_inf0_inbound_data_beats_ccm4] + [local_socket_inf1_inbound_data_beats_ccm4] + [local_socket_inf0_inbound_data_beats_ccm5] + [local_socket_inf1_inbound_data_beats_ccm5] + [local_socket_inf0_inbound_data_beats_ccm6] + [local_socket_inf1_inbound_data_beats_ccm6] + [local_socket_inf0_inbound_data_beats_ccm7] + [local_socket_inf1_inbound_data_beats_ccm7]) / 1000000) / 1"
     },
     {
-        "name": "metric_Local socket outbound bandwidth from the CPU",
+        "name": "Local socket outbound bandwidth from the CPU",
         "expression": "(64 * ([local_socket_inf0_outbound_data_beats_ccm0] + [local_socket_inf1_outbound_data_beats_ccm0] + [local_socket_inf0_outbound_data_beats_ccm1] + [local_socket_inf1_outbound_data_beats_ccm1] + [local_socket_inf0_outbound_data_beats_ccm2] + [local_socket_inf1_outbound_data_beats_ccm2] + [local_socket_inf0_outbound_data_beats_ccm3] + [local_socket_inf1_outbound_data_beats_ccm3] + [local_socket_inf0_outbound_data_beats_ccm4] + [local_socket_inf1_outbound_data_beats_ccm4] + [local_socket_inf0_outbound_data_beats_ccm5] + [local_socket_inf1_outbound_data_beats_ccm5] + [local_socket_inf0_outbound_data_beats_ccm6] + [local_socket_inf1_outbound_data_beats_ccm6] + [local_socket_inf0_outbound_data_beats_ccm7] + [local_socket_inf1_outbound_data_beats_ccm7]) / 1000000) / 1"
     },
     {
-        "name": "metric_Remote socket inbound bandwidth to the CPU",
+        "name": "Remote socket inbound bandwidth to the CPU",
         "expression": "(32 * ([remote_socket_inf0_inbound_data_beats_ccm0] + [remote_socket_inf1_inbound_data_beats_ccm0] + [remote_socket_inf0_inbound_data_beats_ccm1] + [remote_socket_inf1_inbound_data_beats_ccm1] + [remote_socket_inf0_inbound_data_beats_ccm2] + [remote_socket_inf1_inbound_data_beats_ccm2] + [remote_socket_inf0_inbound_data_beats_ccm3] + [remote_socket_inf1_inbound_data_beats_ccm3] + [remote_socket_inf0_inbound_data_beats_ccm4] + [remote_socket_inf1_inbound_data_beats_ccm4] + [remote_socket_inf0_inbound_data_beats_ccm5] + [remote_socket_inf1_inbound_data_beats_ccm5] + [remote_socket_inf0_inbound_data_beats_ccm6] + [remote_socket_inf1_inbound_data_beats_ccm6] + [remote_socket_inf0_inbound_data_beats_ccm7] + [remote_socket_inf1_inbound_data_beats_ccm7]) / 1000000) / 1"
     },
     {
-        "name": "metric_Remote socket outbound bandwidth from the CPU",
+        "name": "Remote socket outbound bandwidth from the CPU",
         "expression": "(64 * ([remote_socket_inf0_outbound_data_beats_ccm0] + [remote_socket_inf1_outbound_data_beats_ccm0] + [remote_socket_inf0_outbound_data_beats_ccm1] + [remote_socket_inf1_outbound_data_beats_ccm1] + [remote_socket_inf0_outbound_data_beats_ccm2] + [remote_socket_inf1_outbound_data_beats_ccm2] + [remote_socket_inf0_outbound_data_beats_ccm3] + [remote_socket_inf1_outbound_data_beats_ccm3] + [remote_socket_inf0_outbound_data_beats_ccm4] + [remote_socket_inf1_outbound_data_beats_ccm4] + [remote_socket_inf0_outbound_data_beats_ccm5] + [remote_socket_inf1_outbound_data_beats_ccm5] + [remote_socket_inf0_outbound_data_beats_ccm6] + [remote_socket_inf1_outbound_data_beats_ccm6] + [remote_socket_inf0_outbound_data_beats_ccm7] + [remote_socket_inf1_outbound_data_beats_ccm7]) / 1000000) / 1"
     },
     {
-        "name": "metric_Outbound bandwidth from all links",
+        "name": "Outbound bandwidth from all links",
         "expression": "(64 * ([local_socket_outbound_data_beats_link0] + [local_socket_outbound_data_beats_link1] + [local_socket_outbound_data_beats_link2] + [local_socket_outbound_data_beats_link3] + [local_socket_outbound_data_beats_link4] + [local_socket_outbound_data_beats_link5] + [local_socket_outbound_data_beats_link6] + [local_socket_outbound_data_beats_link7]) / 1000000) / 1"
     },
     {
-        "name": "metric_Pipeline Utilization - Frontend Bound (%)",
+        "name": "Pipeline Utilization - Frontend Bound (%)",
         "expression": "([de_no_dispatch_per_slot.no_ops_from_frontend] / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Frontend Bound - Latency (%)",
+        "name": "Pipeline Utilization - Frontend Bound - Latency (%)",
         "expression": "((6 * [de_no_dispatch_per_cycle.no_ops_from_frontend]) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Frontend Bound - Bandwidth (%)",
+        "name": "Pipeline Utilization - Frontend Bound - Bandwidth (%)",
         "expression": "((([de_no_dispatch_per_slot.no_ops_from_frontend] / 6) - ([de_no_dispatch_per_cycle.no_ops_from_frontend])) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Bad Speculation (%)",
+        "name": "Pipeline Utilization - Bad Speculation (%)",
         "expression": "(([de_src_op_disp.all] - [ex_ret_ops]) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Bad Speculation - Mispredicts (%)",
+        "name": "Pipeline Utilization - Bad Speculation - Mispredicts (%)",
         "expression": "((([de_src_op_disp.all] - [ex_ret_ops]) * ([ex_ret_brn_misp] / ([ex_ret_brn_misp] + [resyncs_or_nc_redirects]))) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Bad Speculation - Pipeline Restarts (%)",
+        "name": "Pipeline Utilization - Bad Speculation - Pipeline Restarts (%)",
         "expression": "((([de_src_op_disp.all] - [ex_ret_ops]) * ([resyncs_or_nc_redirects] / ([ex_ret_brn_misp] + [resyncs_or_nc_redirects]))) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Backend Bound (%)",
+        "name": "Pipeline Utilization - Backend Bound (%)",
         "expression": "([de_no_dispatch_per_slot.backend_stalls] / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Backend Bound - Memory (%)",
+        "name": "Pipeline Utilization - Backend Bound - Memory (%)",
         "expression": "(([de_no_dispatch_per_slot.backend_stalls] * ([ex_no_retire.load_not_complete] / [ex_no_retire.not_complete])) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Backend Bound - CPU (%)",
+        "name": "Pipeline Utilization - Backend Bound - CPU (%)",
         "expression": "(([de_no_dispatch_per_slot.backend_stalls] * (1 - ([ex_no_retire.load_not_complete] / [ex_no_retire.not_complete]))) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - SMT Contention (%)",
+        "name": "Pipeline Utilization - SMT Contention (%)",
         "expression": "([de_no_dispatch_per_slot.smt_contention] / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Retiring (%)",
+        "name": "Pipeline Utilization - Retiring (%)",
         "expression": "([ex_ret_ops] / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Retiring - Fastpath (%)",
+        "name": "Pipeline Utilization - Retiring - Fastpath (%)",
         "expression": "(([ex_ret_ops] - [ex_ret_ucode_ops]) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Retiring - Microcode (%)",
+        "name": "Pipeline Utilization - Retiring - Microcode (%)",
         "expression": "([ex_ret_ucode_ops] / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/AuthenticAMD/genoa.json
+++ b/cmd/metrics/resources/metrics/x86_64/AuthenticAMD/genoa.json
@@ -1,299 +1,298 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ls_not_halted_p0_cyc] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "(100 * [ls_not_halted_p0_cyc]) / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
+        "name": "CPU utilization% in kernel mode",
         "expression": "(100 * [ls_not_halted_p0_cyc:k]) / [TSC]"
     },
     {
-        "name": "metric_CPI",
+        "name": "CPI",
         "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
+        "name": "kernel_CPI",
         "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_IPC",
+        "name": "IPC",
         "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_giga_instructions_per_sec",
+        "name": "giga_instructions_per_sec",
         "expression": "[instructions] / 1000000000"
     },
     {
-        "name": "metric_Branch Misprediction Ratio",
+        "name": "Branch Misprediction Ratio",
         "expression": "[ex_ret_brn_misp] / [ex_ret_brn]"
     },
     {
-        "name": "metric_All Data Cache Accesses",
+        "name": "All Data Cache Accesses",
         "expression": "[ls_dispatch.any]"
     },
     {
-        "name": "metric_All L2 Cache Accesses",
+        "name": "All L2 Cache Accesses",
         "expression": "[l2_request_g1.all_no_prefetch] + [l2_pf_hit_l2.all] + [l2_pf_miss_l2_hit_l3.all] + [l2_pf_miss_l2_l3.all]"
     },
     {
-        "name": "metric_L2 Cache Accesses from L1 Instruction Cache Misses",
+        "name": "L2 Cache Accesses from L1 Instruction Cache Misses",
         "expression": "[l2_request_g1.cacheable_ic_read]"
     },
     {
-        "name": "metric_L2 Cache Accesses from L1 Data Cache Misses",
+        "name": "L2 Cache Accesses from L1 Data Cache Misses",
         "expression": "[ic_tag_hit_miss.miss] / [instructions]"
     },
     {
-        "name": "metric_L2 Cache Accesses from L2 Cache Hardware Prefetches",
+        "name": "L2 Cache Accesses from L2 Cache Hardware Prefetches",
         "expression": "[l2_pf_hit_l2.all] + [l2_pf_miss_l2_hit_l3.all] + [l2_pf_miss_l2_l3.all]"
     },
     {
-        "name": "metric_All L2 Cache Misses",
+        "name": "All L2 Cache Misses",
         "expression": "[l2_cache_req_stat.ic_dc_miss_in_l2] + [l2_pf_miss_l2_hit_l3.all] + [l2_pf_miss_l2_l3.all]"
     },
     {
-        "name": "metric_L2 Cache Misses from L1 Instruction Cache Misses",
+        "name": "L2 Cache Misses from L1 Instruction Cache Misses",
         "expression": "[l2_cache_req_stat.ic_fill_miss]"
     },
     {
-        "name": "metric_L2 Cache Misses from L1 Data Cache Misses",
+        "name": "L2 Cache Misses from L1 Data Cache Misses",
         "expression": "[l2_cache_req_stat.ls_rd_blk_c]"
     },
     {
-        "name": "metric_L2 Cache Misses from L2 Cache Hardware Prefetches",
+        "name": "L2 Cache Misses from L2 Cache Hardware Prefetches",
         "expression": "[l2_pf_miss_l2_hit_l3.all] + [l2_pf_miss_l2_l3.all]"
     },
     {
-        "name": "metric_All L2 Cache Hits",
+        "name": "All L2 Cache Hits",
         "expression": "[l2_cache_req_stat.ic_dc_hit_in_l2] + [l2_pf_hit_l2.all]"
     },
     {
-        "name": "metric_L2 Cache Hits from L1 Instruction Cache Misses",
+        "name": "L2 Cache Hits from L1 Instruction Cache Misses",
         "expression": "[l2_cache_req_stat.ic_hit_in_l2]"
     },
     {
-        "name": "metric_L2 Cache Hits from L1 Data Cache Misses",
+        "name": "L2 Cache Hits from L1 Data Cache Misses",
         "expression": "[l2_cache_req_stat.dc_hit_in_l2]"
     },
     {
-        "name": "metric_L2 Cache Hits from L2 Cache Hardware Prefetches",
+        "name": "L2 Cache Hits from L2 Cache Hardware Prefetches",
         "expression": "[l2_pf_hit_l2.all]"
     },
     {
-        "name": "metric_L3 Cache Accesses",
+        "name": "L3 Cache Accesses",
         "expression": "[l3_lookup_state.all_coherent_accesses_to_l3]"
     },
     {
-        "name": "metric_L3 Cache Misses",
+        "name": "L3 Cache Misses",
         "expression": "[l3_lookup_state.l3_miss]"
     },
     {
-        "name": "metric_L3 Cache Hits",
+        "name": "L3 Cache Hits",
         "expression": "[l3_lookup_state.l3_hit]"
     },
     {
-        "name": "metric_Average L3 Cache Read Miss Latency (in ns)",
+        "name": "Average L3 Cache Read Miss Latency (in ns)",
         "expression": "([l3_xi_sampled_latency.all] * 10) / [l3_xi_sampled_latency_requests.all]"
     },
     {
-        "name": "metric_Op Cache Fetch Miss Ratio",
+        "name": "Op Cache Fetch Miss Ratio",
         "expression": "[op_cache_hit_miss.miss] / [op_cache_hit_miss.all]"
     },
     {
-        "name": "metric_Instruction Cache Fetch Miss Ratio",
+        "name": "Instruction Cache Fetch Miss Ratio",
         "expression": "[ic_tag_hit_miss.miss] / [ic_tag_hit_miss.all]"
     },
     {
-        "name": "metric_L1 Data Cache Fills from DRAM or IO in any NUMA node",
+        "name": "L1 Data Cache Fills from DRAM or IO in any NUMA node",
         "expression": "[ls_any_fills_from_sys.dram_io_all]"
     },
     {
-        "name": "metric_L1 Data Cache Fills from a different NUMA node",
+        "name": "L1 Data Cache Fills from a different NUMA node",
         "expression": "[ls_any_fills_from_sys.far_all]"
     },
     {
-        "name": "metric_L1 Data Cache Fills from within the same CCX",
+        "name": "L1 Data Cache Fills from within the same CCX",
         "expression": "[ls_any_fills_from_sys.local_all]"
     },
     {
-        "name": "metric_L1 Data Cache Fills from another CCX cache in any NUMA node",
+        "name": "L1 Data Cache Fills from another CCX cache in any NUMA node",
         "expression": "[ls_any_fills_from_sys.remote_cache]"
     },
     {
-        "name": "metric_All L1 Data Cache Fills",
+        "name": "All L1 Data Cache Fills",
         "expression": "[ls_any_fills_from_sys.all]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from local L2",
+        "name": "Demand L1 Data Cache Fills from local L2",
         "expression": "[ls_dmnd_fills_from_sys.local_l2]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from local L3 or different L2 in same CCX",
+        "name": "Demand L1 Data Cache Fills from local L3 or different L2 in same CCX",
         "expression": "[ls_dmnd_fills_from_sys.local_ccx]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from another CCX cache in the same NUMA node",
+        "name": "Demand L1 Data Cache Fills from another CCX cache in the same NUMA node",
         "expression": "[ls_dmnd_fills_from_sys.near_cache]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from DRAM or MMIO in the same NUMA node",
+        "name": "Demand L1 Data Cache Fills from DRAM or MMIO in the same NUMA node",
         "expression": "[ls_dmnd_fills_from_sys.dram_io_near]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from another CCX cache in a different NUMA node",
+        "name": "Demand L1 Data Cache Fills from another CCX cache in a different NUMA node",
         "expression": "[ls_dmnd_fills_from_sys.far_cache]"
     },
     {
-        "name": "metric_Demand L1 Data Cache Fills from DRAM or MMIO in a different NUMA node",
+        "name": "Demand L1 Data Cache Fills from DRAM or MMIO in a different NUMA node",
         "expression": "[ls_dmnd_fills_from_sys.dram_io_far]"
     },
     {
-        "name": "metric_Lines written per Write Combining Buffer close",
+        "name": "Lines written per Write Combining Buffer close",
         "expression": "[ls_wcb_close_flush.full_line_64b] / [l2_wcb_req.wcb_close]"
     },
     {
-        "name": "metric_L1 ITLB Misses",
+        "name": "L1 ITLB Misses",
         "expression": "[bp_l1_tlb_miss_l2_tlb_hit] + [bp_l1_tlb_miss_l2_tlb_miss.all]"
     },
     {
-        "name": "metric_L2 ITLB Misses and Instruction Page Walks",
+        "name": "L2 ITLB Misses and Instruction Page Walks",
         "expression": "[bp_l1_tlb_miss_l2_tlb_miss.all]"
     },
     {
-        "name": "metric_L1 DTLB Misses",
+        "name": "L1 DTLB Misses",
         "expression": "[ls_l1_d_tlb_miss.all]"
     },
     {
-        "name": "metric_L2 DTLB Misses and Data Page Walks",
+        "name": "L2 DTLB Misses and Data Page Walks",
         "expression": "[ls_l1_d_tlb_miss.all_l2_miss]"
     },
     {
-        "name": "metric_All TLBs Flushed",
+        "name": "All TLBs Flushed",
         "expression": "[ls_tlb_flush.all]"
     },
     {
-        "name": "metric_Macro-ops Dispatched",
+        "name": "Macro-ops Dispatched",
         "expression": "[de_src_op_disp.all]"
     },
     {
-        "name": "metric_Mixed SSE and AVX Stalls",
+        "name": "Mixed SSE and AVX Stalls",
         "expression": "[fp_disp_faults.sse_avx_all]"
     },
     {
-        "name": "metric_Macro-ops Retired",
+        "name": "Macro-ops Retired",
         "expression": "[ex_ret_ops]"
     },
     {
-        "name": "metric_DRAM read bandwidth for local processor",
+        "name": "DRAM read bandwidth for local processor",
         "expression": "(64 * ([local_processor_read_data_beats_cs0] + [local_processor_read_data_beats_cs1] + [local_processor_read_data_beats_cs2] + [local_processor_read_data_beats_cs3] + [local_processor_read_data_beats_cs4] + [local_processor_read_data_beats_cs5] + [local_processor_read_data_beats_cs6] + [local_processor_read_data_beats_cs7] + [local_processor_read_data_beats_cs8] + [local_processor_read_data_beats_cs9] + [local_processor_read_data_beats_cs10] + [local_processor_read_data_beats_cs11]) / 1000000) / 1"
     },
     {
-        "name": "metric_DRAM write bandwidth for local processor",
+        "name": "DRAM write bandwidth for local processor",
         "expression": "(64 * ([local_processor_write_data_beats_cs0] + [local_processor_write_data_beats_cs1] + [local_processor_write_data_beats_cs2] + [local_processor_write_data_beats_cs3] + [local_processor_write_data_beats_cs4] + [local_processor_write_data_beats_cs5] + [local_processor_write_data_beats_cs6] + [local_processor_write_data_beats_cs7] + [local_processor_write_data_beats_cs8] + [local_processor_write_data_beats_cs9] + [local_processor_write_data_beats_cs10] + [local_processor_write_data_beats_cs11]) / 1000000) / 1"
     },
     {
-        "name": "metric_DRAM read bandwidth for remote processor",
+        "name": "DRAM read bandwidth for remote processor",
         "expression": "(64 * ([remote_processor_read_data_beats_cs0] + [remote_processor_read_data_beats_cs1] + [remote_processor_read_data_beats_cs2] + [remote_processor_read_data_beats_cs3] + [remote_processor_read_data_beats_cs4] + [remote_processor_read_data_beats_cs5] + [remote_processor_read_data_beats_cs6] + [remote_processor_read_data_beats_cs7] + [remote_processor_read_data_beats_cs8] + [remote_processor_read_data_beats_cs9] + [remote_processor_read_data_beats_cs10] + [remote_processor_read_data_beats_cs11]) / 1000000) / 1"
     },
     {
-        "name": "metric_DRAM write bandwidth for remote processor",
+        "name": "DRAM write bandwidth for remote processor",
         "expression": "(64 * ([remote_processor_write_data_beats_cs0] + [remote_processor_write_data_beats_cs1] + [remote_processor_write_data_beats_cs2] + [remote_processor_write_data_beats_cs3] + [remote_processor_write_data_beats_cs4] + [remote_processor_write_data_beats_cs5] + [remote_processor_write_data_beats_cs6] + [remote_processor_write_data_beats_cs7] + [remote_processor_write_data_beats_cs8] + [remote_processor_write_data_beats_cs9] + [remote_processor_write_data_beats_cs10] + [remote_processor_write_data_beats_cs11]) / 1000000) / 1"
     },
     {
-        "name": "metric_Local socket upstream DMA read bandwidth",
+        "name": "Local socket upstream DMA read bandwidth",
         "expression": "(64 * ([local_socket_upstream_read_beats_iom0] + [local_socket_upstream_read_beats_iom1] + [local_socket_upstream_read_beats_iom2] + [local_socket_upstream_read_beats_iom3]) / 1000000) / 1"
     },
     {
-        "name": "metric_Local socket upstream DMA write bandwidth",
+        "name": "Local socket upstream DMA write bandwidth",
         "expression": "(64 * ([local_socket_upstream_write_beats_iom0] + [local_socket_upstream_write_beats_iom1] + [local_socket_upstream_write_beats_iom2] + [local_socket_upstream_write_beats_iom3]) / 1000000) / 1"
     },
     {
-        "name": "metric_Remote socket upstream DMA read bandwidth",
+        "name": "Remote socket upstream DMA read bandwidth",
         "expression": "(64 * ([remote_socket_upstream_read_beats_iom0] + [remote_socket_upstream_read_beats_iom1] + [remote_socket_upstream_read_beats_iom2] + [remote_socket_upstream_read_beats_iom3]) / 1000000) / 1"
     },
     {
-        "name": "metric_Remote socket upstream DMA write bandwidth",
+        "name": "Remote socket upstream DMA write bandwidth",
         "expression": "(64 * ([remote_socket_upstream_write_beats_iom0] + [remote_socket_upstream_write_beats_iom1] + [remote_socket_upstream_write_beats_iom2] + [remote_socket_upstream_write_beats_iom3]) / 1000000) / 1"
     },
     {
-        "name": "metric_Local socket inbound bandwidth to the CPU",
+        "name": "Local socket inbound bandwidth to the CPU",
         "expression": "(32 * ([local_socket_inf0_inbound_data_beats_ccm0] + [local_socket_inf1_inbound_data_beats_ccm0] + [local_socket_inf0_inbound_data_beats_ccm1] + [local_socket_inf1_inbound_data_beats_ccm1] + [local_socket_inf0_inbound_data_beats_ccm2] + [local_socket_inf1_inbound_data_beats_ccm2] + [local_socket_inf0_inbound_data_beats_ccm3] + [local_socket_inf1_inbound_data_beats_ccm3] + [local_socket_inf0_inbound_data_beats_ccm4] + [local_socket_inf1_inbound_data_beats_ccm4] + [local_socket_inf0_inbound_data_beats_ccm5] + [local_socket_inf1_inbound_data_beats_ccm5] + [local_socket_inf0_inbound_data_beats_ccm6] + [local_socket_inf1_inbound_data_beats_ccm6] + [local_socket_inf0_inbound_data_beats_ccm7] + [local_socket_inf1_inbound_data_beats_ccm7]) / 1000000) / 1"
     },
     {
-        "name": "metric_Local socket outbound bandwidth from the CPU",
+        "name": "Local socket outbound bandwidth from the CPU",
         "expression": "(64 * ([local_socket_inf0_outbound_data_beats_ccm0] + [local_socket_inf1_outbound_data_beats_ccm0] + [local_socket_inf0_outbound_data_beats_ccm1] + [local_socket_inf1_outbound_data_beats_ccm1] + [local_socket_inf0_outbound_data_beats_ccm2] + [local_socket_inf1_outbound_data_beats_ccm2] + [local_socket_inf0_outbound_data_beats_ccm3] + [local_socket_inf1_outbound_data_beats_ccm3] + [local_socket_inf0_outbound_data_beats_ccm4] + [local_socket_inf1_outbound_data_beats_ccm4] + [local_socket_inf0_outbound_data_beats_ccm5] + [local_socket_inf1_outbound_data_beats_ccm5] + [local_socket_inf0_outbound_data_beats_ccm6] + [local_socket_inf1_outbound_data_beats_ccm6] + [local_socket_inf0_outbound_data_beats_ccm7] + [local_socket_inf1_outbound_data_beats_ccm7]) / 1000000) / 1"
     },
     {
-        "name": "metric_Remote socket inbound bandwidth to the CPU",
+        "name": "Remote socket inbound bandwidth to the CPU",
         "expression": "(32 * ([remote_socket_inf0_inbound_data_beats_ccm0] + [remote_socket_inf1_inbound_data_beats_ccm0] + [remote_socket_inf0_inbound_data_beats_ccm1] + [remote_socket_inf1_inbound_data_beats_ccm1] + [remote_socket_inf0_inbound_data_beats_ccm2] + [remote_socket_inf1_inbound_data_beats_ccm2] + [remote_socket_inf0_inbound_data_beats_ccm3] + [remote_socket_inf1_inbound_data_beats_ccm3] + [remote_socket_inf0_inbound_data_beats_ccm4] + [remote_socket_inf1_inbound_data_beats_ccm4] + [remote_socket_inf0_inbound_data_beats_ccm5] + [remote_socket_inf1_inbound_data_beats_ccm5] + [remote_socket_inf0_inbound_data_beats_ccm6] + [remote_socket_inf1_inbound_data_beats_ccm6] + [remote_socket_inf0_inbound_data_beats_ccm7] + [remote_socket_inf1_inbound_data_beats_ccm7]) / 1000000) / 1"
     },
     {
-        "name": "metric_Remote socket outbound bandwidth from the CPU",
+        "name": "Remote socket outbound bandwidth from the CPU",
         "expression": "(64 * ([remote_socket_inf0_outbound_data_beats_ccm0] + [remote_socket_inf1_outbound_data_beats_ccm0] + [remote_socket_inf0_outbound_data_beats_ccm1] + [remote_socket_inf1_outbound_data_beats_ccm1] + [remote_socket_inf0_outbound_data_beats_ccm2] + [remote_socket_inf1_outbound_data_beats_ccm2] + [remote_socket_inf0_outbound_data_beats_ccm3] + [remote_socket_inf1_outbound_data_beats_ccm3] + [remote_socket_inf0_outbound_data_beats_ccm4] + [remote_socket_inf1_outbound_data_beats_ccm4] + [remote_socket_inf0_outbound_data_beats_ccm5] + [remote_socket_inf1_outbound_data_beats_ccm5] + [remote_socket_inf0_outbound_data_beats_ccm6] + [remote_socket_inf1_outbound_data_beats_ccm6] + [remote_socket_inf0_outbound_data_beats_ccm7] + [remote_socket_inf1_outbound_data_beats_ccm7]) / 1000000) / 1"
     },
     {
-        "name": "metric_Outbound bandwidth from all links",
+        "name": "Outbound bandwidth from all links",
         "expression": "(64 * ([local_socket_outbound_data_beats_link0] + [local_socket_outbound_data_beats_link1] + [local_socket_outbound_data_beats_link2] + [local_socket_outbound_data_beats_link3] + [local_socket_outbound_data_beats_link4] + [local_socket_outbound_data_beats_link5] + [local_socket_outbound_data_beats_link6] + [local_socket_outbound_data_beats_link7]) / 1000000) / 1"
     },
     {
-        "name": "metric_Pipeline Utilization - Frontend Bound (%)",
+        "name": "Pipeline Utilization - Frontend Bound (%)",
         "expression": "([de_no_dispatch_per_slot.no_ops_from_frontend] / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Frontend Bound - Latency (%)",
+        "name": "Pipeline Utilization - Frontend Bound - Latency (%)",
         "expression": "((6 * [de_no_dispatch_per_cycle.no_ops_from_frontend]) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Frontend Bound - Bandwidth (%)",
+        "name": "Pipeline Utilization - Frontend Bound - Bandwidth (%)",
         "expression": "((([de_no_dispatch_per_slot.no_ops_from_frontend] / 6) - ([de_no_dispatch_per_cycle.no_ops_from_frontend])) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Bad Speculation (%)",
+        "name": "Pipeline Utilization - Bad Speculation (%)",
         "expression": "(([de_src_op_disp.all] - [ex_ret_ops]) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Bad Speculation - Mispredicts (%)",
+        "name": "Pipeline Utilization - Bad Speculation - Mispredicts (%)",
         "expression": "((([de_src_op_disp.all] - [ex_ret_ops]) * ([ex_ret_brn_misp] / ([ex_ret_brn_misp] + [resyncs_or_nc_redirects]))) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Bad Speculation - Pipeline Restarts (%)",
+        "name": "Pipeline Utilization - Bad Speculation - Pipeline Restarts (%)",
         "expression": "((([de_src_op_disp.all] - [ex_ret_ops]) * ([resyncs_or_nc_redirects] / ([ex_ret_brn_misp] + [resyncs_or_nc_redirects]))) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Backend Bound (%)",
+        "name": "Pipeline Utilization - Backend Bound (%)",
         "expression": "([de_no_dispatch_per_slot.backend_stalls] / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Backend Bound - Memory (%)",
+        "name": "Pipeline Utilization - Backend Bound - Memory (%)",
         "expression": "(([de_no_dispatch_per_slot.backend_stalls] * ([ex_no_retire.load_not_complete] / [ex_no_retire.not_complete])) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Backend Bound - CPU (%)",
+        "name": "Pipeline Utilization - Backend Bound - CPU (%)",
         "expression": "(([de_no_dispatch_per_slot.backend_stalls] * (1 - ([ex_no_retire.load_not_complete] / [ex_no_retire.not_complete]))) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - SMT Contention (%)",
+        "name": "Pipeline Utilization - SMT Contention (%)",
         "expression": "([de_no_dispatch_per_slot.smt_contention] / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Retiring (%)",
+        "name": "Pipeline Utilization - Retiring (%)",
         "expression": "([ex_ret_ops] / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Retiring - Fastpath (%)",
+        "name": "Pipeline Utilization - Retiring - Fastpath (%)",
         "expression": "(([ex_ret_ops] - [ex_ret_ucode_ops]) / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_Pipeline Utilization - Retiring - Microcode (%)",
+        "name": "Pipeline Utilization - Retiring - Microcode (%)",
         "expression": "([ex_ret_ucode_ops] / (6 * [ls_not_halted_cyc])) * 100"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/bdx.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/bdx.json
@@ -1,396 +1,414 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycle",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[TXN] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]",
-        "origin": "perfmon website"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_L1D MPI (includes data+rfo w/ prefetches)",
-        "name-txn": "metric_L1D misses per txn (includes data+rfo w/ prefetches)",
-        "expression": "[L1D.REPLACEMENT] / [instructions]",
-        "expression-txn": "[L1D.REPLACEMENT] / [TXN]"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_UOPS_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_UOPS_RETIRED.L1_HIT] / [TXN]"
+        "name": "txn per cycle",
+        "expression": "[TXN] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1-I code read misses (w/ prefetches) per txn",
-        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]",
-        "expression-txn": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_UOPS_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_UOPS_RETIRED.L2_HIT] / [txn]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[L2_LINES_IN.ALL] / [instructions]",
-        "expression-txn": "[L2_LINES_IN.ALL] / [TXN]"
+        "name": "L1D MPI (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read MPI",
-        "name-txn": "metric_L2 demand data read misses per txn",
-        "expression": "[MEM_LOAD_UOPS_RETIRED.L2_MISS] / [instructions]",
-        "expression-txn": "[MEM_LOAD_UOPS_RETIRED.L2_MISS] / [TXN]"
+        "name": "L1D misses per txn (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [TXN]"
     },
     {
-        "name": "metric_L2 demand code MPI",
-        "name-txn": "metric_L2 demand code misses per txn",
-        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]",
-        "expression-txn": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L1_HIT] / [instructions]"
     },
     {
-        "name": "metric_LLC MPI",
-        "name-txn": "metric_LLC misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x180] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x181] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x182] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x190] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x191] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x192] - [UNC_C_TOR_INSERTS.MISS_OPCODE.tid.0x180]) / [instructions]",
-        "expression-txn": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x180] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x181] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x182] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x190] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x191] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x192] - [UNC_C_TOR_INSERTS.MISS_OPCODE.tid.0x180]) / [TXN]",
-        "origin": "perfspect"
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L1_HIT] / [TXN]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x181] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x191]) / [instructions]",
-        "expression-txn": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x181] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x191]) / [TXN]"
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x182] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x192]) / [instructions]",
-        "expression-txn": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x182] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x192]) / [TXN]"
+        "name": "L1-I code read misses (w/ prefetches) per txn",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
     },
     {
-        "name": "metric_LLC total HITM (per instr)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [instructions]",
-        "expression-txn": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [TXN]",
-        "origin": "perfspect"
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L2_HIT] / [instructions]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [instructions]",
-        "expression-txn": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [TXN]",
-        "origin": "perfspect"
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L2_HIT] / [txn]"
     },
     {
-        "name": "metric_Average LLC data read miss latency (in clks)",
-        "expression": "[UNC_C_TOR_OCCUPANCY.MISS_OPCODE.0x182] / [UNC_C_TOR_INSERTS.MISS_OPCODE.0x182]",
-        "origin": "perfspect"
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [instructions]"
     },
     {
-        "name": "metric_Average LLC data read miss latency (in ns)",
-        "expression": "(1000000000 * [UNC_C_TOR_OCCUPANCY.MISS_OPCODE.0x182] / [UNC_C_TOR_INSERTS.MISS_OPCODE.0x182]) / ([UNC_C_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )",
-        "origin": "perfspect"
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [TXN]"
     },
     {
-        "name": "metric_Average LLC data read miss latency for LOCAL requests (in ns)",
-        "expression": "(1000000000 * [UNC_C_TOR_OCCUPANCY.MISS_LOCAL_OPCODE.0x182] / [UNC_C_TOR_INSERTS.MISS_LOCAL_OPCODE.0x182]) / ([UNC_C_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]))",
-        "origin": "perfspect"
+        "name": "L2 demand data read MPI",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L2_MISS] / [instructions]"
     },
     {
-        "name": "metric_Average LLC data read miss latency for REMOTE requests (in ns)",
-        "expression": "(1000000000 * [UNC_C_TOR_OCCUPANCY.MISS_REMOTE_OPCODE.0x182] / [UNC_C_TOR_INSERTS.MISS_REMOTE_OPCODE.0x182]) / ([UNC_C_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]))",
-        "origin": "perfspect"
+        "name": "L2 demand data read misses per txn",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L2_MISS] / [TXN]"
     },
     {
-        "name": "metric_ITLB MPI",
-        "name-txn": "metric_ITLB misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "L2 demand code MPI",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]"
     },
     {
-        "name": "metric_ITLB large page MPI",
-        "name-txn": "metric_ITLB large page misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "L2 demand code misses per txn",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
     },
     {
-        "name": "metric_DTLB load MPI",
-        "name-txn": "metric_DTLB load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "LLC MPI",
+        "expression": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x180] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x181] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x182] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x190] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x191] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x192] - [UNC_C_TOR_INSERTS.MISS_OPCODE.tid.0x180]) / [instructions]"
     },
     {
-        "name": "metric_DTLB 2MB large page load MPI",
-        "name-txn": "metric_DTLB 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]",
-        "origin": "perfspect"
+        "name": "LLC misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x180] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x181] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x182] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x190] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x191] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x192] - [UNC_C_TOR_INSERTS.MISS_OPCODE.tid.0x180]) / [TXN]"
     },
     {
-        "name": "metric_DTLB store MPI",
-        "name-txn": "metric_DTLB store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x181] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x191]) / [instructions]"
     },
     {
-        "name": "metric_DTLB load miss latency (in core clks)",
-        "expression": "[DTLB_LOAD_MISSES.WALK_DURATION] / [DTLB_LOAD_MISSES.WALK_COMPLETED]",
-        "origin": "perfspect"
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x181] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x191]) / [TXN]"
     },
     {
-        "name": "metric_DTLB store miss latency (in core clks)",
-        "expression": "[DTLB_STORE_MISSES.WALK_DURATION] / [DTLB_STORE_MISSES.WALK_COMPLETED]",
-        "origin": "perfspect"
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x182] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x192]) / [instructions]"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to local DRAM",
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "([UNC_C_TOR_INSERTS.MISS_OPCODE.0x182] + [UNC_C_TOR_INSERTS.MISS_OPCODE.0x192]) / [TXN]"
+    },
+    {
+        "name": "LLC total HITM (per instr)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [instructions]"
+    },
+    {
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [TXN]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards (per instr)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [instructions]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [TXN]"
+    },
+    {
+        "name": "Average LLC data read miss latency (in clks)",
+        "expression": "[UNC_C_TOR_OCCUPANCY.MISS_OPCODE.0x182] / [UNC_C_TOR_INSERTS.MISS_OPCODE.0x182]"
+    },
+    {
+        "name": "Average LLC data read miss latency (in ns)",
+        "expression": "(1000000000 * [UNC_C_TOR_OCCUPANCY.MISS_OPCODE.0x182] / [UNC_C_TOR_INSERTS.MISS_OPCODE.0x182]) / ([UNC_C_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )"
+    },
+    {
+        "name": "Average LLC data read miss latency for LOCAL requests (in ns)",
+        "expression": "(1000000000 * [UNC_C_TOR_OCCUPANCY.MISS_LOCAL_OPCODE.0x182] / [UNC_C_TOR_INSERTS.MISS_LOCAL_OPCODE.0x182]) / ([UNC_C_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]))"
+    },
+    {
+        "name": "Average LLC data read miss latency for REMOTE requests (in ns)",
+        "expression": "(1000000000 * [UNC_C_TOR_OCCUPANCY.MISS_REMOTE_OPCODE.0x182] / [UNC_C_TOR_INSERTS.MISS_REMOTE_OPCODE.0x182]) / ([UNC_C_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]))"
+    },
+    {
+        "name": "ITLB MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "ITLB misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "ITLB large page MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "ITLB large page misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "DTLB 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "DTLB load miss latency (in core clks)",
+        "expression": "[DTLB_LOAD_MISSES.WALK_DURATION] / [DTLB_LOAD_MISSES.WALK_COMPLETED]"
+    },
+    {
+        "name": "DTLB store miss latency (in core clks)",
+        "expression": "[DTLB_STORE_MISSES.WALK_DURATION] / [DTLB_STORE_MISSES.WALK_COMPLETED]"
+    },
+    {
+        "name": "NUMA %_Reads addressed to local DRAM",
         "expression": "100 * [UNC_C_TOR_INSERTS.MISS_LOCAL_OPCODE.0x182] / ([UNC_C_TOR_INSERTS.MISS_LOCAL_OPCODE.0x182] + [UNC_C_TOR_INSERTS.MISS_REMOTE_OPCODE.0x182])"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to remote DRAM",
+        "name": "NUMA %_Reads addressed to remote DRAM",
         "expression": "100 * [UNC_C_TOR_INSERTS.MISS_REMOTE_OPCODE.0x182] / ([UNC_C_TOR_INSERTS.MISS_LOCAL_OPCODE.0x182] + [UNC_C_TOR_INSERTS.MISS_REMOTE_OPCODE.0x182])"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_C_CLOCKTICKS] / ([CORES_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
-        "expression": "[power/energy-ram/]",
-        "origin": "perfspect"
+        "name": "DRAM power (watts)",
+        "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
-        "expression": "100 * [cstate_core/c6-residency/] / [TSC]",
-        "origin": "perfspect"
+        "name": "core c6 residency %",
+        "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
-        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]",
-        "origin": "perfspect"
+        "name": "package c6 residency %",
+        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_% Uops delivered from decoded Icache (DSB)",
+        "name": "% Uops delivered from decoded Icache (DSB)",
         "expression": "100 * ([IDQ.DSB_UOPS] / [UOPS_ISSUED.ANY])"
     },
     {
-        "name": "metric_% Uops delivered from legacy decode pipeline (MITE)",
+        "name": "% Uops delivered from legacy decode pipeline (MITE)",
         "expression": "100 * ([IDQ.MITE_UOPS] / [UOPS_ISSUED.ANY])"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.RD] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.WR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT.RD] + [UNC_M_CAS_COUNT.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_writes (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_writes (MB/sec)",
         "expression": "([UNC_C_TOR_INSERTS.OPCODE.0x19e] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_reads (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_reads (MB/sec)",
         "expression": "(([UNC_C_TOR_INSERTS.OPCODE.0x1c8.tid.0x3e] + [UNC_C_TOR_INSERTS.OPCODE.0x180.tid.0x3e]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Latency(%)",
+        "name": "TMA_..Fetch_Latency(%)",
         "expression": "100 * ( ( 4 ) * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( [ICACHE.IFDATA_STALL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( ( 14 * [ITLB_MISSES.STLB_HIT] + [ITLB_MISSES.WALK_DURATION:c1] + 7 * [ITLB_MISSES.WALK_COMPLETED] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....Branch_Resteers(%)",
+        "name": "TMA_....Branch_Resteers(%)",
         "expression": "100 * ( ( 12 ) * ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] + [BACLEARS.ANY] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Mispredicts_Resteers(%)",
+        "name": "TMA_......Mispredicts_Resteers(%)",
         "expression": "100 * ( [BR_MISP_RETIRED.ALL_BRANCHES] * ( ( 12 ) * ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] + [BACLEARS.ANY] ) / ( [cpu-cycles] ) ) / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] + [BACLEARS.ANY] ) )"
     },
     {
-        "name": "metric_TMA_......Clears_Resteers(%)",
+        "name": "TMA_......Clears_Resteers(%)",
         "expression": "100 * ( [MACHINE_CLEARS.COUNT] * ( ( 12 ) * ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] + [BACLEARS.ANY] ) / ( [cpu-cycles] ) ) / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] + [BACLEARS.ANY] ) )"
     },
     {
-        "name": "metric_TMA_......Unknown_Branches(%)",
+        "name": "TMA_......Unknown_Branches(%)",
         "expression": "100 * ( ( ( 12 ) * ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] + [BACLEARS.ANY] ) / ( [cpu-cycles] ) ) - ( [BR_MISP_RETIRED.ALL_BRANCHES] * ( ( 12 ) * ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] + [BACLEARS.ANY] ) / ( [cpu-cycles] ) ) / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] + [BACLEARS.ANY] ) ) - ( [MACHINE_CLEARS.COUNT] * ( ( 12 ) * ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] + [BACLEARS.ANY] ) / ( [cpu-cycles] ) ) / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] + [BACLEARS.ANY] ) ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Bandwidth(%)",
+        "name": "TMA_..Fetch_Bandwidth(%)",
         "expression": "100 * ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( ( 4 ) * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....MITE(%)",
+        "name": "TMA_....MITE(%)",
         "expression": "100 * ( ( [IDQ.ALL_MITE_CYCLES_ANY_UOPS] - [IDQ.ALL_MITE_CYCLES_4_UOPS] ) / ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) / 2 )"
     },
     {
-        "name": "metric_TMA_....DSB(%)",
+        "name": "TMA_....DSB(%)",
         "expression": "100 * ( ( [IDQ.ALL_DSB_CYCLES_ANY_UOPS] - [IDQ.ALL_DSB_CYCLES_4_UOPS] ) / ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) / 2 )"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100 * ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100 * ( ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( 1 - ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) + ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100 * ( ( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] + [RESOURCE_STALLS.SB] ) / ( ( [CYCLE_ACTIVITY.STALLS_TOTAL] + [UOPS_EXECUTED.CYCLES_GE_1_UOP_EXEC] - ( [UOPS_EXECUTED.CYCLES_GE_3_UOPS_EXEC] if ( ( [instructions] / ( [cpu-cycles] ) ) > 1.8 ) else [UOPS_EXECUTED.CYCLES_GE_2_UOPS_EXEC] ) - ( [RS_EVENTS.EMPTY_CYCLES] if ( ( ( 4 ) * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) > 0.1 ) else 0 ) + [RESOURCE_STALLS.SB] ) ) ) * ( 1 - ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) + ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100 * ( max( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] - [CYCLE_ACTIVITY.STALLS_L1D_MISS] ) / ( [cpu-cycles] ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_......DTLB_Load(%)",
+        "name": "TMA_......DTLB_Load(%)",
         "expression": "100 * ( ( ( 8 ) * [DTLB_LOAD_MISSES.STLB_HIT] + [DTLB_LOAD_MISSES.WALK_DURATION:c1] + 7 * [DTLB_LOAD_MISSES.WALK_COMPLETED] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100 * ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100 * ( ( [MEM_LOAD_UOPS_RETIRED.L3_HIT] / ( [MEM_LOAD_UOPS_RETIRED.L3_HIT] + ( 7 ) * [MEM_LOAD_UOPS_RETIRED.L3_MISS] ) ) * [CYCLE_ACTIVITY.STALLS_L2_MISS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Data_Sharing(%)",
+        "name": "TMA_......Data_Sharing(%)",
         "expression": "100 * ( min( ( ( 43 ) * ( [MEM_LOAD_UOPS_L3_HIT_RETIRED.XSNP_HIT] * ( 1 + [MEM_LOAD_UOPS_RETIRED.HIT_LFB] / ( ( [MEM_LOAD_UOPS_RETIRED.L2_HIT] + [MEM_LOAD_UOPS_RETIRED.L3_HIT] + [MEM_LOAD_UOPS_L3_HIT_RETIRED.XSNP_HIT] + [MEM_LOAD_UOPS_L3_HIT_RETIRED.XSNP_HITM] + [MEM_LOAD_UOPS_L3_HIT_RETIRED.XSNP_MISS] ) + [MEM_LOAD_UOPS_L3_MISS_RETIRED.LOCAL_DRAM] + [MEM_LOAD_UOPS_L3_MISS_RETIRED.REMOTE_DRAM] + [MEM_LOAD_UOPS_L3_MISS_RETIRED.REMOTE_HITM] + [MEM_LOAD_UOPS_L3_MISS_RETIRED.REMOTE_FWD] ) ) ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....MEM_Bound(%)",
-        "expression": "100 * (1 - ( [MEM_LOAD_UOPS_RETIRED.L3_HIT] / ([MEM_LOAD_UOPS_RETIRED.L3_HIT] + 7 * [MEM_LOAD_UOPS_RETIRED.L3_MISS])) ) * ([CYCLE_ACTIVITY.STALLS_L2_MISS] / [cpu-cycles])",
-        "origin": "perfspect"
+        "name": "TMA_....MEM_Bound(%)",
+        "expression": "100 * (1 - ( [MEM_LOAD_UOPS_RETIRED.L3_HIT] / ([MEM_LOAD_UOPS_RETIRED.L3_HIT] + 7 * [MEM_LOAD_UOPS_RETIRED.L3_MISS])) ) * ([CYCLE_ACTIVITY.STALLS_L2_MISS] / [cpu-cycles])"
     },
     {
-        "name": "metric_TMA_......MEM_Bandwidth(%)",
+        "name": "TMA_......MEM_Bandwidth(%)",
         "expression": "100 * ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.DATA_RD:c4] ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......MEM_Latency(%)",
+        "name": "TMA_......MEM_Latency(%)",
         "expression": "100 * ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DATA_RD] ) ) / ( [cpu-cycles] ) - ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.DATA_RD:c4] ) ) / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100 * ( [RESOURCE_STALLS.SB] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100 * ( ( 1 - ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) + ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) ) ) - ( ( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] + [RESOURCE_STALLS.SB] ) / ( ( [CYCLE_ACTIVITY.STALLS_TOTAL] + [UOPS_EXECUTED.CYCLES_GE_1_UOP_EXEC] - ( [UOPS_EXECUTED.CYCLES_GE_3_UOPS_EXEC] if ( ( [instructions] / ( [cpu-cycles] ) ) > 1.8 ) else [UOPS_EXECUTED.CYCLES_GE_2_UOPS_EXEC] ) - ( [RS_EVENTS.EMPTY_CYCLES] if ( ( ( 4 ) * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) > 0.1 ) else 0 ) + [RESOURCE_STALLS.SB] ) ) ) * ( 1 - ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) + ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Ports_Utilization(%)",
+        "name": "TMA_....Ports_Utilization(%)",
         "expression": "100 * ( ( ( ( [CYCLE_ACTIVITY.STALLS_TOTAL] + [UOPS_EXECUTED.CYCLES_GE_1_UOP_EXEC] - ( [UOPS_EXECUTED.CYCLES_GE_3_UOPS_EXEC] if ( ( [instructions] / ( [cpu-cycles] ) ) > 1.8 ) else [UOPS_EXECUTED.CYCLES_GE_2_UOPS_EXEC] ) - ( [RS_EVENTS.EMPTY_CYCLES] if ( ( ( 4 ) * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) > 0.1 ) else 0 ) + [RESOURCE_STALLS.SB] ) ) - [RESOURCE_STALLS.SB] - [CYCLE_ACTIVITY.STALLS_MEM_ANY] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_0(%)",
-        "expression": "100 * (([UOPS_EXECUTED.CORE_i1_c1] / [CONST_THREAD_COUNT]) if ([CONST_THREAD_COUNT] > 1) else ([RS_EVENTS.EMPTY_CYCLES] if ([CYCLE_ACTIVITY.STALLS_TOTAL] - ([IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])) ) > 0.1 else 0)) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT]) ",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_0(%)",
+        "expression": "100 * (([UOPS_EXECUTED.CORE_i1_c1] / [CONST_THREAD_COUNT]) if ([CONST_THREAD_COUNT] > 1) else ([RS_EVENTS.EMPTY_CYCLES] if ([CYCLE_ACTIVITY.STALLS_TOTAL] - ([IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])) ) > 0.1 else 0)) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT]) "
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_1(%)",
-        "expression": "100 * (([UOPS_EXECUTED.CORE_c1] - [UOPS_EXECUTED.CORE_c2]) / [CONST_THREAD_COUNT]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_1(%)",
+        "expression": "100 * (([UOPS_EXECUTED.CORE_c1] - [UOPS_EXECUTED.CORE_c2]) / [CONST_THREAD_COUNT]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_2(%)",
-        "expression": "100 * (([UOPS_EXECUTED.CORE_c2] - [UOPS_EXECUTED.CORE_c3]) / [CONST_THREAD_COUNT]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_2(%)",
+        "expression": "100 * (([UOPS_EXECUTED.CORE_c2] - [UOPS_EXECUTED.CORE_c3]) / [CONST_THREAD_COUNT]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_3m(%)",
-        "expression": "100 * ([UOPS_EXECUTED.CORE_c3] / [CONST_THREAD_COUNT]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_3m(%)",
+        "expression": "100 * ([UOPS_EXECUTED.CORE_c3] / [CONST_THREAD_COUNT]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Light_Operations(%)",
+        "name": "TMA_..Light_Operations(%)",
         "expression": "100 * ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....FP_Arith(%)",
+        "name": "TMA_....FP_Arith(%)",
         "expression": "100 * ( ( [INST_RETIRED.X87] * ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / [instructions] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) ) + ( ( [FP_ARITH_INST_RETIRED.SCALAR_SINGLE:u0x03] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) ) + ( min( ( ( [FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE:u0x3c] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) ) , ( 1 ) ) ) )"
     },
     {
-        "name": "metric_TMA_......FP_Scalar(%)",
+        "name": "TMA_......FP_Scalar(%)",
         "expression": "100 * ( ( [FP_ARITH_INST_RETIRED.SCALAR_SINGLE:u0x03] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_......FP_Vector(%)",
+        "name": "TMA_......FP_Vector(%)",
         "expression": "100 * ( min( ( ( [FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE:u0x3c] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_..Heavy_Operations(%)",
+        "name": "TMA_..Heavy_Operations(%)",
         "expression": "100 * ( ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Microcode_Sequencer(%)",
-        "expression": "100 * (([UOPS_RETIRED.RETIRE_SLOTS] / [UOPS_ISSUED.ANY]) * [IDQ.MS_UOPS] )/ (4 * ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT]))",
-        "origin": "perfspect"
+        "name": "TMA_..Microcode_Sequencer(%)",
+        "expression": "100 * (([UOPS_RETIRED.RETIRE_SLOTS] / [UOPS_ISSUED.ANY]) * [IDQ.MS_UOPS] )/ (4 * ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT]))"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/clx.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/clx.json
@@ -1,466 +1,472 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycle",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[TXN] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]",
-        "origin": "perfmon website"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_L1D MPI (includes data+rfo w/ prefetches)",
-        "name-txn": "metric_L1D misses per txn (includes data+rfo w/ prefetches)",
-        "expression": "[L1D.REPLACEMENT] / [instructions]",
-        "expression-txn": "[L1D.REPLACEMENT] / [TXN]"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+        "name": "txn per cycle",
+        "expression": "[TXN] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1I code read misses (includes prefetches) per txn",
-        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]",
-        "expression-txn": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[L2_LINES_IN.ALL] / [instructions]",
-        "expression-txn": "[L2_LINES_IN.ALL] / [TXN]"
+        "name": "L1D MPI (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read MPI",
+        "name": "L1D misses per txn (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [TXN]"
+    },
+    {
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]"
+    },
+    {
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+    },
+    {
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]"
+    },
+    {
+        "name": "L1I code read misses (includes prefetches) per txn",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]"
+    },
+    {
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+    },
+    {
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [instructions]"
+    },
+    {
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read MPI",
         "name-txn": "metric_L2 demand data read misses per txn",
         "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]",
         "exression-txn": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
     },
     {
-        "name": "metric_L2 demand code MPI",
-        "name-txn": "metric_L2 demand code misses per txn",
-        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]",
-        "expression-txn": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+        "name": "L2 demand code MPI",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]"
     },
     {
-        "name": "metric_LLC MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_LLC misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12C40033]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12C40033]) / [TXN]",
-        "origin": "perfspect"
+        "name": "L2 demand code misses per txn",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] / [instructions]",
-        "expression-txn": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] / [TXN]"
+        "name": "LLC MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12C40033]) / [instructions]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] / [instructions]",
-        "expression-txn": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] / [TXN]"
+        "name": "LLC misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12C40033]) / [TXN]"
     },
     {
-        "name": "metric_LLC total HITM (per instr)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [instructions]",
-        "expression-txn": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [TXN]",
-        "origin": "perfspect"
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] / [instructions]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [instructions]",
-        "expression-txn": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [TXN]",
-        "origin": "perfspect"
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] / [TXN]"
     },
     {
-        "name": "metric_Average LLC data read miss latency (in ns)",
-        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40433] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40433]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )",
-        "origin": "perfspect"
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] / [instructions]"
     },
     {
-        "name": "metric_Average LLC data read miss latency for LOCAL requests (in ns)",
-        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40432] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40432]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )",
-        "origin": "perfspect"
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] / [TXN]"
     },
     {
-        "name": "metric_Average LLC data read miss latency for REMOTE requests (in ns)",
-        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40431] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40431]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )",
-        "origin": "perfspect"
+        "name": "LLC total HITM (per instr)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [instructions]"
     },
     {
-        "name": "metric_ITLB MPI",
-        "name-txn": "metric_ITLB misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [TXN]"
     },
     {
-        "name": "metric_ITLB large page MPI",
-        "name-txn": "metric_ITLB large page misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "LLC total HIT clean line forwards (per instr)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [instructions]"
     },
     {
-        "name": "metric_DTLB load MPI",
-        "name-txn": "metric_DTLB load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [TXN]"
     },
     {
-        "name": "metric_DTLB 4KB page load MPI",
-        "name-txn": "metric_DTLB 4KB page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [TXN]",
-        "origin": "perfspect"
+        "name": "Average LLC data read miss latency (in ns)",
+        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40433] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40433]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )"
     },
     {
-        "name": "metric_DTLB 2MB large page load MPI",
-        "name-txn": "metric_DTLB 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "Average LLC data read miss latency for LOCAL requests (in ns)",
+        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40432] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40432]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )"
     },
     {
-        "name": "metric_DTLB 1GB large page load MPI",
-        "name-txn": "metric_DTLB 1GB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [TXN]",
-        "origin": "perfspect"
+        "name": "Average LLC data read miss latency for REMOTE requests (in ns)",
+        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40431] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40431]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )"
     },
     {
-        "name": "metric_DTLB store MPI",
-        "name-txn": "metric_DTLB store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB load miss latency (in core clks)",
-        "expression": "[DTLB_LOAD_MISSES.WALK_ACTIVE] / [DTLB_LOAD_MISSES.WALK_COMPLETED]",
-        "origin": "perfspect"
+        "name": "ITLB misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB store miss latency (in core clks)",
-        "expression": "[DTLB_STORE_MISSES.WALK_ACTIVE] / [DTLB_STORE_MISSES.WALK_COMPLETED]",
-        "origin": "perfspect"
+        "name": "ITLB large page MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
     },
     {
-        "name": "metric_ITLB miss latency (in core clks)",
-        "expression": "[ITLB_MISSES.WALK_ACTIVE] / [ITLB_MISSES.WALK_COMPLETED]",
-        "origin": "perfspect"
+        "name": "ITLB large page misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to local DRAM",
+        "name": "DTLB load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "DTLB 4KB page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [instructions]"
+    },
+    {
+        "name": "DTLB 4KB page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [TXN]"
+    },
+    {
+        "name": "DTLB 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB 1GB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [instructions]"
+    },
+    {
+        "name": "DTLB 1GB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [TXN]"
+    },
+    {
+        "name": "DTLB store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "DTLB load miss latency (in core clks)",
+        "expression": "[DTLB_LOAD_MISSES.WALK_ACTIVE] / [DTLB_LOAD_MISSES.WALK_COMPLETED]"
+    },
+    {
+        "name": "DTLB store miss latency (in core clks)",
+        "expression": "[DTLB_STORE_MISSES.WALK_ACTIVE] / [DTLB_STORE_MISSES.WALK_COMPLETED]"
+    },
+    {
+        "name": "ITLB miss latency (in core clks)",
+        "expression": "[ITLB_MISSES.WALK_ACTIVE] / [ITLB_MISSES.WALK_COMPLETED]"
+    },
+    {
+        "name": "NUMA %_Reads addressed to local DRAM",
         "expression": "100 * [UNC_CHA_TOR_INSERTS.IA_MISS.0x40432] / ([UNC_CHA_TOR_INSERTS.IA_MISS.0x40432] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x40431])"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to remote DRAM",
+        "name": "NUMA %_Reads addressed to remote DRAM",
         "expression": "100 * [UNC_CHA_TOR_INSERTS.IA_MISS.0x40431] / ([UNC_CHA_TOR_INSERTS.IA_MISS.0x40432] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x40431])"
     },
     {
-        "name": "metric_UPI Data transmit BW (MB/sec) (only data)",
+        "name": "UPI Data transmit BW (MB/sec) (only data)",
         "expression": "([UNC_UPI_TxL_FLITS.ALL_DATA] * (64 / 9.0) / 1000000) / 1"
     },
     {
-        "name": "metric_UPI Transmit utilization_% (includes control)",
-        "expression": "100 * (([UNC_UPI_TxL_FLITS.ALL_DATA] + [UNC_UPI_TxL_FLITS.NON_DATA]) / 3) / ((((([SYSTEM_TSC_FREQ] / ([CHAS_PER_SOCKET] * [CONST_THREAD_COUNT])) / (([SYSTEM_TSC_FREQ] / ([CHAS_PER_SOCKET] * [CONST_THREAD_COUNT])) - [cstate_pkg/c6-residency/])) * ([UNC_UPI_CLOCKTICKS] - [UNC_UPI_L1_POWER_CYCLES])) * 5 / 6))",
-        "origin": "perfspect"
+        "name": "UPI Transmit utilization_% (includes control)",
+        "expression": "100 * (([UNC_UPI_TxL_FLITS.ALL_DATA] + [UNC_UPI_TxL_FLITS.NON_DATA]) / 3) / ((((([SYSTEM_TSC_FREQ] / ([CHAS_PER_SOCKET] * [CONST_THREAD_COUNT])) / (([SYSTEM_TSC_FREQ] / ([CHAS_PER_SOCKET] * [CONST_THREAD_COUNT])) - [cstate_pkg/c6-residency/])) * ([UNC_UPI_CLOCKTICKS] - [UNC_UPI_L1_POWER_CYCLES])) * 5 / 6))"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
-        "expression": "[power/energy-ram/]",
-        "origin": "perfspect"
+        "name": "DRAM power (watts)",
+        "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
-        "expression": "100 * [cstate_core/c6-residency/] / [TSC]",
-        "origin": "perfspect"
+        "name": "core c6 residency %",
+        "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
-        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]",
-        "origin": "perfspect"
+        "name": "package c6 residency %",
+        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_% Uops delivered from decoded Icache (DSB)",
+        "name": "% Uops delivered from decoded Icache (DSB)",
         "expression": "100 * ([IDQ.DSB_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_% Uops delivered from legacy decode pipeline (MITE)",
+        "name": "% Uops delivered from legacy decode pipeline (MITE)",
         "expression": "100 * ([IDQ.MITE_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_core % cycles in non AVX license",
-        "expression": "(100 * [CORE_POWER.LVL0_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])",
-        "origin": "perfspect"
+        "name": "core % cycles in non AVX license",
+        "expression": "(100 * [CORE_POWER.LVL0_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])"
     },
     {
-        "name": "metric_core % cycles in AVX2 license",
-        "expression": "(100 * [CORE_POWER.LVL1_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])",
-        "origin": "perfspect"
+        "name": "core % cycles in AVX2 license",
+        "expression": "(100 * [CORE_POWER.LVL1_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])"
     },
     {
-        "name": "metric_core % cycles in AVX-512 license",
-        "expression": "(100 * [CORE_POWER.LVL2_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])",
-        "origin": "perfspect"
+        "name": "core % cycles in AVX-512 license",
+        "expression": "(100 * [CORE_POWER.LVL2_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])"
     },
     {
-        "name": "metric_core initiated local dram read bandwidth (MB/sec)",
-        "expression": "[OCR.ALL_READS.L3_MISS_LOCAL_DRAM.ANY_SNOOP] * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated local dram read bandwidth (MB/sec)",
+        "expression": "[OCR.ALL_READS.L3_MISS_LOCAL_DRAM.ANY_SNOOP] * 64 / 1000000"
     },
     {
-        "name": "metric_core initiated remote dram read bandwidth (MB/sec)",
-        "expression": "[OCR.ALL_READS.L3_MISS_LOCAL_DRAM.ANY_SNOOP_ocr_msr_3fB80007f7] * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated remote dram read bandwidth (MB/sec)",
+        "expression": "[OCR.ALL_READS.L3_MISS_LOCAL_DRAM.ANY_SNOOP_ocr_msr_3fB80007f7] * 64 / 1000000"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.RD] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.WR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT.RD] + [UNC_M_CAS_COUNT.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_writes (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_writes (MB/sec)",
         "expression": "(([UNC_IIO_DATA_REQ_OF_CPU.MEM_READ.PART0] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_READ.PART1] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_READ.PART2] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_READ.PART3]) * 4 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_reads (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_reads (MB/sec)",
         "expression": "(([UNC_IIO_DATA_REQ_OF_CPU.MEM_WRITE.PART0] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_WRITE.PART1] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_WRITE.PART2] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_WRITE.PART3]) * 4 / 1000000) / 1"
     },
     {
-        "name": "metric_TMA_Info_cycles_both_threads_active(%)",
-        "expression": "100 * ( (1 - ([CPU_CLK_THREAD_UNHALTED.ONE_THREAD_ACTIVE] / ([CPU_CLK_THREAD_UNHALTED.REF_XCLK_ANY] / 2)) ) if [CONST_THREAD_COUNT] > 1 else 0)",
-        "origin": "perfspect"
+        "name": "TMA_Info_cycles_both_threads_active(%)",
+        "expression": "100 * ( (1 - ([CPU_CLK_THREAD_UNHALTED.ONE_THREAD_ACTIVE] / ([CPU_CLK_THREAD_UNHALTED.REF_XCLK_ANY] / 2)) ) if [CONST_THREAD_COUNT] > 1 else 0)"
     },
     {
-        "name": "metric_TMA_Info_CoreIPC",
-        "expression": "[instructions] / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_Info_CoreIPC",
+        "expression": "[instructions] / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Frontend_Latency(%)",
-        "expression": "100 * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] /  ([CPU_CLK_UNHALTED.THREAD_ANY] /[CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_..Frontend_Latency(%)",
+        "expression": "100 * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] /  ([CPU_CLK_UNHALTED.THREAD_ANY] /[CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( ( [ICACHE_16B.IFDATA_STALL] + 2 * [ICACHE_16B.IFDATA_STALL:c1:e1] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( [ICACHE_64B.IFTAG_STALL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....Branch_Resteers(%)",
+        "name": "TMA_....Branch_Resteers(%)",
         "expression": "100 * ( [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) + ( ( 9 ) * [BACLEARS.ANY] / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_......Mispredicts_Resteers(%)",
+        "name": "TMA_......Mispredicts_Resteers(%)",
         "expression": "100 * ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Clears_Resteers(%)",
+        "name": "TMA_......Clears_Resteers(%)",
         "expression": "100 * ( ( 1 - ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Unknown_Branches_Resteers(%)",
-        "expression": "100 * (9 * [BACLEARS.ANY]) /  [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "TMA_......Unknown_Branches_Resteers(%)",
+        "expression": "100 * (9 * [BACLEARS.ANY]) /  [cpu-cycles]"
     },
     {
-        "name": "metric_TMA_..Frontend_Bandwidth(%)",
-        "expression": "100 * ([IDQ_UOPS_NOT_DELIVERED.CORE] - 4 * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE]) / (4 * ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT]))",
-        "origin": "perfspect"
+        "name": "TMA_..Frontend_Bandwidth(%)",
+        "expression": "100 * ([IDQ_UOPS_NOT_DELIVERED.CORE] - 4 * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE]) / (4 * ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT]))"
     },
     {
-        "name": "metric_TMA_....MITE(%)",
+        "name": "TMA_....MITE(%)",
         "expression": "100 * ( ( [IDQ.ALL_MITE_CYCLES_ANY_UOPS] - [IDQ.ALL_MITE_CYCLES_4_UOPS] ) / ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) / 2 )"
     },
     {
-        "name": "metric_TMA_....DSB(%)",
+        "name": "TMA_....DSB(%)",
         "expression": "100 * ( ( [IDQ.ALL_DSB_CYCLES_ANY_UOPS] - [IDQ.ALL_DSB_CYCLES_4_UOPS] ) / ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) / 2 )"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100 * ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100 * ( ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( 1 - ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( [UOPS_ISSUED.ANY] + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100 * ( ( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] + [EXE_ACTIVITY.BOUND_ON_STORES] ) / ( [CYCLE_ACTIVITY.STALLS_TOTAL] + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) + [EXE_ACTIVITY.BOUND_ON_STORES] ) ) * ( 1 - ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( [UOPS_ISSUED.ANY] + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100 * ( max( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] - [CYCLE_ACTIVITY.STALLS_L1D_MISS] ) / ( [cpu-cycles] ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_......DTLB_Load(%)",
+        "name": "TMA_......DTLB_Load(%)",
         "expression": "100 * ( min( ( 9 ) * [DTLB_LOAD_MISSES.STLB_HIT:c1] + [DTLB_LOAD_MISSES.WALK_ACTIVE] , max( [CYCLE_ACTIVITY.CYCLES_MEM_ANY] - [CYCLE_ACTIVITY.CYCLES_L1D_MISS] , 0 ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Lock_Latency(%)",
+        "name": "TMA_......Lock_Latency(%)",
         "expression": "100 * ( min( ( ( 12 * max( 0 , [MEM_INST_RETIRED.LOCK_LOADS] - [L2_RQSTS.ALL_RFO] ) + ( [MEM_INST_RETIRED.LOCK_LOADS] / [MEM_INST_RETIRED.ALL_STORES] ) * ( ( 11 ) * [L2_RQSTS.RFO_HIT] + ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_RFO] ) ) ) ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100 * ( ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) / ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + [L1D_PEND_MISS.FB_FULL:c1] ) ) * ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100 * ( ( [CYCLE_ACTIVITY.STALLS_L2_MISS] - [CYCLE_ACTIVITY.STALLS_L3_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Data_Sharing(%)",
+        "name": "TMA_......Data_Sharing(%)",
         "expression": "100 * ( min( ( ( ( 47.5 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) - ( 3.5 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) ) * ( [MEM_LOAD_L3_HIT_RETIRED.XSNP_HIT] + [MEM_LOAD_L3_HIT_RETIRED.XSNP_HITM] * ( 1 - ( [OCR.DEMAND_DATA_RD.L3_HIT.HITM_OTHER_CORE] / ( [OCR.DEMAND_DATA_RD.L3_HIT.HITM_OTHER_CORE] + [OCR.DEMAND_DATA_RD.L3_HIT.HIT_OTHER_CORE_FWD] ) ) ) ) * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) / 2 ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....MEM_Bound(%)",
-        "expression": "100 * [CYCLE_ACTIVITY.STALLS_L3_MISS]  / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "TMA_....MEM_Bound(%)",
+        "expression": "100 * [CYCLE_ACTIVITY.STALLS_L3_MISS]  / [cpu-cycles]"
     },
     {
-        "name": "metric_TMA_......MEM_Bandwidth(%)",
-        "expression": "100 * min([OFFCORE_REQUESTS_OUTSTANDING.L3_MISS_DEMAND_DATA_RD_GE_6] , [cpu-cycles]) / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "TMA_......MEM_Bandwidth(%)",
+        "expression": "100 * min([OFFCORE_REQUESTS_OUTSTANDING.L3_MISS_DEMAND_DATA_RD_GE_6] , [cpu-cycles]) / [cpu-cycles]"
     },
     {
-        "name": "metric_TMA_......MEM_Latency(%)",
-        "expression": "100 * (min([OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_L3_MISS_DEMAND_DATA_RD] , [cpu-cycles]) - min([OFFCORE_REQUESTS_OUTSTANDING.L3_MISS_DEMAND_DATA_RD_GE_6] , [cpu-cycles]))/ [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "TMA_......MEM_Latency(%)",
+        "expression": "100 * (min([OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_L3_MISS_DEMAND_DATA_RD] , [cpu-cycles]) - min([OFFCORE_REQUESTS_OUTSTANDING.L3_MISS_DEMAND_DATA_RD_GE_6] , [cpu-cycles]))/ [cpu-cycles]"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100 * ( [EXE_ACTIVITY.BOUND_ON_STORES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......False_Sharing(%)",
+        "name": "TMA_......False_Sharing(%)",
         "expression": "100 * ( min( ( ( ( 110 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) * ( [OCR.DEMAND_RFO.L3_MISS.REMOTE_HITM] + [OCR.PF_L2_RFO.L3_MISS.REMOTE_HITM] ) + ( 47.5 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) * ( [OCR.DEMAND_RFO.L3_HIT.HITM_OTHER_CORE] + [OCR.PF_L2_RFO.L3_HIT.HITM_OTHER_CORE] ) ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100 * ( ( 1 - ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( [UOPS_ISSUED.ANY] + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( ( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] + [EXE_ACTIVITY.BOUND_ON_STORES] ) / ( [CYCLE_ACTIVITY.STALLS_TOTAL] + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) + [EXE_ACTIVITY.BOUND_ON_STORES] ) ) * ( 1 - ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( [UOPS_ISSUED.ANY] + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Ports_Utilization(%)",
+        "name": "TMA_....Ports_Utilization(%)",
         "expression": "100 * ( ( [EXE_ACTIVITY.EXE_BOUND_0_PORTS] + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) ) / ( [cpu-cycles] ) if ( [ARITH.DIVIDER_ACTIVE] < ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [CYCLE_ACTIVITY.STALLS_MEM_ANY] ) ) else ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_0(%)",
-        "expression": "100 * (([UOPS_EXECUTED.CORE_CYCLES_NONE] / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.EXE_BOUND_0_PORTS]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_0(%)",
+        "expression": "100 * (([UOPS_EXECUTED.CORE_CYCLES_NONE] / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.EXE_BOUND_0_PORTS]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_1(%)",
-        "expression": "100 * ((([UOPS_EXECUTED.CORE_CYCLES_GE_1] - [UOPS_EXECUTED.CORE_CYCLES_GE_2]) / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.1_PORTS_UTIL]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_1(%)",
+        "expression": "100 * ((([UOPS_EXECUTED.CORE_CYCLES_GE_1] - [UOPS_EXECUTED.CORE_CYCLES_GE_2]) / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.1_PORTS_UTIL]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_2(%)",
-        "expression": "100 * ((([UOPS_EXECUTED.CORE_CYCLES_GE_2] - [UOPS_EXECUTED.CORE_CYCLES_GE_3]) / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.2_PORTS_UTIL]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_2(%)",
+        "expression": "100 * ((([UOPS_EXECUTED.CORE_CYCLES_GE_2] - [UOPS_EXECUTED.CORE_CYCLES_GE_3]) / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.2_PORTS_UTIL]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_3m(%)",
-        "expression": "100 * [UOPS_EXECUTED.CORE_CYCLES_GE_3] / [CPU_CLK_UNHALTED.THREAD_ANY]",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_3m(%)",
+        "expression": "100 * [UOPS_EXECUTED.CORE_CYCLES_GE_3] / [CPU_CLK_UNHALTED.THREAD_ANY]"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Light_Operations(%)",
+        "name": "TMA_..Light_Operations(%)",
         "expression": "100 * ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) + [UOPS_RETIRED.MACRO_FUSED] - [instructions] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....FP_Arith(%)",
+        "name": "TMA_....FP_Arith(%)",
         "expression": "100 * ( ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) * [UOPS_EXECUTED.X87] / [UOPS_EXECUTED.THREAD] ) + ( ( [FP_ARITH_INST_RETIRED.SCALAR_SINGLE:u0x03] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) ) + ( min( ( ( [FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE:u0xfc] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) ) , ( 1 ) ) ) )"
     },
     {
-        "name": "metric_TMA_......FP_Scalar(%)",
+        "name": "TMA_......FP_Scalar(%)",
         "expression": "100 * ( ( [FP_ARITH_INST_RETIRED.SCALAR_SINGLE:u0x03] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_......FP_Vector(%)",
+        "name": "TMA_......FP_Vector(%)",
         "expression": "100 * ( min( ( ( [FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE:u0xfc] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_..Heavy_Operations(%)",
+        "name": "TMA_..Heavy_Operations(%)",
         "expression": "100 * ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) + [UOPS_RETIRED.MACRO_FUSED] - [instructions] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Microcode_Sequencer(%)",
-        "expression": "100 * (([UOPS_RETIRED.RETIRE_SLOTS] / [UOPS_ISSUED.ANY]) * [IDQ.MS_UOPS] / (4 * ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])))",
-        "origin": "perfspect"
+        "name": "TMA_..Microcode_Sequencer(%)",
+        "expression": "100 * (([UOPS_RETIRED.RETIRE_SLOTS] / [UOPS_ISSUED.ANY]) * [IDQ.MS_UOPS] / (4 * ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])))"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/emr.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/emr.json
@@ -1,404 +1,426 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycle",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[TXN] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_giga_instructions_per_sec",
-        "expression": "[instructions] / 1000000000",
-        "origin": "perfspect"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_branch misprediction ratio",
-        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]",
-        "origin": "perfspect"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]",
-        "origin": "perfmon website"
+        "name": "txn per cycle",
+        "expression": "[TXN] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1D MPI (includes data+rfo w/ prefetches)",
-        "name-txn": "metric_L1D misses per txn (includes data+rfo w/ prefetches)",
-        "expression": "[L1D.REPLACEMENT] / [instructions]",
-        "expression-txn": "[L1D.REPLACEMENT] / [TXN]"
+        "name": "giga_instructions_per_sec",
+        "expression": "[instructions] / 1000000000"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+        "name": "branch misprediction ratio",
+        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1I code read misses (includes prefetches) per txn",
-        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]",
-        "expression-txn": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[L2_LINES_IN.ALL] / [instructions]",
-        "expression-txn": "[L2_LINES_IN.ALL] / [TXN]"
+        "name": "L1D MPI (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read MPI",
-        "name-txn": "metric_L2 demand data read misses per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+        "name": "L1D misses per txn (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [TXN]"
     },
     {
-        "name": "metric_L2 demand code MPI",
-        "name-txn": "metric_L2 demand code misses per txn",
-        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]",
-        "expression-txn": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [instructions]",
-        "expression-txn": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [TXN]"
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]"
     },
     {
-        "name": "metric_LLC total HITM (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]",
-        "origin": "perfspect"
+        "name": "L1I code read misses (includes prefetches) per txn",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]",
-        "origin": "perfspect"
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency (in ns)",
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+    },
+    {
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [instructions]"
+    },
+    {
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read MPI",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand data read misses per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+    },
+    {
+        "name": "L2 demand code MPI",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand code misses per txn",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+    },
+    {
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [instructions]"
+    },
+    {
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [TXN]"
+    },
+    {
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]"
+    },
+    {
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+    },
+    {
+        "name": "LLC total HITM (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]"
+    },
+    {
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+    },
+    {
+        "name": "Average LLC demand data read miss latency (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for LOCAL requests (in ns)",
+        "name": "Average LLC demand data read miss latency for LOCAL requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_LOCAL] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for REMOTE requests (in ns)",
+        "name": "Average LLC demand data read miss latency for REMOTE requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_REMOTE] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_UPI Data transmit BW (MB/sec) (only data)",
+        "name": "UPI Data transmit BW (MB/sec) (only data)",
         "expression": "([UNC_UPI_TxL_FLITS.ALL_DATA] * (64 / 9.0) / 1000000) / 1"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
-        "expression": "[power/energy-ram/]",
-        "origin": "perfspect"
+        "name": "DRAM power (watts)",
+        "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
-        "expression": "100 * [cstate_core/c6-residency/] / [TSC]",
-        "origin": "perfspect"
+        "name": "core c6 residency %",
+        "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
-        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]",
-        "origin": "perfspect"
+        "name": "package c6 residency %",
+        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_% Uops delivered from decoded Icache (DSB)",
+        "name": "% Uops delivered from decoded Icache (DSB)",
         "expression": "100 * ([IDQ.DSB_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_% Uops delivered from legacy decode pipeline (MITE)",
+        "name": "% Uops delivered from legacy decode pipeline (MITE)",
         "expression": "100 * ([IDQ.MITE_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_core initiated local dram read bandwidth (MB/sec)",
-        "expression": "([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated local dram read bandwidth (MB/sec)",
+        "expression": "([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000"
     },
     {
-        "name": "metric_core initiated remote dram read bandwidth (MB/sec)",
-        "expression": "([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated remote dram read bandwidth (MB/sec)",
+        "expression": "([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.RD] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.WR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT.RD] + [UNC_M_CAS_COUNT.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_ITLB (2nd level) MPI",
-        "name-txn": "metric_ITLB (2nd level) misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) load MPI",
-        "name-txn": "metric_DTLB (2nd level) load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB (2nd level) 2MB large page load MPI",
-        "name-txn": "metric_DTLB (2nd level) 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "DTLB (2nd level) load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) store MPI",
-        "name-txn": "metric_DTLB (2nd level) store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "DTLB (2nd level) load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to local DRAM",
+        "name": "DTLB (2nd level) 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB (2nd level) store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "NUMA %_Reads addressed to local DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to remote DRAM",
+        "name": "NUMA %_Reads addressed to remote DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_writes (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_writes (MB/sec)",
         "expression": "([UNC_CHA_TOR_INSERTS.IO_PCIRDCUR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_reads (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_reads (MB/sec)",
         "expression": "(([UNC_CHA_TOR_INSERTS.IO_ITOM] + [UNC_CHA_TOR_INSERTS.IO_ITOMCACHENEAR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Latency(%)",
+        "name": "TMA_..Fetch_Latency(%)",
         "expression": "100 * ( ( [PERF_METRICS.FETCH_LATENCY] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) )"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( [ICACHE_DATA.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( [ICACHE_TAG.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....Branch_Resteers(%)",
+        "name": "TMA_....Branch_Resteers(%)",
         "expression": "100 * ( [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) + ( [INT_MISC.UNKNOWN_BRANCH_CYCLES] / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_......Mispredicts_Resteers(%)",
+        "name": "TMA_......Mispredicts_Resteers(%)",
         "expression": "100 * ( ( ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) / ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Clears_Resteers(%)",
+        "name": "TMA_......Clears_Resteers(%)",
         "expression": "100 * ( ( 1 - ( ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) / ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Unknown_Branches(%)",
+        "name": "TMA_......Unknown_Branches(%)",
         "expression": "100 * ( [INT_MISC.UNKNOWN_BRANCH_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Bandwidth(%)",
+        "name": "TMA_..Fetch_Bandwidth(%)",
         "expression": "100 * ( max( 0 , ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) - ( ( [PERF_METRICS.FETCH_LATENCY] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....MITE(%)",
+        "name": "TMA_....MITE(%)",
         "expression": "100 * ( ( [IDQ.MITE_CYCLES_ANY] - [IDQ.MITE_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_....DSB(%)",
+        "name": "TMA_....DSB(%)",
         "expression": "100 * ( ( [IDQ.DSB_CYCLES_ANY] - [IDQ.DSB_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100 * ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100 * ( max( 0 , ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) - ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) )"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.MEMORY_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100 * ( max( ( [EXE_ACTIVITY.BOUND_ON_LOADS] - [MEMORY_ACTIVITY.STALLS_L1D_MISS] ) / ( [cpu-cycles] ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_......DTLB_Load(%)",
+        "name": "TMA_......DTLB_Load(%)",
         "expression": "100 * ( min( ( 7 ) * [DTLB_LOAD_MISSES.STLB_HIT:c1] + [DTLB_LOAD_MISSES.WALK_ACTIVE] , max( [CYCLE_ACTIVITY.CYCLES_MEM_ANY] - [MEMORY_ACTIVITY.CYCLES_L1D_MISS] , 0 ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Lock_Latency(%)",
+        "name": "TMA_......Lock_Latency(%)",
         "expression": "100 * ( min( ( ( 16 * max( 0 , [MEM_INST_RETIRED.LOCK_LOADS] - [L2_RQSTS.ALL_RFO] ) + ( [MEM_INST_RETIRED.LOCK_LOADS] / [MEM_INST_RETIRED.ALL_STORES] ) * ( ( 10 ) * [L2_RQSTS.RFO_HIT] + ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_RFO] ) ) ) ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L1D_MISS] - [MEMORY_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L2_MISS] - [MEMORY_ACTIVITY.STALLS_L3_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Data_Sharing(%)",
+        "name": "TMA_......Data_Sharing(%)",
         "expression": "100 * ( min( ( ( ( 79.5 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) - ( 4 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) ) * ( [MEM_LOAD_L3_HIT_RETIRED.XSNP_NO_FWD] + [MEM_LOAD_L3_HIT_RETIRED.XSNP_FWD] * ( 1 - ( [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HITM] / ( [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HITM] + [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD] ) ) ) ) * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) / 2 ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....DRAM_Bound(%)",
+        "name": "TMA_....DRAM_Bound(%)",
         "expression": "100 * ( min( ( ( ( [MEMORY_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) ) - ( min( ( ( ( ( 1 - ( ( ( 19 * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + 10 * ( ( [MEM_LOAD_L3_MISS_RETIRED.LOCAL_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_FWD] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_HITM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) / ( ( 19 * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + 10 * ( ( [MEM_LOAD_L3_MISS_RETIRED.LOCAL_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_FWD] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_HITM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) + ( 25 * ( ( [MEM_LOAD_RETIRED.LOCAL_PMM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) + 33 * ( ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_PMM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) ) ) ) ) * ( [MEMORY_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) ) ) if ( ( 1000000 ) * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_PMM] + [MEM_LOAD_RETIRED.LOCAL_PMM] ) > [MEM_LOAD_RETIRED.L1_MISS] ) else 0 ) ) , ( 1 ) ) ) ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_......MEM_Bandwidth(%)",
+        "name": "TMA_......MEM_Bandwidth(%)",
         "expression": "100 * ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.DATA_RD:c4] ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......MEM_Latency(%)",
+        "name": "TMA_......MEM_Latency(%)",
         "expression": "100 * ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DATA_RD] ) ) / ( [cpu-cycles] ) - ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.DATA_RD:c4] ) ) / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100 * ( [EXE_ACTIVITY.BOUND_ON_STORES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......False_Sharing(%)",
+        "name": "TMA_......False_Sharing(%)",
         "expression": "100 * ( min( ( ( 80 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) * [OCR.DEMAND_RFO.L3_HIT.SNOOP_HITM] / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100 * ( max( 0 , ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) - ( [PERF_METRICS.MEMORY_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Ports_Utilization(%)",
+        "name": "TMA_....Ports_Utilization(%)",
         "expression": "100 * ( ( [EXE_ACTIVITY.3_PORTS_UTIL:u0x80] + ( [RESOURCE_STALLS.SCOREBOARD] / ( [cpu-cycles] ) ) * ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [EXE_ACTIVITY.BOUND_ON_LOADS] ) + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * [EXE_ACTIVITY.2_PORTS_UTIL:u0xc] ) ) / ( [cpu-cycles] ) if ( [ARITH.DIV_ACTIVE] < ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [EXE_ACTIVITY.BOUND_ON_LOADS] ) ) else ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * [EXE_ACTIVITY.2_PORTS_UTIL:u0xc] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_0(%)",
+        "name": "TMA_......Ports_Utilized_0(%)",
         "expression": "100 * ( [EXE_ACTIVITY.3_PORTS_UTIL:u0x80] / ( [cpu-cycles] ) + ( [RESOURCE_STALLS.SCOREBOARD] / ( [cpu-cycles] ) ) * ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [EXE_ACTIVITY.BOUND_ON_LOADS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_........AMX_Busy(%)",
+        "name": "TMA_........AMX_Busy(%)",
         "expression": "100 * ( [EXE.AMX_BUSY] / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_1(%)",
+        "name": "TMA_......Ports_Utilized_1(%)",
         "expression": "100 * ( [EXE_ACTIVITY.1_PORTS_UTIL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_2(%)",
+        "name": "TMA_......Ports_Utilized_2(%)",
         "expression": "100 * ( [EXE_ACTIVITY.2_PORTS_UTIL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_3m(%)",
+        "name": "TMA_......Ports_Utilized_3m(%)",
         "expression": "100 * ( [UOPS_EXECUTED.CYCLES_GE_3] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_..Light_Operations(%)",
+        "name": "TMA_..Light_Operations(%)",
         "expression": "100 * ( max( 0 , ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) - ( [PERF_METRICS.HEAVY_OPERATIONS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) )"
     },
     {
-        "name": "metric_TMA_........FP_Vector_256b(%)",
+        "name": "TMA_........FP_Vector_256b(%)",
         "expression": "100 * ( min( ( ( [FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE] + [FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE] + [FP_ARITH_INST_RETIRED2.256B_PACKED_HALF] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_........FP_Vector_512b(%)",
+        "name": "TMA_........FP_Vector_512b(%)",
         "expression": "100 * ( min( ( ( [FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE] + [FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE] + [FP_ARITH_INST_RETIRED2.512B_PACKED_HALF] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_......Int_Vector_256b(%)",
+        "name": "TMA_......Int_Vector_256b(%)",
         "expression": "100 * ( ( [INT_VEC_RETIRED.ADD_256] + [INT_VEC_RETIRED.MUL_256] + [INT_VEC_RETIRED.VNNI_256] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) )"
     },
     {
-        "name": "metric_TMA_..Heavy_Operations(%)",
+        "name": "TMA_..Heavy_Operations(%)",
         "expression": "100 * ( [PERF_METRICS.HEAVY_OPERATIONS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_....Microcode_Sequencer(%)",
+        "name": "TMA_....Microcode_Sequencer(%)",
         "expression": "100 * ( [UOPS_RETIRED.MS] / ( [TOPDOWN.SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_Info_Thread_IPC",
-        "expression": "[instructions] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "TMA_Info_Thread_IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_TMA_Info_System_SMT_2T_Utilization",
-        "expression": "(1 - [CPU_CLK_UNHALTED.ONE_THREAD_ACTIVE] / [CPU_CLK_UNHALTED.REF_DISTRIBUTED]) if [SOCKET_COUNT] > 1 else 0",
-        "origin": "perfspect"
+        "name": "TMA_Info_System_SMT_2T_Utilization",
+        "expression": "(1 - [CPU_CLK_UNHALTED.ONE_THREAD_ACTIVE] / [CPU_CLK_UNHALTED.REF_DISTRIBUTED]) if [SOCKET_COUNT] > 1 else 0"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/emr_nofixedtma.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/emr_nofixedtma.json
@@ -1,354 +1,378 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycle",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[TXN] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_giga_instructions_per_sec",
-        "expression": "[instructions] / 1000000000",
-        "origin": "perfspect"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_branch misprediction ratio",
-        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]",
-        "origin": "perfspect"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]",
-        "origin": "perfmon website"
+        "name": "txn per cycle",
+        "expression": "[TXN] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1D MPI (includes data+rfo w/ prefetches)",
-        "name-txn": "metric_L1D misses per txn (includes data+rfo w/ prefetches)",
-        "expression": "[L1D.REPLACEMENT] / [instructions]",
-        "expression-txn": "[L1D.REPLACEMENT] / [TXN]"
+        "name": "giga_instructions_per_sec",
+        "expression": "[instructions] / 1000000000"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+        "name": "branch misprediction ratio",
+        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1I code read misses (includes prefetches) per txn",
-        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]",
-        "expression-txn": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[L2_LINES_IN.ALL] / [instructions]",
-        "expression-txn": "[L2_LINES_IN.ALL] / [TXN]"
+        "name": "L1D MPI (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read MPI",
-        "name-txn": "metric_L2 demand data read misses per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+        "name": "L1D misses per txn (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [TXN]"
     },
     {
-        "name": "metric_L2 demand code MPI",
-        "name-txn": "metric_L2 demand code misses per txn",
-        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]",
-        "expression-txn": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [instructions]",
-        "expression-txn": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [TXN]"
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]"
     },
     {
-        "name": "metric_LLC total HITM (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]",
-        "origin": "perfspect"
+        "name": "L1I code read misses (includes prefetches) per txn",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]",
-        "origin": "perfspect"
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency (in ns)",
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+    },
+    {
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [instructions]"
+    },
+    {
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read MPI",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand data read misses per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+    },
+    {
+        "name": "L2 demand code MPI",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand code misses per txn",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+    },
+    {
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [instructions]"
+    },
+    {
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [TXN]"
+    },
+    {
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]"
+    },
+    {
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+    },
+    {
+        "name": "LLC total HITM (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]"
+    },
+    {
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+    },
+    {
+        "name": "Average LLC demand data read miss latency (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for LOCAL requests (in ns)",
+        "name": "Average LLC demand data read miss latency for LOCAL requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_LOCAL] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for REMOTE requests (in ns)",
+        "name": "Average LLC demand data read miss latency for REMOTE requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_REMOTE] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_UPI Data transmit BW (MB/sec) (only data)",
+        "name": "UPI Data transmit BW (MB/sec) (only data)",
         "expression": "([UNC_UPI_TxL_FLITS.ALL_DATA] * (64 / 9.0) / 1000000) / 1"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
-        "expression": "[power/energy-ram/]",
-        "origin": "perfspect"
+        "name": "DRAM power (watts)",
+        "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
-        "expression": "100 * [cstate_core/c6-residency/] / [TSC]",
-        "origin": "perfspect"
+        "name": "core c6 residency %",
+        "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
-        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]",
-        "origin": "perfspect"
+        "name": "package c6 residency %",
+        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_% Uops delivered from decoded Icache (DSB)",
+        "name": "% Uops delivered from decoded Icache (DSB)",
         "expression": "100 * ([IDQ.DSB_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_% Uops delivered from legacy decode pipeline (MITE)",
+        "name": "% Uops delivered from legacy decode pipeline (MITE)",
         "expression": "100 * ([IDQ.MITE_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_core initiated local dram read bandwidth (MB/sec)",
-        "expression": "([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated local dram read bandwidth (MB/sec)",
+        "expression": "([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000"
     },
     {
-        "name": "metric_core initiated remote dram read bandwidth (MB/sec)",
-        "expression": "([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated remote dram read bandwidth (MB/sec)",
+        "expression": "([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.RD] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.WR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT.RD] + [UNC_M_CAS_COUNT.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_ITLB (2nd level) MPI",
-        "name-txn": "metric_ITLB (2nd level) misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) load MPI",
-        "name-txn": "metric_DTLB (2nd level) load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB (2nd level) 2MB large page load MPI",
-        "name-txn": "metric_DTLB (2nd level) 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "DTLB (2nd level) load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) store MPI",
-        "name-txn": "metric_DTLB (2nd level) store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "DTLB (2nd level) load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to local DRAM",
+        "name": "DTLB (2nd level) 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB (2nd level) store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "NUMA %_Reads addressed to local DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to remote DRAM",
+        "name": "NUMA %_Reads addressed to remote DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_writes (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_writes (MB/sec)",
         "expression": "([UNC_CHA_TOR_INSERTS.IO_PCIRDCUR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_reads (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_reads (MB/sec)",
         "expression": "(([UNC_CHA_TOR_INSERTS.IO_ITOM] + [UNC_CHA_TOR_INSERTS.IO_ITOMCACHENEAR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Latency(%)",
+        "name": "TMA_..Fetch_Latency(%)",
         "expression": "100 * ( ( [IDQ_BUBBLES.CYCLES_0_UOPS_DELIV.CORE] * ( 6 ) - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( [ICACHE_DATA.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( [ICACHE_TAG.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....MS_Switches(%)",
+        "name": "TMA_....MS_Switches(%)",
         "expression": "100 * ( ( 3 ) * [UOPS_RETIRED.MS:c1:e1] / ( [UOPS_RETIRED.SLOTS] / [UOPS_ISSUED.ANY] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....LCP(%)",
+        "name": "TMA_....LCP(%)",
         "expression": "100 * ( [DECODE.LCP] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....DSB_Switches(%)",
+        "name": "TMA_....DSB_Switches(%)",
         "expression": "100 * ( [DSB2MITE_SWITCHES.PENALTY_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Bandwidth(%)",
+        "name": "TMA_..Fetch_Bandwidth(%)",
         "expression": "100 * ( max( 0 , ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) - ( ( [IDQ_BUBBLES.CYCLES_0_UOPS_DELIV.CORE] * ( 6 ) - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....MITE(%)",
+        "name": "TMA_....MITE(%)",
         "expression": "100 * ( ( [IDQ.MITE_CYCLES_ANY] - [IDQ.MITE_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_....DSB(%)",
+        "name": "TMA_....DSB(%)",
         "expression": "100 * ( ( [IDQ.DSB_CYCLES_ANY] - [IDQ.DSB_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( max( 1 - ( ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( [TOPDOWN.BACKEND_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100 * ( [TOPDOWN.BR_MISPREDICT_SLOTS] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100 * ( max( 0 , ( max( 1 - ( ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( [TOPDOWN.BACKEND_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) , 0 ) ) - ( [TOPDOWN.BR_MISPREDICT_SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( [TOPDOWN.BACKEND_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100 * ( [TOPDOWN.MEMORY_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100 * ( max( ( [EXE_ACTIVITY.BOUND_ON_LOADS] - [MEMORY_ACTIVITY.STALLS_L1D_MISS] ) / ( [cpu-cycles] ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L1D_MISS] - [MEMORY_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L2_MISS] - [MEMORY_ACTIVITY.STALLS_L3_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....DRAM_Bound(%)",
+        "name": "TMA_....DRAM_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100 * ( [EXE_ACTIVITY.BOUND_ON_STORES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100 * ( max( 0 , ( [TOPDOWN.BACKEND_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( [TOPDOWN.MEMORY_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Divider(%)",
+        "name": "TMA_....Divider(%)",
         "expression": "100 * ( [ARITH.DIV_ACTIVE] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....AMX_Busy(%)",
+        "name": "TMA_....AMX_Busy(%)",
         "expression": "100 * ( [EXE.AMX_BUSY] / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) )"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Light_Operations(%)",
+        "name": "TMA_..Light_Operations(%)",
         "expression": "100 * ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Memory_Operations(%)",
+        "name": "TMA_....Memory_Operations(%)",
         "expression": "100 * ( ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) ) ) ) * [MEM_UOP_RETIRED.ANY] / ( ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [TOPDOWN.SLOTS_P] ) ) )"
     },
     {
-        "name": "metric_TMA_....Fused_Instructions(%)",
+        "name": "TMA_....Fused_Instructions(%)",
         "expression": "100 * ( ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) ) ) ) * [INST_RETIRED.MACRO_FUSED] / ( ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [TOPDOWN.SLOTS_P] ) ) )"
     },
     {
-        "name": "metric_TMA_....Non_Fused_Branches(%)",
+        "name": "TMA_....Non_Fused_Branches(%)",
         "expression": "100 * ( ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) ) ) ) * ( [BR_INST_RETIRED.ALL_BRANCHES] - [INST_RETIRED.MACRO_FUSED] ) / ( ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [TOPDOWN.SLOTS_P] ) ) )"
     },
     {
-        "name": "metric_TMA_..Heavy_Operations(%)",
+        "name": "TMA_..Heavy_Operations(%)",
         "expression": "100 * ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_....Few_Uops_Instructions(%)",
+        "name": "TMA_....Few_Uops_Instructions(%)",
         "expression": "100 * ( max( 0 , ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) ) - ( [UOPS_RETIRED.MS] / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Microcode_Sequencer(%)",
+        "name": "TMA_....Microcode_Sequencer(%)",
         "expression": "100 * ( [UOPS_RETIRED.MS] / ( [TOPDOWN.SLOTS_P] ) )"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/gnr.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/gnr.json
@@ -1,379 +1,406 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycle",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[TXN] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_giga_instructions_per_sec",
-        "expression": "[instructions] / 1000000000",
-        "origin": "perfspect"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_branch misprediction ratio",
-        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]",
-        "origin": "perfspect"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]",
-        "origin": "perfmon website"
+        "name": "txn per cycle",
+        "expression": "[TXN] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1D MPI (includes data+rfo w/ prefetches)",
-        "name-txn": "metric_L1D misses per txn (includes data+rfo w/ prefetches)",
-        "expression": "[L1D.REPLACEMENT] / [instructions]",
-        "expression-txn": "[L1D.REPLACEMENT] / [TXN]"
+        "name": "giga_instructions_per_sec",
+        "expression": "[instructions] / 1000000000"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+        "name": "branch misprediction ratio",
+        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1I code read misses (includes prefetches) per txn",
-        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]",
-        "expression-txn": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[L2_LINES_IN.ALL] / [instructions]",
-        "expression-txn": "[L2_LINES_IN.ALL] / [TXN]"
+        "name": "L1D MPI (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read MPI",
-        "name-txn": "metric_L2 demand data read misses per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+        "name": "L1D misses per txn (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [TXN]"
     },
     {
-        "name": "metric_L2 demand code MPI",
-        "name-txn": "metric_L2 demand code misses per txn",
-        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]",
-        "expression-txn": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [instructions]",
-        "expression-txn": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [TXN]"
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]"
     },
     {
-        "name": "metric_LLC total HITM (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]",
-        "origin": "perfspect"
+        "name": "L1I code read misses (includes prefetches) per txn",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]",
-        "origin": "perfspect"
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency (in ns)",
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+    },
+    {
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [instructions]"
+    },
+    {
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read MPI",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand data read misses per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+    },
+    {
+        "name": "L2 demand code MPI",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand code misses per txn",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+    },
+    {
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [instructions]"
+    },
+    {
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [TXN]"
+    },
+    {
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]"
+    },
+    {
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+    },
+    {
+        "name": "LLC total HITM (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]"
+    },
+    {
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+    },
+    {
+        "name": "Average LLC demand data read miss latency (in ns)",
         "expression": "1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]))"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for LOCAL requests (in ns)",
+        "name": "Average LLC demand data read miss latency for LOCAL requests (in ns)",
         "expression": "1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_LOCAL] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]))"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for REMOTE requests (in ns)",
+        "name": "Average LLC demand data read miss latency for REMOTE requests (in ns)",
         "expression": "1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_REMOTE] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE]) / ([UNC_CHA_CLOCKTICKS]/([CHAS_PER_SOCKET] * [SOCKET_COUNT]))"
     },
     {
-        "name": "metric_UPI Data transmit BW (MB/sec) (only data)",
+        "name": "UPI Data transmit BW (MB/sec) (only data)",
         "expression": "[UNC_UPI_TxL_FLITS.ALL_DATA] * (64/9.0) / 1000000"
     },
     {
-        "name": "metric_package power (watts)",
+        "name": "package power (watts)",
         "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
+        "name": "DRAM power (watts)",
         "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
+        "name": "core c6 residency %",
         "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
+        "name": "package c6 residency %",
         "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_% Uops delivered from decoded Icache (DSB)",
+        "name": "% Uops delivered from decoded Icache (DSB)",
         "expression": "100 * ([IDQ.DSB_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]))"
     },
     {
-        "name": "metric_% Uops delivered from legacy decode pipeline (MITE)",
+        "name": "% Uops delivered from legacy decode pipeline (MITE)",
         "expression": "100 * ([IDQ.MITE_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]))"
     },
     {
-        "name": "metric_core initiated local dram read bandwidth (MB/sec)",
-        "expression": "([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated local dram read bandwidth (MB/sec)",
+        "expression": "([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000"
     },
     {
-        "name": "metric_core initiated remote dram read bandwidth (MB/sec)",
-        "expression": "([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated remote dram read bandwidth (MB/sec)",
+        "expression": "([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT_SCH0.RD] + [UNC_M_CAS_COUNT_SCH1.RD]) * 64 / 1000000"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT_SCH0.WR] + [UNC_M_CAS_COUNT_SCH1.WR]) * 64 / 1000000"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT_SCH0.RD] + [UNC_M_CAS_COUNT_SCH1.RD] + [UNC_M_CAS_COUNT_SCH0.WR] + [UNC_M_CAS_COUNT_SCH1.WR]) * 64 / 1000000"
     },
     {
-        "name": "metric_ITLB (2nd level) MPI",
-        "name-txn": "metric_ITLB (2nd level) misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) load MPI",
-        "name-txn": "metric_DTLB (2nd level) load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB (2nd level) 2MB large page load MPI",
-        "name-txn": "metric_DTLB (2nd level) 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "DTLB (2nd level) load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) store MPI",
-        "name-txn": "metric_DTLB (2nd level) store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "DTLB (2nd level) load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to local DRAM",
+        "name": "DTLB (2nd level) 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB (2nd level) store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "NUMA %_Reads addressed to local DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to remote DRAM",
+        "name": "NUMA %_Reads addressed to remote DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_writes (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_writes (MB/sec)",
         "expression": "([UNC_CHA_TOR_INSERTS.IO_PCIRDCUR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_reads (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_reads (MB/sec)",
         "expression": "(([UNC_CHA_TOR_INSERTS.IO_ITOM] + [UNC_CHA_TOR_INSERTS.IO_ITOMCACHENEAR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Latency(%)",
+        "name": "TMA_..Fetch_Latency(%)",
         "expression": "100 * ( ( [PERF_METRICS.FETCH_LATENCY] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) )"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( [ICACHE_DATA.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( [ICACHE_TAG.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....Branch_Resteers(%)",
+        "name": "TMA_....Branch_Resteers(%)",
         "expression": "100 * ( [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) + ( [INT_MISC.UNKNOWN_BRANCH_CYCLES] / ( [cpu-cycles] ) ) )"
     },
-   {
-        "name": "metric_TMA_......Mispredicts_Resteers(%)",
+    {
+        "name": "TMA_......Mispredicts_Resteers(%)",
         "expression": "100 * ( ( ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) / ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Clears_Resteers(%)",
+        "name": "TMA_......Clears_Resteers(%)",
         "expression": "100 * ( ( 1 - ( ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) / ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Unknown_Branches(%)",
+        "name": "TMA_......Unknown_Branches(%)",
         "expression": "100 * ( [INT_MISC.UNKNOWN_BRANCH_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Bandwidth(%)",
+        "name": "TMA_..Fetch_Bandwidth(%)",
         "expression": "100 * ( max( ( 0 ) , ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) - ( ( [PERF_METRICS.FETCH_LATENCY] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( max( ( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) ) , ( 0 ) ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100 * ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100 * ( max( ( 0 ) , ( ( max( ( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) ) , ( 0 ) ) ) - ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.MEMORY_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100 * ( max( ( ( [EXE_ACTIVITY.BOUND_ON_LOADS] - [MEMORY_ACTIVITY.STALLS_L1D_MISS] ) / ( [cpu-cycles] ) ) , ( 0 ) ) )"
     },
     {
-        "name": "metric_TMA_......DTLB_Load(%)",
+        "name": "TMA_......DTLB_Load(%)",
         "expression": "100 * ( min( ( ( 7 ) * [DTLB_LOAD_MISSES.STLB_HIT:c1] + [DTLB_LOAD_MISSES.WALK_ACTIVE] ) , ( max( ( [CYCLE_ACTIVITY.CYCLES_MEM_ANY] - [MEMORY_ACTIVITY.CYCLES_L1D_MISS] ) , ( 0 ) ) ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Lock_Latency(%)",
+        "name": "TMA_......Lock_Latency(%)",
         "expression": "100 * ( ( 16 * max( ( 0 ) , ( [MEM_INST_RETIRED.LOCK_LOADS] - [L2_RQSTS.ALL_RFO] ) ) + ( [MEM_INST_RETIRED.LOCK_LOADS] / [MEM_INST_RETIRED.ALL_STORES] ) * ( ( 10 ) * [L2_RQSTS.RFO_HIT] + ( min( ( [cpu-cycles] - 0 ) , ( [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_RFO] - 0 ) ) ) ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L1D_MISS] - [MEMORY_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L2_MISS] - [MEMORY_ACTIVITY.STALLS_L3_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Data_Sharing(%)",
+        "name": "TMA_......Data_Sharing(%)",
         "expression": "100 * ( ( ( 79 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( ( 1000 / 1000 ) ) ) ) - ( 4.4 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( ( 1000 / 1000 ) ) ) ) ) * ( [MEM_LOAD_L3_HIT_RETIRED.XSNP_NO_FWD] + [MEM_LOAD_L3_HIT_RETIRED.XSNP_FWD] * ( 1 - ( [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HITM] / ( [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HITM] + [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD] ) ) ) ) * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) / 2 ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....DRAM_Bound(%)",
+        "name": "TMA_....DRAM_Bound(%)",
         "expression": "100 * ( ( ( [MEMORY_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) ) - ( ( ( ( ( 1 - ( ( 19 * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + 10 * ( ( [MEM_LOAD_L3_MISS_RETIRED.LOCAL_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_FWD] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_HITM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) / ( ( 19 * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + 10 * ( ( [MEM_LOAD_L3_MISS_RETIRED.LOCAL_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_FWD] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_HITM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) + ( 25 * ( 1 * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + 33 * ( 1 * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) ) ) * ( [MEMORY_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) ) ) ) if ( ( ( 1000000 ) * 1 > [MEM_LOAD_RETIRED.L1_MISS] ) ) else 0 ) ) ) )"
     },
     {
-        "name": "metric_TMA_......MEM_Bandwidth(%)",
+        "name": "TMA_......MEM_Bandwidth(%)",
         "expression": "100 * ( ( min( ( [cpu-cycles] - 0 ) , ( [OFFCORE_REQUESTS_OUTSTANDING.DATA_RD:c4] - 0 ) ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......MEM_Latency(%)",
+        "name": "TMA_......MEM_Latency(%)",
         "expression": "100 * ( ( min( ( [cpu-cycles] - 0 ) , ( [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DATA_RD] - 0 ) ) ) / ( [cpu-cycles] ) - ( ( min( ( [cpu-cycles] - 0 ) , ( [OFFCORE_REQUESTS_OUTSTANDING.DATA_RD:c4] - 0 ) ) ) / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100 * ( [EXE_ACTIVITY.BOUND_ON_STORES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......False_Sharing(%)",
+        "name": "TMA_......False_Sharing(%)",
         "expression": "100 * ( ( 81 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( ( 1000 / 1000 ) ) ) ) * [OCR.DEMAND_RFO.L3_HIT.SNOOP_HITM] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100 * ( max( ( 0 ) , ( ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) - ( [PERF_METRICS.MEMORY_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_........AMX_Busy(%)",
-        "expression": "100 * ( [EXE.AMX_BUSY] / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) )",
-        "origin": "perfspect"
+        "name": "TMA_........AMX_Busy(%)",
+        "expression": "100 * ( [EXE.AMX_BUSY] / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_1(%)",
+        "name": "TMA_......Ports_Utilized_1(%)",
         "expression": "100 * ( [EXE_ACTIVITY.1_PORTS_UTIL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_2(%)",
+        "name": "TMA_......Ports_Utilized_2(%)",
         "expression": "100 * ( [EXE_ACTIVITY.2_PORTS_UTIL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_3m(%)",
+        "name": "TMA_......Ports_Utilized_3m(%)",
         "expression": "100 * ( [UOPS_EXECUTED.CYCLES_GE_3] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_..Light_Operations(%)",
+        "name": "TMA_..Light_Operations(%)",
         "expression": "100 * ( max( ( 0 ) , ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) - ( [PERF_METRICS.HEAVY_OPERATIONS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_........FP_Vector_256b(%)",
+        "name": "TMA_........FP_Vector_256b(%)",
         "expression": "100 * ( ( [FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE] + [FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE] + [FP_ARITH_INST_RETIRED2.256B_PACKED_HALF] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) )"
     },
     {
-        "name": "metric_TMA_........FP_Vector_512b(%)",
+        "name": "TMA_........FP_Vector_512b(%)",
         "expression": "100 * ( ( [FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE] + [FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE] + [FP_ARITH_INST_RETIRED2.512B_PACKED_HALF] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) )"
     },
     {
-        "name": "metric_TMA_......Int_Vector_256b(%)",
+        "name": "TMA_......Int_Vector_256b(%)",
         "expression": "100 * ( ( [INT_VEC_RETIRED.ADD_256] + [INT_VEC_RETIRED.MUL_256] + [INT_VEC_RETIRED.VNNI_256] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) )"
     },
     {
-        "name": "metric_TMA_..Heavy_Operations(%)",
+        "name": "TMA_..Heavy_Operations(%)",
         "expression": "100 * ( [PERF_METRICS.HEAVY_OPERATIONS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_....Microcode_Sequencer(%)",
+        "name": "TMA_....Microcode_Sequencer(%)",
         "expression": "100 * ( [UOPS_RETIRED.MS] / ( [TOPDOWN.SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_Info_Thread_IPC",
+        "name": "TMA_Info_Thread_IPC",
         "expression": "[instructions] / ( [cpu-cycles] )"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/icx.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/icx.json
@@ -1,382 +1,410 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycles",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[instructions] / [TXN]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_giga_instructions_per_sec",
-        "expression": "[instructions] / 1000000000",
-        "origin": "perfspect"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_branch misprediction ratio",
-        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]",
-        "origin": "perfspect"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]",
-        "origin": "perfmon website"
+        "name": "txn per cycles",
+        "expression": "[instructions] / [TXN]"
     },
     {
-        "name": "metric_L1D MPI (includes data+rfo w/ prefetches)",
-        "name-txn": "metric_L1D misses per txn (includes data+rfo w/ prefetches)",
-        "expression": "[L1D.REPLACEMENT] / [instructions]",
-        "expression-txn": "[L1D.REPLACEMENT] / [TXN]"
+        "name": "giga_instructions_per_sec",
+        "expression": "[instructions] / 1000000000"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+        "name": "branch misprediction ratio",
+        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1I code read misses (includes prefetches) per txn",
-        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]",
-        "expression-txn": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[L2_LINES_IN.ALL] / [instructions]",
-        "expression-txn": "[L2_LINES_IN.ALL] / [TXN]"
+        "name": "L1D MPI (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read MPI",
-        "name-txn": "metric_L2 demand data read misses per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+        "name": "L1D misses per txn (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [TXN]"
     },
     {
-        "name": "metric_L2 demand code MPI",
-        "name-txn": "metric_L2 demand code misses per txn",
-        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]",
-        "expression-txn": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [TXN]"
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]"
     },
     {
-        "name": "metric_LLC total HITM (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
+        "name": "L1I code read misses (includes prefetches) per txn",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency (in ns)",
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+    },
+    {
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [instructions]"
+    },
+    {
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read MPI",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand data read misses per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+    },
+    {
+        "name": "L2 demand code MPI",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand code misses per txn",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+    },
+    {
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [instructions]"
+    },
+    {
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [TXN]"
+    },
+    {
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]"
+    },
+    {
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+    },
+    {
+        "name": "LLC total HITM (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]"
+    },
+    {
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+    },
+    {
+        "name": "Average LLC demand data read miss latency (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for LOCAL requests (in ns)",
+        "name": "Average LLC demand data read miss latency for LOCAL requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_LOCAL] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for REMOTE requests (in ns)",
+        "name": "Average LLC demand data read miss latency for REMOTE requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_REMOTE] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_UPI Data transmit BW (MB/sec) (only data)",
+        "name": "UPI Data transmit BW (MB/sec) (only data)",
         "expression": "([UNC_UPI_TxL_FLITS.ALL_DATA] * (64 / 9.0) / 1000000) / 1"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
-        "expression": "[power/energy-ram/]",
-        "origin": "perfspect"
+        "name": "DRAM power (watts)",
+        "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
-        "expression": "100 * [cstate_core/c6-residency/] / [TSC]",
-        "origin": "perfspect"
+        "name": "core c6 residency %",
+        "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
-        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]",
-        "origin": "perfspect"
+        "name": "package c6 residency %",
+        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_% Uops delivered from decoded Icache (DSB)",
+        "name": "% Uops delivered from decoded Icache (DSB)",
         "expression": "100 * ([IDQ.DSB_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_% Uops delivered from legacy decode pipeline (MITE)",
+        "name": "% Uops delivered from legacy decode pipeline (MITE)",
         "expression": "100 * ([IDQ.MITE_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_core initiated local dram read bandwidth (MB/sec)",
+        "name": "core initiated local dram read bandwidth (MB/sec)",
         "expression": "(([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_core initiated remote dram read bandwidth (MB/sec)",
+        "name": "core initiated remote dram read bandwidth (MB/sec)",
         "expression": "(([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.RD] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.WR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT.RD] + [UNC_M_CAS_COUNT.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_ITLB (2nd level) MPI",
-        "name-txn": "metric_ITLB (2nd level) misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) load MPI",
-        "name-txn": "metric_DTLB (2nd level) load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB (2nd level) 2MB large page load MPI",
-        "name-txn": "metric_DTLB (2nd level) 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "DTLB (2nd level) load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) store MPI",
-        "name-txn": "metric_DTLB (2nd level) store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "DTLB (2nd level) load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to local DRAM",
+        "name": "DTLB (2nd level) 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB (2nd level) store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "NUMA %_Reads addressed to local DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to remote DRAM",
+        "name": "NUMA %_Reads addressed to remote DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Latency(%)",
+        "name": "TMA_..Fetch_Latency(%)",
         "expression": "100 * ( ( ( 5 ) * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( [ICACHE_16B.IFDATA_STALL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( [ICACHE_64B.IFTAG_STALL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....Branch_Resteers(%)",
+        "name": "TMA_....Branch_Resteers(%)",
         "expression": "100 * ( [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) + ( ( 10 ) * [BACLEARS.ANY] / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_......Mispredicts_Resteers(%)",
+        "name": "TMA_......Mispredicts_Resteers(%)",
         "expression": "100 * ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Clears_Resteers(%)",
+        "name": "TMA_......Clears_Resteers(%)",
         "expression": "100 * ( ( 1 - ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Unknown_Branches(%)",
+        "name": "TMA_......Unknown_Branches(%)",
         "expression": "100 * ( ( 10 ) * [BACLEARS.ANY] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Bandwidth(%)",
+        "name": "TMA_..Fetch_Bandwidth(%)",
         "expression": "100 * ( max( 0 , ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) - ( ( ( 5 ) * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....MITE(%)",
+        "name": "TMA_....MITE(%)",
         "expression": "100 * ( ( [IDQ.MITE_CYCLES_ANY] - [IDQ.MITE_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_....DSB(%)",
+        "name": "TMA_....DSB(%)",
         "expression": "100 * ( ( [IDQ.DSB_CYCLES_ANY] - [IDQ.DSB_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) + ( ( 5 ) * [INT_MISC.RECOVERY_CYCLES:c1:e1] ) / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100 * ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) + ( ( 5 ) * [INT_MISC.RECOVERY_CYCLES:c1:e1] ) / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) )"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100 * ( max( 0 , ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) + ( ( 5 ) * [INT_MISC.RECOVERY_CYCLES:c1:e1] ) / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) - ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) + ( ( 5 ) * [INT_MISC.RECOVERY_CYCLES:c1:e1] ) / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) + ( ( 5 ) * [INT_MISC.RECOVERY_CYCLES:c1:e1] ) / ( [TOPDOWN.SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100 * ( ( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] + [EXE_ACTIVITY.BOUND_ON_STORES] ) / ( [CYCLE_ACTIVITY.STALLS_TOTAL] + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) + [EXE_ACTIVITY.BOUND_ON_STORES] ) ) * ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) + ( ( 5 ) * [INT_MISC.RECOVERY_CYCLES:c1:e1] ) / ( [TOPDOWN.SLOTS] ) ) )"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100 * ( max( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] - [CYCLE_ACTIVITY.STALLS_L1D_MISS] ) / ( [cpu-cycles] ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_......DTLB_Load(%)",
+        "name": "TMA_......DTLB_Load(%)",
         "expression": "100 * ( min( ( 7 ) * [DTLB_LOAD_MISSES.STLB_HIT:c1] + [DTLB_LOAD_MISSES.WALK_ACTIVE] , max( [CYCLE_ACTIVITY.CYCLES_MEM_ANY] - [CYCLE_ACTIVITY.CYCLES_L1D_MISS] , 0 ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Lock_Latency(%)",
+        "name": "TMA_......Lock_Latency(%)",
         "expression": "100 * ( min( ( ( 16 * max( 0 , [MEM_INST_RETIRED.LOCK_LOADS] - [L2_RQSTS.ALL_RFO] ) + ( [MEM_INST_RETIRED.LOCK_LOADS] / [MEM_INST_RETIRED.ALL_STORES] ) * ( ( 10 ) * [L2_RQSTS.RFO_HIT] + ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_RFO] ) ) ) ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100 * ( ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) / ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + [L1D_PEND_MISS.FB_FULL_PERIODS] ) ) * ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100 * ( ( [CYCLE_ACTIVITY.STALLS_L2_MISS] - [CYCLE_ACTIVITY.STALLS_L3_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Data_Sharing(%)",
+        "name": "TMA_......Data_Sharing(%)",
         "expression": "100 * ( min( ( ( ( 47.5 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) - ( 4 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) ) * ( [MEM_LOAD_L3_HIT_RETIRED.XSNP_HIT] + [MEM_LOAD_L3_HIT_RETIRED.XSNP_HITM] * ( 1 - ( [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HITM] / ( [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HITM] + [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD] ) ) ) ) * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) / 2 ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....DRAM_Bound(%)",
+        "name": "TMA_....DRAM_Bound(%)",
         "expression": "100 * ( min( ( ( ( [CYCLE_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) + ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) ) - ( ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) / ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + [L1D_PEND_MISS.FB_FULL_PERIODS] ) ) * ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) ) ) ) - ( min( ( ( ( ( 1 - ( ( ( 19 * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + 10 * ( ( [MEM_LOAD_L3_MISS_RETIRED.LOCAL_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_FWD] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_HITM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) / ( ( 19 * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + 10 * ( ( [MEM_LOAD_L3_MISS_RETIRED.LOCAL_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_FWD] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_HITM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) + ( 25 * ( ( [MEM_LOAD_RETIRED.LOCAL_PMM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) + 33 * ( ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_PMM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) ) ) ) ) * ( [CYCLE_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) + ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) ) - ( ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) / ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + [L1D_PEND_MISS.FB_FULL_PERIODS] ) ) * ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) ) ) ) ) if ( ( 1000000 ) * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_PMM] + [MEM_LOAD_RETIRED.LOCAL_PMM] ) > [MEM_LOAD_RETIRED.L1_MISS] ) else 0 ) ) , ( 1 ) ) ) ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_......MEM_Bandwidth(%)",
+        "name": "TMA_......MEM_Bandwidth(%)",
         "expression": "100 * ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.ALL_DATA_RD:c4] ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......MEM_Latency(%)",
+        "name": "TMA_......MEM_Latency(%)",
         "expression": "100 * ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DATA_RD] ) ) / ( [cpu-cycles] ) - ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.ALL_DATA_RD:c4] ) ) / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100 * ( [EXE_ACTIVITY.BOUND_ON_STORES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......False_Sharing(%)",
+        "name": "TMA_......False_Sharing(%)",
         "expression": "100 * ( min( ( ( 48 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) * [OCR.DEMAND_RFO.L3_HIT.SNOOP_HITM] / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100 * ( max( 0 , ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) + ( ( 5 ) * [INT_MISC.RECOVERY_CYCLES:c1:e1] ) / ( [TOPDOWN.SLOTS] ) ) - ( ( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] + [EXE_ACTIVITY.BOUND_ON_STORES] ) / ( [CYCLE_ACTIVITY.STALLS_TOTAL] + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) + [EXE_ACTIVITY.BOUND_ON_STORES] ) ) * ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) + ( ( 5 ) * [INT_MISC.RECOVERY_CYCLES:c1:e1] ) / ( [TOPDOWN.SLOTS] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Ports_Utilization(%)",
+        "name": "TMA_....Ports_Utilization(%)",
         "expression": "100 * ( ( [EXE_ACTIVITY.3_PORTS_UTIL:u0x80] + ( [RESOURCE_STALLS.SCOREBOARD] / ( [cpu-cycles] ) ) * ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [CYCLE_ACTIVITY.STALLS_MEM_ANY] ) + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) ) / ( [cpu-cycles] ) if ( [ARITH.DIVIDER_ACTIVE] < ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [CYCLE_ACTIVITY.STALLS_MEM_ANY] ) ) else ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_0(%)",
+        "name": "TMA_......Ports_Utilized_0(%)",
         "expression": "100 * ( [EXE_ACTIVITY.3_PORTS_UTIL:u0x80] / ( [cpu-cycles] ) + ( [RESOURCE_STALLS.SCOREBOARD] / ( [cpu-cycles] ) ) * ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [CYCLE_ACTIVITY.STALLS_MEM_ANY] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_1(%)",
+        "name": "TMA_......Ports_Utilized_1(%)",
         "expression": "100 * ( [EXE_ACTIVITY.1_PORTS_UTIL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_2(%)",
+        "name": "TMA_......Ports_Utilized_2(%)",
         "expression": "100 * ( [EXE_ACTIVITY.2_PORTS_UTIL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_3m(%)",
+        "name": "TMA_......Ports_Utilized_3m(%)",
         "expression": "100 * ( [UOPS_EXECUTED.CYCLES_GE_3] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_..Light_Operations(%)",
+        "name": "TMA_..Light_Operations(%)",
         "expression": "100 * ( max( 0 , ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) - ( ( ( ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [UOPS_DECODED.DEC0] - [UOPS_DECODED.DEC0:c1] ) / [IDQ.MITE_UOPS] ) ) )"
     },
     {
-        "name": "metric_TMA_........FP_Vector_128b(%)",
+        "name": "TMA_........FP_Vector_128b(%)",
         "expression": "100 * ( min( ( ( [FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE] + [FP_ARITH_INST_RETIRED.128B_PACKED_SINGLE] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_........FP_Vector_256b(%)",
+        "name": "TMA_........FP_Vector_256b(%)",
         "expression": "100 * ( min( ( ( [FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE] + [FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_........FP_Vector_512b(%)",
+        "name": "TMA_........FP_Vector_512b(%)",
         "expression": "100 * ( min( ( ( [FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE] + [FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_..Heavy_Operations(%)",
+        "name": "TMA_..Heavy_Operations(%)",
         "expression": "100 * ( ( ( ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [UOPS_DECODED.DEC0] - [UOPS_DECODED.DEC0:c1] ) / [IDQ.MITE_UOPS] )"
     },
     {
-        "name": "metric_TMA_....Microcode_Sequencer(%)",
+        "name": "TMA_....Microcode_Sequencer(%)",
         "expression": "100 * ( ( ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( [TOPDOWN.SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_Info_System_SMT_2T_Utilization",
+        "name": "TMA_Info_System_SMT_2T_Utilization",
         "expression": "1 - [CPU_CLK_UNHALTED.ONE_THREAD_ACTIVE] / [CPU_CLK_UNHALTED.REF_DISTRIBUTED] if [SOCKET_COUNT] > 1 else 0"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/icx_nofixedtma.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/icx_nofixedtma.json
@@ -1,334 +1,362 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycles",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[instructions] / [TXN]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_giga_instructions_per_sec",
-        "expression": "[instructions] / 1000000000",
-        "origin": "perfspect"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_branch misprediction ratio",
-        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]",
-        "origin": "perfspect"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]",
-        "origin": "perfmon website"
+        "name": "txn per cycles",
+        "expression": "[instructions] / [TXN]"
     },
     {
-        "name": "metric_L1D MPI (includes data+rfo w/ prefetches)",
-        "name-txn": "metric_L1D misses per txn (includes data+rfo w/ prefetches)",
-        "expression": "[L1D.REPLACEMENT] / [instructions]",
-        "expression-txn": "[L1D.REPLACEMENT] / [TXN]"
+        "name": "giga_instructions_per_sec",
+        "expression": "[instructions] / 1000000000"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+        "name": "branch misprediction ratio",
+        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1I code read misses (includes prefetches) per txn",
-        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]",
-        "expression-txn": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[L2_LINES_IN.ALL] / [instructions]",
-        "expression-txn": "[L2_LINES_IN.ALL] / [TXN]"
+        "name": "L1D MPI (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read MPI",
-        "name-txn": "metric_L2 demand data read misses per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+        "name": "L1D misses per txn (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [TXN]"
     },
     {
-        "name": "metric_L2 demand code MPI",
-        "name-txn": "metric_L2 demand code misses per txn",
-        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]",
-        "expression-txn": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [TXN]"
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]"
     },
     {
-        "name": "metric_LLC total HITM (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
+        "name": "L1I code read misses (includes prefetches) per txn",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency (in ns)",
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+    },
+    {
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [instructions]"
+    },
+    {
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read MPI",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand data read misses per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+    },
+    {
+        "name": "L2 demand code MPI",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand code misses per txn",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+    },
+    {
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [instructions]"
+    },
+    {
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [TXN]"
+    },
+    {
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]"
+    },
+    {
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+    },
+    {
+        "name": "LLC total HITM (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]"
+    },
+    {
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+    },
+    {
+        "name": "Average LLC demand data read miss latency (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for LOCAL requests (in ns)",
+        "name": "Average LLC demand data read miss latency for LOCAL requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_LOCAL] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for REMOTE requests (in ns)",
+        "name": "Average LLC demand data read miss latency for REMOTE requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_REMOTE] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_UPI Data transmit BW (MB/sec) (only data)",
+        "name": "UPI Data transmit BW (MB/sec) (only data)",
         "expression": "([UNC_UPI_TxL_FLITS.ALL_DATA] * (64 / 9.0) / 1000000) / 1"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
-        "expression": "[power/energy-ram/]",
-        "origin": "perfspect"
+        "name": "DRAM power (watts)",
+        "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
-        "expression": "100 * [cstate_core/c6-residency/] / [TSC]",
-        "origin": "perfspect"
+        "name": "core c6 residency %",
+        "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
-        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]",
-        "origin": "perfspect"
+        "name": "package c6 residency %",
+        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_% Uops delivered from decoded Icache (DSB)",
+        "name": "% Uops delivered from decoded Icache (DSB)",
         "expression": "100 * ([IDQ.DSB_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_% Uops delivered from legacy decode pipeline (MITE)",
+        "name": "% Uops delivered from legacy decode pipeline (MITE)",
         "expression": "100 * ([IDQ.MITE_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_core initiated local dram read bandwidth (MB/sec)",
+        "name": "core initiated local dram read bandwidth (MB/sec)",
         "expression": "(([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_core initiated remote dram read bandwidth (MB/sec)",
+        "name": "core initiated remote dram read bandwidth (MB/sec)",
         "expression": "(([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.RD] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.WR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT.RD] + [UNC_M_CAS_COUNT.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_ITLB (2nd level) MPI",
-        "name-txn": "metric_ITLB (2nd level) misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) load MPI",
-        "name-txn": "metric_DTLB (2nd level) load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB (2nd level) 2MB large page load MPI",
-        "name-txn": "metric_DTLB (2nd level) 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "DTLB (2nd level) load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) store MPI",
-        "name-txn": "metric_DTLB (2nd level) store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "DTLB (2nd level) load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to local DRAM",
+        "name": "DTLB (2nd level) 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB (2nd level) store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "NUMA %_Reads addressed to local DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to remote DRAM",
+        "name": "NUMA %_Reads addressed to remote DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Latency(%)",
+        "name": "TMA_..Fetch_Latency(%)",
         "expression": "100 * ( ( ( 5 ) * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( [ICACHE_DATA.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( [ICACHE_TAG.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....MS_Switches(%)",
+        "name": "TMA_....MS_Switches(%)",
         "expression": "100 * ( ( 3 ) * [IDQ.MS_SWITCHES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....LCP(%)",
+        "name": "TMA_....LCP(%)",
         "expression": "100 * ( [DECODE.LCP] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....DSB_Switches(%)",
+        "name": "TMA_....DSB_Switches(%)",
         "expression": "100 * ( [DSB2MITE_SWITCHES.PENALTY_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Bandwidth(%)",
+        "name": "TMA_..Fetch_Bandwidth(%)",
         "expression": "100 * ( max( 0 , ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) - ( ( ( 5 ) * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....MITE(%)",
+        "name": "TMA_....MITE(%)",
         "expression": "100 * ( ( [IDQ.MITE_CYCLES_ANY] - [IDQ.MITE_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_....DSB(%)",
+        "name": "TMA_....DSB(%)",
         "expression": "100 * ( ( [IDQ.DSB_CYCLES_ANY] - [IDQ.DSB_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( max( 1 - ( ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( ( [TOPDOWN.BACKEND_BOUND_SLOTS] + ( 5 ) * [INT_MISC.CLEARS_COUNT] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100 * ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * ( max( 1 - ( ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( ( [TOPDOWN.BACKEND_BOUND_SLOTS] + ( 5 ) * [INT_MISC.CLEARS_COUNT] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) , 0 ) ) )"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100 * ( max( 0 , ( max( 1 - ( ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( ( [TOPDOWN.BACKEND_BOUND_SLOTS] + ( 5 ) * [INT_MISC.CLEARS_COUNT] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) , 0 ) ) - ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * ( max( 1 - ( ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( ( [TOPDOWN.BACKEND_BOUND_SLOTS] + ( 5 ) * [INT_MISC.CLEARS_COUNT] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) , 0 ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( ( [TOPDOWN.BACKEND_BOUND_SLOTS] + ( 5 ) * [INT_MISC.CLEARS_COUNT] ) / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100 * ( ( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] + [EXE_ACTIVITY.BOUND_ON_STORES] ) / ( [CYCLE_ACTIVITY.STALLS_TOTAL] + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) + [EXE_ACTIVITY.BOUND_ON_STORES] ) ) * ( ( [TOPDOWN.BACKEND_BOUND_SLOTS] + ( 5 ) * [INT_MISC.CLEARS_COUNT] ) / ( [TOPDOWN.SLOTS_P] ) ) )"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100 * ( max( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] - [CYCLE_ACTIVITY.STALLS_L1D_MISS] ) / ( [cpu-cycles] ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100 * ( ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) / ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + [L1D_PEND_MISS.FB_FULL_PERIODS] ) ) * ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100 * ( ( [CYCLE_ACTIVITY.STALLS_L2_MISS] - [CYCLE_ACTIVITY.STALLS_L3_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....DRAM_Bound(%)",
+        "name": "TMA_....DRAM_Bound(%)",
         "expression": "100 * ( ( [CYCLE_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) + ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) ) - ( ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) / ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + [L1D_PEND_MISS.FB_FULL_PERIODS] ) ) * ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100 * ( [EXE_ACTIVITY.BOUND_ON_STORES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100 * ( max( 0 , ( ( [TOPDOWN.BACKEND_BOUND_SLOTS] + ( 5 ) * [INT_MISC.CLEARS_COUNT] ) / ( [TOPDOWN.SLOTS_P] ) ) - ( ( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] + [EXE_ACTIVITY.BOUND_ON_STORES] ) / ( [CYCLE_ACTIVITY.STALLS_TOTAL] + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) + [EXE_ACTIVITY.BOUND_ON_STORES] ) ) * ( ( [TOPDOWN.BACKEND_BOUND_SLOTS] + ( 5 ) * [INT_MISC.CLEARS_COUNT] ) / ( [TOPDOWN.SLOTS_P] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Divider(%)",
+        "name": "TMA_....Divider(%)",
         "expression": "100 * ( [ARITH.DIVIDER_ACTIVE] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Light_Operations(%)",
+        "name": "TMA_..Light_Operations(%)",
         "expression": "100 * ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( ( ( [UOPS_RETIRED.SLOTS] / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [UOPS_DECODED.DEC0] - [UOPS_DECODED.DEC0:c1] ) / [IDQ.MITE_UOPS] ) ) )"
     },
     {
-        "name": "metric_TMA_....Memory_Operations(%)",
+        "name": "TMA_....Memory_Operations(%)",
         "expression": "100 * ( ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( ( ( [UOPS_RETIRED.SLOTS] / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [UOPS_DECODED.DEC0] - [UOPS_DECODED.DEC0:c1] ) / [IDQ.MITE_UOPS] ) ) ) * [MEM_INST_RETIRED.ANY] / [instructions] )"
     },
     {
-        "name": "metric_TMA_....Branch_Instructions(%)",
+        "name": "TMA_....Branch_Instructions(%)",
         "expression": "100 * ( ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( ( ( [UOPS_RETIRED.SLOTS] / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [UOPS_DECODED.DEC0] - [UOPS_DECODED.DEC0:c1] ) / [IDQ.MITE_UOPS] ) ) ) * [BR_INST_RETIRED.ALL_BRANCHES] / ( ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [TOPDOWN.SLOTS_P] ) ) )"
     },
     {
-        "name": "metric_TMA_..Heavy_Operations(%)",
+        "name": "TMA_..Heavy_Operations(%)",
         "expression": "100 * ( ( ( [UOPS_RETIRED.SLOTS] / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [UOPS_DECODED.DEC0] - [UOPS_DECODED.DEC0:c1] ) / [IDQ.MITE_UOPS] )"
     },
     {
-        "name": "metric_TMA_....Few_Uops_Instructions(%)",
+        "name": "TMA_....Few_Uops_Instructions(%)",
         "expression": "100 * ( ( ( ( [UOPS_RETIRED.SLOTS] / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [UOPS_DECODED.DEC0] - [UOPS_DECODED.DEC0:c1] ) / [IDQ.MITE_UOPS] ) - ( ( [UOPS_RETIRED.SLOTS] / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( [TOPDOWN.SLOTS_P] ) ) )"
     },
     {
-        "name": "metric_TMA_....Microcode_Sequencer(%)",
+        "name": "TMA_....Microcode_Sequencer(%)",
         "expression": "100 * ( ( [UOPS_RETIRED.SLOTS] / [UOPS_ISSUED.ANY] ) * [IDQ.MS_UOPS] / ( [TOPDOWN.SLOTS_P] ) )"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/skx.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/skx.json
@@ -1,466 +1,472 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycle",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[TXN] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]",
-        "origin": "perfmon website"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_L1D MPI (includes data+rfo w/ prefetches)",
-        "name-txn": "metric_L1D misses per txn (includes data+rfo w/ prefetches)",
-        "expression": "[L1D.REPLACEMENT] / [instructions]",
-        "expression-txn": "[L1D.REPLACEMENT] / [TXN]"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+        "name": "txn per cycle",
+        "expression": "[TXN] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1I code read misses (includes prefetches) per txn",
-        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]",
-        "expression-txn": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[L2_LINES_IN.ALL] / [instructions]",
-        "expression-txn": "[L2_LINES_IN.ALL] / [TXN]"
+        "name": "L1D MPI (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read MPI",
+        "name": "L1D misses per txn (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [TXN]"
+    },
+    {
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]"
+    },
+    {
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+    },
+    {
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]"
+    },
+    {
+        "name": "L1I code read misses (includes prefetches) per txn",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]"
+    },
+    {
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+    },
+    {
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [instructions]"
+    },
+    {
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read MPI",
         "name-txn": "metric_L2 demand data read misses per txn",
         "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]",
         "exression-txn": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
     },
     {
-        "name": "metric_L2 demand code MPI",
-        "name-txn": "metric_L2 demand code misses per txn",
-        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]",
-        "expression-txn": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+        "name": "L2 demand code MPI",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]"
     },
     {
-        "name": "metric_LLC MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_LLC misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12C40033]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12C40033]) / [TXN]",
-        "origin": "perfspect"
+        "name": "L2 demand code misses per txn",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] / [instructions]",
-        "expression-txn": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] / [TXN]"
+        "name": "LLC MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12C40033]) / [instructions]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] / [instructions]",
-        "expression-txn": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] / [TXN]"
+        "name": "LLC misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x12C40033]) / [TXN]"
     },
     {
-        "name": "metric_LLC total HITM (per instr)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [instructions]",
-        "expression-txn": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [TXN]",
-        "origin": "perfspect"
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] / [instructions]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [instructions]",
-        "expression-txn": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [TXN]",
-        "origin": "perfspect"
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12CC0233] / [TXN]"
     },
     {
-        "name": "metric_Average LLC data read miss latency (in ns)",
-        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40433] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40433]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )",
-        "origin": "perfspect"
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] / [instructions]"
     },
     {
-        "name": "metric_Average LLC data read miss latency for LOCAL requests (in ns)",
-        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40432] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40432]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )",
-        "origin": "perfspect"
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS.0x12D40433] / [TXN]"
     },
     {
-        "name": "metric_Average LLC data read miss latency for REMOTE requests (in ns)",
-        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40431] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40431]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )",
-        "origin": "perfspect"
+        "name": "LLC total HITM (per instr)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [instructions]"
     },
     {
-        "name": "metric_ITLB MPI",
-        "name-txn": "metric_ITLB misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HITM] / [TXN]"
     },
     {
-        "name": "metric_ITLB large page MPI",
-        "name-txn": "metric_ITLB large page misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "LLC total HIT clean line forwards (per instr)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [instructions]"
     },
     {
-        "name": "metric_DTLB load MPI",
-        "name-txn": "metric_DTLB load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.ALL_READS.L3_MISS.REMOTE_HIT_FORWARD] / [TXN]"
     },
     {
-        "name": "metric_DTLB 4KB page load MPI",
-        "name-txn": "metric_DTLB 4KB page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [TXN]",
-        "origin": "perfspect"
+        "name": "Average LLC data read miss latency (in ns)",
+        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40433] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40433]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )"
     },
     {
-        "name": "metric_DTLB 2MB large page load MPI",
-        "name-txn": "metric_DTLB 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "Average LLC data read miss latency for LOCAL requests (in ns)",
+        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40432] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40432]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )"
     },
     {
-        "name": "metric_DTLB 1GB large page load MPI",
-        "name-txn": "metric_DTLB 1GB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [TXN]",
-        "origin": "perfspect"
+        "name": "Average LLC data read miss latency for REMOTE requests (in ns)",
+        "expression": "(1000000000 * [UNC_CHA_TOR_OCCUPANCY.IA_MISS.0x40431] / [UNC_CHA_TOR_INSERTS.IA_MISS.0x40431]) / ( [UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) )"
     },
     {
-        "name": "metric_DTLB store MPI",
-        "name-txn": "metric_DTLB store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB load miss latency (in core clks)",
-        "expression": "[DTLB_LOAD_MISSES.WALK_ACTIVE] / [DTLB_LOAD_MISSES.WALK_COMPLETED]",
-        "origin": "perfspect"
+        "name": "ITLB misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB store miss latency (in core clks)",
-        "expression": "[DTLB_STORE_MISSES.WALK_ACTIVE] / [DTLB_STORE_MISSES.WALK_COMPLETED]",
-        "origin": "perfspect"
+        "name": "ITLB large page MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
     },
     {
-        "name": "metric_ITLB miss latency (in core clks)",
-        "expression": "[ITLB_MISSES.WALK_ACTIVE] / [ITLB_MISSES.WALK_COMPLETED]",
-        "origin": "perfspect"
+        "name": "ITLB large page misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to local DRAM",
+        "name": "DTLB load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "DTLB 4KB page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [instructions]"
+    },
+    {
+        "name": "DTLB 4KB page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [TXN]"
+    },
+    {
+        "name": "DTLB 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB 1GB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [instructions]"
+    },
+    {
+        "name": "DTLB 1GB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [TXN]"
+    },
+    {
+        "name": "DTLB store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "DTLB load miss latency (in core clks)",
+        "expression": "[DTLB_LOAD_MISSES.WALK_ACTIVE] / [DTLB_LOAD_MISSES.WALK_COMPLETED]"
+    },
+    {
+        "name": "DTLB store miss latency (in core clks)",
+        "expression": "[DTLB_STORE_MISSES.WALK_ACTIVE] / [DTLB_STORE_MISSES.WALK_COMPLETED]"
+    },
+    {
+        "name": "ITLB miss latency (in core clks)",
+        "expression": "[ITLB_MISSES.WALK_ACTIVE] / [ITLB_MISSES.WALK_COMPLETED]"
+    },
+    {
+        "name": "NUMA %_Reads addressed to local DRAM",
         "expression": "100 * [UNC_CHA_TOR_INSERTS.IA_MISS.0x40432] / ([UNC_CHA_TOR_INSERTS.IA_MISS.0x40432] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x40431])"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to remote DRAM",
+        "name": "NUMA %_Reads addressed to remote DRAM",
         "expression": "100 * [UNC_CHA_TOR_INSERTS.IA_MISS.0x40431] / ([UNC_CHA_TOR_INSERTS.IA_MISS.0x40432] + [UNC_CHA_TOR_INSERTS.IA_MISS.0x40431])"
     },
     {
-        "name": "metric_UPI Data transmit BW (MB/sec) (only data)",
+        "name": "UPI Data transmit BW (MB/sec) (only data)",
         "expression": "([UNC_UPI_TxL_FLITS.ALL_DATA] * (64 / 9.0) / 1000000) / 1"
     },
     {
-        "name": "metric_UPI Transmit utilization_% (includes control)",
-        "expression": "100 * (([UNC_UPI_TxL_FLITS.ALL_DATA] + [UNC_UPI_TxL_FLITS.NON_DATA]) / 3) / ((((([SYSTEM_TSC_FREQ] / ([CHAS_PER_SOCKET] * [CONST_THREAD_COUNT])) / (([SYSTEM_TSC_FREQ] / ([CHAS_PER_SOCKET] * [CONST_THREAD_COUNT])) - [cstate_pkg/c6-residency/])) * ([UNC_UPI_CLOCKTICKS] - [UNC_UPI_L1_POWER_CYCLES])) * 5 / 6))",
-        "origin": "perfspect"
+        "name": "UPI Transmit utilization_% (includes control)",
+        "expression": "100 * (([UNC_UPI_TxL_FLITS.ALL_DATA] + [UNC_UPI_TxL_FLITS.NON_DATA]) / 3) / ((((([SYSTEM_TSC_FREQ] / ([CHAS_PER_SOCKET] * [CONST_THREAD_COUNT])) / (([SYSTEM_TSC_FREQ] / ([CHAS_PER_SOCKET] * [CONST_THREAD_COUNT])) - [cstate_pkg/c6-residency/])) * ([UNC_UPI_CLOCKTICKS] - [UNC_UPI_L1_POWER_CYCLES])) * 5 / 6))"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
-        "expression": "[power/energy-ram/]",
-        "origin": "perfspect"
+        "name": "DRAM power (watts)",
+        "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
-        "expression": "100 * [cstate_core/c6-residency/] / [TSC]",
-        "origin": "perfspect"
+        "name": "core c6 residency %",
+        "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
-        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]",
-        "origin": "perfspect"
+        "name": "package c6 residency %",
+        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_% Uops delivered from decoded Icache (DSB)",
+        "name": "% Uops delivered from decoded Icache (DSB)",
         "expression": "100 * ([IDQ.DSB_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_% Uops delivered from legacy decode pipeline (MITE)",
+        "name": "% Uops delivered from legacy decode pipeline (MITE)",
         "expression": "100 * ([IDQ.MITE_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_core % cycles in non AVX license",
-        "expression": "(100 * [CORE_POWER.LVL0_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])",
-        "origin": "perfspect"
+        "name": "core % cycles in non AVX license",
+        "expression": "(100 * [CORE_POWER.LVL0_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])"
     },
     {
-        "name": "metric_core % cycles in AVX2 license",
-        "expression": "(100 * [CORE_POWER.LVL1_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])",
-        "origin": "perfspect"
+        "name": "core % cycles in AVX2 license",
+        "expression": "(100 * [CORE_POWER.LVL1_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])"
     },
     {
-        "name": "metric_core % cycles in AVX-512 license",
-        "expression": "(100 * [CORE_POWER.LVL2_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])",
-        "origin": "perfspect"
+        "name": "core % cycles in AVX-512 license",
+        "expression": "(100 * [CORE_POWER.LVL2_TURBO_LICENSE]) / ([CORE_POWER.LVL0_TURBO_LICENSE] + [CORE_POWER.LVL1_TURBO_LICENSE] + [CORE_POWER.LVL2_TURBO_LICENSE])"
     },
     {
-        "name": "metric_core initiated local dram read bandwidth (MB/sec)",
-        "expression": "[OCR.ALL_READS.L3_MISS_LOCAL_DRAM.ANY_SNOOP] * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated local dram read bandwidth (MB/sec)",
+        "expression": "[OCR.ALL_READS.L3_MISS_LOCAL_DRAM.ANY_SNOOP] * 64 / 1000000"
     },
     {
-        "name": "metric_core initiated remote dram read bandwidth (MB/sec)",
-        "expression": "[OCR.ALL_READS.L3_MISS_LOCAL_DRAM.ANY_SNOOP_ocr_msr_3fB80007f7] * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated remote dram read bandwidth (MB/sec)",
+        "expression": "[OCR.ALL_READS.L3_MISS_LOCAL_DRAM.ANY_SNOOP_ocr_msr_3fB80007f7] * 64 / 1000000"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.RD] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.WR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT.RD] + [UNC_M_CAS_COUNT.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_writes (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_writes (MB/sec)",
         "expression": "(([UNC_IIO_DATA_REQ_OF_CPU.MEM_READ.PART0] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_READ.PART1] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_READ.PART2] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_READ.PART3]) * 4 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_reads (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_reads (MB/sec)",
         "expression": "(([UNC_IIO_DATA_REQ_OF_CPU.MEM_WRITE.PART0] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_WRITE.PART1] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_WRITE.PART2] + [UNC_IIO_DATA_REQ_OF_CPU.MEM_WRITE.PART3]) * 4 / 1000000) / 1"
     },
     {
-        "name": "metric_TMA_Info_cycles_both_threads_active(%)",
-        "expression": "100 * ( (1 - ([CPU_CLK_THREAD_UNHALTED.ONE_THREAD_ACTIVE] / ([CPU_CLK_THREAD_UNHALTED.REF_XCLK_ANY] / 2)) ) if [CONST_THREAD_COUNT] > 1 else 0)",
-        "origin": "perfspect"
+        "name": "TMA_Info_cycles_both_threads_active(%)",
+        "expression": "100 * ( (1 - ([CPU_CLK_THREAD_UNHALTED.ONE_THREAD_ACTIVE] / ([CPU_CLK_THREAD_UNHALTED.REF_XCLK_ANY] / 2)) ) if [CONST_THREAD_COUNT] > 1 else 0)"
     },
     {
-        "name": "metric_TMA_Info_CoreIPC",
-        "expression": "[instructions] / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_Info_CoreIPC",
+        "expression": "[instructions] / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Frontend_Latency(%)",
-        "expression": "100 * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] /  ([CPU_CLK_UNHALTED.THREAD_ANY] /[CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_..Frontend_Latency(%)",
+        "expression": "100 * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE] /  ([CPU_CLK_UNHALTED.THREAD_ANY] /[CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( ( [ICACHE_16B.IFDATA_STALL] + 2 * [ICACHE_16B.IFDATA_STALL:c1:e1] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( [ICACHE_64B.IFTAG_STALL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....Branch_Resteers(%)",
+        "name": "TMA_....Branch_Resteers(%)",
         "expression": "100 * ( [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) + ( ( 9 ) * [BACLEARS.ANY] / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_......Mispredicts_Resteers(%)",
+        "name": "TMA_......Mispredicts_Resteers(%)",
         "expression": "100 * ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Clears_Resteers(%)",
+        "name": "TMA_......Clears_Resteers(%)",
         "expression": "100 * ( ( 1 - ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Unknown_Branches_Resteers(%)",
-        "expression": "100 * (9 * [BACLEARS.ANY]) /  [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "TMA_......Unknown_Branches_Resteers(%)",
+        "expression": "100 * (9 * [BACLEARS.ANY]) /  [cpu-cycles]"
     },
     {
-        "name": "metric_TMA_..Frontend_Bandwidth(%)",
-        "expression": "100 * ([IDQ_UOPS_NOT_DELIVERED.CORE] - 4 * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE]) / (4 * ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT]))",
-        "origin": "perfspect"
+        "name": "TMA_..Frontend_Bandwidth(%)",
+        "expression": "100 * ([IDQ_UOPS_NOT_DELIVERED.CORE] - 4 * [IDQ_UOPS_NOT_DELIVERED.CYCLES_0_UOPS_DELIV.CORE]) / (4 * ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT]))"
     },
     {
-        "name": "metric_TMA_....MITE(%)",
+        "name": "TMA_....MITE(%)",
         "expression": "100 * ( ( [IDQ.ALL_MITE_CYCLES_ANY_UOPS] - [IDQ.ALL_MITE_CYCLES_4_UOPS] ) / ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) / 2 )"
     },
     {
-        "name": "metric_TMA_....DSB(%)",
+        "name": "TMA_....DSB(%)",
         "expression": "100 * ( ( [IDQ.ALL_DSB_CYCLES_ANY_UOPS] - [IDQ.ALL_DSB_CYCLES_4_UOPS] ) / ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) / 2 )"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100 * ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100 * ( ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( ( [BR_MISP_RETIRED.ALL_BRANCHES] / ( [BR_MISP_RETIRED.ALL_BRANCHES] + [MACHINE_CLEARS.COUNT] ) ) * ( ( [UOPS_ISSUED.ANY] - ( [UOPS_RETIRED.RETIRE_SLOTS] ) + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( 1 - ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( [UOPS_ISSUED.ANY] + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100 * ( ( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] + [EXE_ACTIVITY.BOUND_ON_STORES] ) / ( [CYCLE_ACTIVITY.STALLS_TOTAL] + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) + [EXE_ACTIVITY.BOUND_ON_STORES] ) ) * ( 1 - ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( [UOPS_ISSUED.ANY] + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100 * ( max( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] - [CYCLE_ACTIVITY.STALLS_L1D_MISS] ) / ( [cpu-cycles] ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_......DTLB_Load(%)",
+        "name": "TMA_......DTLB_Load(%)",
         "expression": "100 * ( min( ( 9 ) * [DTLB_LOAD_MISSES.STLB_HIT:c1] + [DTLB_LOAD_MISSES.WALK_ACTIVE] , max( [CYCLE_ACTIVITY.CYCLES_MEM_ANY] - [CYCLE_ACTIVITY.CYCLES_L1D_MISS] , 0 ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Lock_Latency(%)",
+        "name": "TMA_......Lock_Latency(%)",
         "expression": "100 * ( min( ( ( 12 * max( 0 , [MEM_INST_RETIRED.LOCK_LOADS] - [L2_RQSTS.ALL_RFO] ) + ( [MEM_INST_RETIRED.LOCK_LOADS] / [MEM_INST_RETIRED.ALL_STORES] ) * ( ( 11 ) * [L2_RQSTS.RFO_HIT] + ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_RFO] ) ) ) ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100 * ( ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) / ( ( [MEM_LOAD_RETIRED.L2_HIT] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + [L1D_PEND_MISS.FB_FULL:c1] ) ) * ( ( [CYCLE_ACTIVITY.STALLS_L1D_MISS] - [CYCLE_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100 * ( ( [CYCLE_ACTIVITY.STALLS_L2_MISS] - [CYCLE_ACTIVITY.STALLS_L3_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Data_Sharing(%)",
+        "name": "TMA_......Data_Sharing(%)",
         "expression": "100 * ( min( ( ( ( 47.5 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) - ( 3.5 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) ) * ( [MEM_LOAD_L3_HIT_RETIRED.XSNP_HIT] + [MEM_LOAD_L3_HIT_RETIRED.XSNP_HITM] * ( 1 - ( [OCR.DEMAND_DATA_RD.L3_HIT.HITM_OTHER_CORE] / ( [OCR.DEMAND_DATA_RD.L3_HIT.HITM_OTHER_CORE] + [OCR.DEMAND_DATA_RD.L3_HIT.HIT_OTHER_CORE_FWD] ) ) ) ) * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) / 2 ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....MEM_Bound(%)",
-        "expression": "100 * [CYCLE_ACTIVITY.STALLS_L3_MISS]  / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "TMA_....MEM_Bound(%)",
+        "expression": "100 * [CYCLE_ACTIVITY.STALLS_L3_MISS]  / [cpu-cycles]"
     },
     {
-        "name": "metric_TMA_......MEM_Bandwidth(%)",
-        "expression": "100 * min([OFFCORE_REQUESTS_OUTSTANDING.L3_MISS_DEMAND_DATA_RD_GE_6] , [cpu-cycles]) / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "TMA_......MEM_Bandwidth(%)",
+        "expression": "100 * min([OFFCORE_REQUESTS_OUTSTANDING.L3_MISS_DEMAND_DATA_RD_GE_6] , [cpu-cycles]) / [cpu-cycles]"
     },
     {
-        "name": "metric_TMA_......MEM_Latency(%)",
-        "expression": "100 * (min([OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_L3_MISS_DEMAND_DATA_RD] , [cpu-cycles]) - min([OFFCORE_REQUESTS_OUTSTANDING.L3_MISS_DEMAND_DATA_RD_GE_6] , [cpu-cycles]))/ [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "TMA_......MEM_Latency(%)",
+        "expression": "100 * (min([OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_L3_MISS_DEMAND_DATA_RD] , [cpu-cycles]) - min([OFFCORE_REQUESTS_OUTSTANDING.L3_MISS_DEMAND_DATA_RD_GE_6] , [cpu-cycles]))/ [cpu-cycles]"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100 * ( [EXE_ACTIVITY.BOUND_ON_STORES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......False_Sharing(%)",
+        "name": "TMA_......False_Sharing(%)",
         "expression": "100 * ( min( ( ( ( 110 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) * ( [OCR.DEMAND_RFO.L3_MISS.REMOTE_HITM] + [OCR.PF_L2_RFO.L3_MISS.REMOTE_HITM] ) + ( 47.5 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) * ( [OCR.DEMAND_RFO.L3_HIT.HITM_OTHER_CORE] + [OCR.PF_L2_RFO.L3_HIT.HITM_OTHER_CORE] ) ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100 * ( ( 1 - ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( [UOPS_ISSUED.ANY] + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( ( ( [CYCLE_ACTIVITY.STALLS_MEM_ANY] + [EXE_ACTIVITY.BOUND_ON_STORES] ) / ( [CYCLE_ACTIVITY.STALLS_TOTAL] + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) + [EXE_ACTIVITY.BOUND_ON_STORES] ) ) * ( 1 - ( [IDQ_UOPS_NOT_DELIVERED.CORE] / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( [UOPS_ISSUED.ANY] + ( 4 ) * ( ( [INT_MISC.RECOVERY_CYCLES_ANY] / 2 ) if [HYPERTHREADING_ON] else [INT_MISC.RECOVERY_CYCLES] ) ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Ports_Utilization(%)",
+        "name": "TMA_....Ports_Utilization(%)",
         "expression": "100 * ( ( [EXE_ACTIVITY.EXE_BOUND_0_PORTS] + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) ) / ( [cpu-cycles] ) if ( [ARITH.DIVIDER_ACTIVE] < ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [CYCLE_ACTIVITY.STALLS_MEM_ANY] ) ) else ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) * [EXE_ACTIVITY.2_PORTS_UTIL] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_0(%)",
-        "expression": "100 * (([UOPS_EXECUTED.CORE_CYCLES_NONE] / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.EXE_BOUND_0_PORTS]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_0(%)",
+        "expression": "100 * (([UOPS_EXECUTED.CORE_CYCLES_NONE] / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.EXE_BOUND_0_PORTS]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_1(%)",
-        "expression": "100 * ((([UOPS_EXECUTED.CORE_CYCLES_GE_1] - [UOPS_EXECUTED.CORE_CYCLES_GE_2]) / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.1_PORTS_UTIL]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_1(%)",
+        "expression": "100 * ((([UOPS_EXECUTED.CORE_CYCLES_GE_1] - [UOPS_EXECUTED.CORE_CYCLES_GE_2]) / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.1_PORTS_UTIL]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_2(%)",
-        "expression": "100 * ((([UOPS_EXECUTED.CORE_CYCLES_GE_2] - [UOPS_EXECUTED.CORE_CYCLES_GE_3]) / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.2_PORTS_UTIL]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_2(%)",
+        "expression": "100 * ((([UOPS_EXECUTED.CORE_CYCLES_GE_2] - [UOPS_EXECUTED.CORE_CYCLES_GE_3]) / 2) if ([CONST_THREAD_COUNT] > 1) else [EXE_ACTIVITY.2_PORTS_UTIL]) / ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_3m(%)",
-        "expression": "100 * [UOPS_EXECUTED.CORE_CYCLES_GE_3] / [CPU_CLK_UNHALTED.THREAD_ANY]",
-        "origin": "perfspect"
+        "name": "TMA_......Ports_Utilized_3m(%)",
+        "expression": "100 * [UOPS_EXECUTED.CORE_CYCLES_GE_3] / [CPU_CLK_UNHALTED.THREAD_ANY]"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Light_Operations(%)",
+        "name": "TMA_..Light_Operations(%)",
         "expression": "100 * ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) - ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) + [UOPS_RETIRED.MACRO_FUSED] - [instructions] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....FP_Arith(%)",
+        "name": "TMA_....FP_Arith(%)",
         "expression": "100 * ( ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) ) * [UOPS_EXECUTED.X87] / [UOPS_EXECUTED.THREAD] ) + ( ( [FP_ARITH_INST_RETIRED.SCALAR_SINGLE:u0x03] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) ) + ( min( ( ( [FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE:u0xfc] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) ) , ( 1 ) ) ) )"
     },
     {
-        "name": "metric_TMA_......FP_Scalar(%)",
+        "name": "TMA_......FP_Scalar(%)",
         "expression": "100 * ( ( [FP_ARITH_INST_RETIRED.SCALAR_SINGLE:u0x03] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_......FP_Vector(%)",
+        "name": "TMA_......FP_Vector(%)",
         "expression": "100 * ( min( ( ( [FP_ARITH_INST_RETIRED.128B_PACKED_DOUBLE:u0xfc] ) / ( [UOPS_RETIRED.RETIRE_SLOTS] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_..Heavy_Operations(%)",
+        "name": "TMA_..Heavy_Operations(%)",
         "expression": "100 * ( ( ( [UOPS_RETIRED.RETIRE_SLOTS] ) + [UOPS_RETIRED.MACRO_FUSED] - [instructions] ) / ( ( 4 ) * ( ( [CPU_CLK_UNHALTED.THREAD_ANY] / 2 ) if [HYPERTHREADING_ON] else ( [cpu-cycles] ) ) ) )"
     },
     {
-        "name": "metric_TMA_..Microcode_Sequencer(%)",
-        "expression": "100 * (([UOPS_RETIRED.RETIRE_SLOTS] / [UOPS_ISSUED.ANY]) * [IDQ.MS_UOPS] / (4 * ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])))",
-        "origin": "perfspect"
+        "name": "TMA_..Microcode_Sequencer(%)",
+        "expression": "100 * (([UOPS_RETIRED.RETIRE_SLOTS] / [UOPS_ISSUED.ANY]) * [IDQ.MS_UOPS] / (4 * ([CPU_CLK_UNHALTED.THREAD_ANY] / [CONST_THREAD_COUNT])))"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/spr.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/spr.json
@@ -1,404 +1,426 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycle",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[TXN] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_giga_instructions_per_sec",
-        "expression": "[instructions] / 1000000000",
-        "origin": "perfspect"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_branch misprediction ratio",
-        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]",
-        "origin": "perfspect"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]",
-        "origin": "perfmon website"
+        "name": "txn per cycle",
+        "expression": "[TXN] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1D MPI (includes data+rfo w/ prefetches)",
-        "name-txn": "metric_L1D misses per txn (includes data+rfo w/ prefetches)",
-        "expression": "[L1D.REPLACEMENT] / [instructions]",
-        "expression-txn": "[L1D.REPLACEMENT] / [TXN]"
+        "name": "giga_instructions_per_sec",
+        "expression": "[instructions] / 1000000000"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+        "name": "branch misprediction ratio",
+        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1I code read misses (includes prefetches) per txn",
-        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]",
-        "expression-txn": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[L2_LINES_IN.ALL] / [instructions]",
-        "expression-txn": "[L2_LINES_IN.ALL] / [TXN]"
+        "name": "L1D MPI (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read MPI",
-        "name-txn": "metric_L2 demand data read misses per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+        "name": "L1D misses per txn (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [TXN]"
     },
     {
-        "name": "metric_L2 demand code MPI",
-        "name-txn": "metric_L2 demand code misses per txn",
-        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]",
-        "expression-txn": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [instructions]",
-        "expression-txn": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [TXN]"
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]"
     },
     {
-        "name": "metric_LLC total HITM (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]",
-        "origin": "perfspect"
+        "name": "L1I code read misses (includes prefetches) per txn",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]",
-        "origin": "perfspect"
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency (in ns)",
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+    },
+    {
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [instructions]"
+    },
+    {
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read MPI",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand data read misses per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+    },
+    {
+        "name": "L2 demand code MPI",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand code misses per txn",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+    },
+    {
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [instructions]"
+    },
+    {
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [TXN]"
+    },
+    {
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]"
+    },
+    {
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+    },
+    {
+        "name": "LLC total HITM (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]"
+    },
+    {
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+    },
+    {
+        "name": "Average LLC demand data read miss latency (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for LOCAL requests (in ns)",
+        "name": "Average LLC demand data read miss latency for LOCAL requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_LOCAL] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for REMOTE requests (in ns)",
+        "name": "Average LLC demand data read miss latency for REMOTE requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_REMOTE] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_UPI Data transmit BW (MB/sec) (only data)",
+        "name": "UPI Data transmit BW (MB/sec) (only data)",
         "expression": "([UNC_UPI_TxL_FLITS.ALL_DATA] * (64 / 9.0) / 1000000) / 1"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
-        "expression": "[power/energy-ram/]",
-        "origin": "perfspect"
+        "name": "DRAM power (watts)",
+        "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
-        "expression": "100 * [cstate_core/c6-residency/] / [TSC]",
-        "origin": "perfspect"
+        "name": "core c6 residency %",
+        "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
-        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]",
-        "origin": "perfspect"
+        "name": "package c6 residency %",
+        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_% Uops delivered from decoded Icache (DSB)",
+        "name": "% Uops delivered from decoded Icache (DSB)",
         "expression": "100 * ([IDQ.DSB_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_% Uops delivered from legacy decode pipeline (MITE)",
+        "name": "% Uops delivered from legacy decode pipeline (MITE)",
         "expression": "100 * ([IDQ.MITE_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_core initiated local dram read bandwidth (MB/sec)",
-        "expression": "([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated local dram read bandwidth (MB/sec)",
+        "expression": "([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000"
     },
     {
-        "name": "metric_core initiated remote dram read bandwidth (MB/sec)",
-        "expression": "([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated remote dram read bandwidth (MB/sec)",
+        "expression": "([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.RD] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.WR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT.RD] + [UNC_M_CAS_COUNT.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_ITLB (2nd level) MPI",
-        "name-txn": "metric_ITLB (2nd level) misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) load MPI",
-        "name-txn": "metric_DTLB (2nd level) load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB (2nd level) 2MB large page load MPI",
-        "name-txn": "metric_DTLB (2nd level) 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "DTLB (2nd level) load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) store MPI",
-        "name-txn": "metric_DTLB (2nd level) store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "DTLB (2nd level) load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to local DRAM",
+        "name": "DTLB (2nd level) 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB (2nd level) store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "NUMA %_Reads addressed to local DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to remote DRAM",
+        "name": "NUMA %_Reads addressed to remote DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_writes (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_writes (MB/sec)",
         "expression": "([UNC_CHA_TOR_INSERTS.IO_PCIRDCUR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_reads (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_reads (MB/sec)",
         "expression": "(([UNC_CHA_TOR_INSERTS.IO_ITOM] + [UNC_CHA_TOR_INSERTS.IO_ITOMCACHENEAR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Latency(%)",
+        "name": "TMA_..Fetch_Latency(%)",
         "expression": "100 * ( ( [PERF_METRICS.FETCH_LATENCY] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) )"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( [ICACHE_DATA.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( [ICACHE_TAG.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....Branch_Resteers(%)",
+        "name": "TMA_....Branch_Resteers(%)",
         "expression": "100 * ( [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) + ( [INT_MISC.UNKNOWN_BRANCH_CYCLES] / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_......Mispredicts_Resteers(%)",
+        "name": "TMA_......Mispredicts_Resteers(%)",
         "expression": "100 * ( ( ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) / ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Clears_Resteers(%)",
+        "name": "TMA_......Clears_Resteers(%)",
         "expression": "100 * ( ( 1 - ( ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) / ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) ) ) * [INT_MISC.CLEAR_RESTEER_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Unknown_Branches(%)",
+        "name": "TMA_......Unknown_Branches(%)",
         "expression": "100 * ( [INT_MISC.UNKNOWN_BRANCH_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Bandwidth(%)",
+        "name": "TMA_..Fetch_Bandwidth(%)",
         "expression": "100 * ( max( 0 , ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) - ( ( [PERF_METRICS.FETCH_LATENCY] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) ) ) )"
     },
     {
-        "name": "metric_TMA_....MITE(%)",
+        "name": "TMA_....MITE(%)",
         "expression": "100 * ( ( [IDQ.MITE_CYCLES_ANY] - [IDQ.MITE_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_....DSB(%)",
+        "name": "TMA_....DSB(%)",
         "expression": "100 * ( ( [IDQ.DSB_CYCLES_ANY] - [IDQ.DSB_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100 * ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100 * ( max( 0 , ( max( 1 - ( ( [PERF_METRICS.FRONTEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) - [INT_MISC.UOP_DROPPING] / ( [TOPDOWN.SLOTS] ) ) + ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) , 0 ) ) - ( [PERF_METRICS.BRANCH_MISPREDICTS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) )"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100 * ( [PERF_METRICS.MEMORY_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100 * ( max( ( [EXE_ACTIVITY.BOUND_ON_LOADS] - [MEMORY_ACTIVITY.STALLS_L1D_MISS] ) / ( [cpu-cycles] ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_......DTLB_Load(%)",
+        "name": "TMA_......DTLB_Load(%)",
         "expression": "100 * ( min( ( 7 ) * [DTLB_LOAD_MISSES.STLB_HIT:c1] + [DTLB_LOAD_MISSES.WALK_ACTIVE] , max( [CYCLE_ACTIVITY.CYCLES_MEM_ANY] - [MEMORY_ACTIVITY.CYCLES_L1D_MISS] , 0 ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Lock_Latency(%)",
+        "name": "TMA_......Lock_Latency(%)",
         "expression": "100 * ( min( ( ( 16 * max( 0 , [MEM_INST_RETIRED.LOCK_LOADS] - [L2_RQSTS.ALL_RFO] ) + ( [MEM_INST_RETIRED.LOCK_LOADS] / [MEM_INST_RETIRED.ALL_STORES] ) * ( ( 10 ) * [L2_RQSTS.RFO_HIT] + ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DEMAND_RFO] ) ) ) ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L1D_MISS] - [MEMORY_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L2_MISS] - [MEMORY_ACTIVITY.STALLS_L3_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Data_Sharing(%)",
+        "name": "TMA_......Data_Sharing(%)",
         "expression": "100 * ( min( ( ( ( 79.5 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) - ( 4 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) ) * ( [MEM_LOAD_L3_HIT_RETIRED.XSNP_NO_FWD] + [MEM_LOAD_L3_HIT_RETIRED.XSNP_FWD] * ( 1 - ( [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HITM] / ( [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HITM] + [OCR.DEMAND_DATA_RD.L3_HIT.SNOOP_HIT_WITH_FWD] ) ) ) ) * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) / 2 ) / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_....DRAM_Bound(%)",
+        "name": "TMA_....DRAM_Bound(%)",
         "expression": "100 * ( min( ( ( ( [MEMORY_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) ) - ( min( ( ( ( ( 1 - ( ( ( 19 * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + 10 * ( ( [MEM_LOAD_L3_MISS_RETIRED.LOCAL_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_FWD] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_HITM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) / ( ( 19 * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + 10 * ( ( [MEM_LOAD_L3_MISS_RETIRED.LOCAL_DRAM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_FWD] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) + ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_HITM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) + ( 25 * ( ( [MEM_LOAD_RETIRED.LOCAL_PMM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) + 33 * ( ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_PMM] * ( 1 + ( [MEM_LOAD_RETIRED.FB_HIT] / [MEM_LOAD_RETIRED.L1_MISS] ) ) ) ) ) ) ) ) ) * ( [MEMORY_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) ) ) if ( ( 1000000 ) * ( [MEM_LOAD_L3_MISS_RETIRED.REMOTE_PMM] + [MEM_LOAD_RETIRED.LOCAL_PMM] ) > [MEM_LOAD_RETIRED.L1_MISS] ) else 0 ) ) , ( 1 ) ) ) ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_......MEM_Bandwidth(%)",
+        "name": "TMA_......MEM_Bandwidth(%)",
         "expression": "100 * ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.DATA_RD:c4] ) ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......MEM_Latency(%)",
+        "name": "TMA_......MEM_Latency(%)",
         "expression": "100 * ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.CYCLES_WITH_DATA_RD] ) ) / ( [cpu-cycles] ) - ( ( min( [cpu-cycles] , [OFFCORE_REQUESTS_OUTSTANDING.DATA_RD:c4] ) ) / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100 * ( [EXE_ACTIVITY.BOUND_ON_STORES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......False_Sharing(%)",
+        "name": "TMA_......False_Sharing(%)",
         "expression": "100 * ( min( ( ( 80 * ( ( ( [cpu-cycles] ) / [ref-cycles] ) * [SYSTEM_TSC_FREQ] / ( 1000000000 ) / ( 1000 / 1000 ) ) ) * [OCR.DEMAND_RFO.L3_HIT.SNOOP_HITM] / ( [cpu-cycles] ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100 * ( max( 0 , ( [PERF_METRICS.BACKEND_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) - ( [PERF_METRICS.MEMORY_BOUND] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Ports_Utilization(%)",
+        "name": "TMA_....Ports_Utilization(%)",
         "expression": "100 * ( ( [EXE_ACTIVITY.3_PORTS_UTIL:u0x80] + ( [RESOURCE_STALLS.SCOREBOARD] / ( [cpu-cycles] ) ) * ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [EXE_ACTIVITY.BOUND_ON_LOADS] ) + ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * [EXE_ACTIVITY.2_PORTS_UTIL:u0xc] ) ) / ( [cpu-cycles] ) if ( [ARITH.DIV_ACTIVE] < ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [EXE_ACTIVITY.BOUND_ON_LOADS] ) ) else ( [EXE_ACTIVITY.1_PORTS_UTIL] + ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * [EXE_ACTIVITY.2_PORTS_UTIL:u0xc] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_0(%)",
+        "name": "TMA_......Ports_Utilized_0(%)",
         "expression": "100 * ( [EXE_ACTIVITY.3_PORTS_UTIL:u0x80] / ( [cpu-cycles] ) + ( [RESOURCE_STALLS.SCOREBOARD] / ( [cpu-cycles] ) ) * ( [CYCLE_ACTIVITY.STALLS_TOTAL] - [EXE_ACTIVITY.BOUND_ON_LOADS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_........AMX_Busy(%)",
+        "name": "TMA_........AMX_Busy(%)",
         "expression": "100 * ( [EXE.AMX_BUSY] / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_1(%)",
+        "name": "TMA_......Ports_Utilized_1(%)",
         "expression": "100 * ( [EXE_ACTIVITY.1_PORTS_UTIL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_2(%)",
+        "name": "TMA_......Ports_Utilized_2(%)",
         "expression": "100 * ( [EXE_ACTIVITY.2_PORTS_UTIL] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_......Ports_Utilized_3m(%)",
+        "name": "TMA_......Ports_Utilized_3m(%)",
         "expression": "100 * ( [UOPS_EXECUTED.CYCLES_GE_3] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_..Light_Operations(%)",
+        "name": "TMA_..Light_Operations(%)",
         "expression": "100 * ( max( 0 , ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) - ( [PERF_METRICS.HEAVY_OPERATIONS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) ) )"
     },
     {
-        "name": "metric_TMA_........FP_Vector_256b(%)",
+        "name": "TMA_........FP_Vector_256b(%)",
         "expression": "100 * ( min( ( ( [FP_ARITH_INST_RETIRED.256B_PACKED_DOUBLE] + [FP_ARITH_INST_RETIRED.256B_PACKED_SINGLE] + [FP_ARITH_INST_RETIRED2.256B_PACKED_HALF] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_........FP_Vector_512b(%)",
+        "name": "TMA_........FP_Vector_512b(%)",
         "expression": "100 * ( min( ( ( [FP_ARITH_INST_RETIRED.512B_PACKED_DOUBLE] + [FP_ARITH_INST_RETIRED.512B_PACKED_SINGLE] + [FP_ARITH_INST_RETIRED2.512B_PACKED_HALF] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) ) , ( 1 ) ) )"
     },
     {
-        "name": "metric_TMA_......Int_Vector_256b(%)",
+        "name": "TMA_......Int_Vector_256b(%)",
         "expression": "100 * ( ( [INT_VEC_RETIRED.ADD_256] + [INT_VEC_RETIRED.MUL_256] + [INT_VEC_RETIRED.VNNI_256] ) / ( ( [PERF_METRICS.RETIRING] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) ) * ( [TOPDOWN.SLOTS] ) ) )"
     },
     {
-        "name": "metric_TMA_..Heavy_Operations(%)",
+        "name": "TMA_..Heavy_Operations(%)",
         "expression": "100 * ( [PERF_METRICS.HEAVY_OPERATIONS] / ( [PERF_METRICS.FRONTEND_BOUND] + [PERF_METRICS.BAD_SPECULATION] + [PERF_METRICS.RETIRING] + [PERF_METRICS.BACKEND_BOUND] ) )"
     },
     {
-        "name": "metric_TMA_....Microcode_Sequencer(%)",
+        "name": "TMA_....Microcode_Sequencer(%)",
         "expression": "100 * ( [UOPS_RETIRED.MS] / ( [TOPDOWN.SLOTS] ) )"
     },
     {
-        "name": "metric_TMA_Info_Thread_IPC",
-        "expression": "[instructions] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "TMA_Info_Thread_IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_TMA_Info_System_SMT_2T_Utilization",
-        "expression": "(1 - [CPU_CLK_UNHALTED.ONE_THREAD_ACTIVE] / [CPU_CLK_UNHALTED.REF_DISTRIBUTED]) if [SOCKET_COUNT] > 1 else 0",
-        "origin": "perfspect"
+        "name": "TMA_Info_System_SMT_2T_Utilization",
+        "expression": "(1 - [CPU_CLK_UNHALTED.ONE_THREAD_ACTIVE] / [CPU_CLK_UNHALTED.REF_DISTRIBUTED]) if [SOCKET_COUNT] > 1 else 0"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/spr_nofixedtma.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/spr_nofixedtma.json
@@ -1,354 +1,378 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycle",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[TXN] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_giga_instructions_per_sec",
-        "expression": "[instructions] / 1000000000",
-        "origin": "perfspect"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_branch misprediction ratio",
-        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]",
-        "origin": "perfspect"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]",
-        "origin": "perfmon website"
+        "name": "txn per cycle",
+        "expression": "[TXN] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1D MPI (includes data+rfo w/ prefetches)",
-        "name-txn": "metric_L1D misses per txn (includes data+rfo w/ prefetches)",
-        "expression": "[L1D.REPLACEMENT] / [instructions]",
-        "expression-txn": "[L1D.REPLACEMENT] / [TXN]"
+        "name": "giga_instructions_per_sec",
+        "expression": "[instructions] / 1000000000"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
+        "name": "branch misprediction ratio",
+        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1I code read misses (includes prefetches) per txn",
-        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]",
-        "expression-txn": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[L2_LINES_IN.ALL] / [instructions]",
-        "expression-txn": "[L2_LINES_IN.ALL] / [TXN]"
+        "name": "L1D MPI (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read MPI",
-        "name-txn": "metric_L2 demand data read misses per txn",
-        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]",
-        "expression-txn": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+        "name": "L1D misses per txn (includes data+rfo w/ prefetches)",
+        "expression": "[L1D.REPLACEMENT] / [TXN]"
     },
     {
-        "name": "metric_L2 demand code MPI",
-        "name-txn": "metric_L2 demand code misses per txn",
-        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]",
-        "expression-txn": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [instructions]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [instructions]",
-        "expression-txn": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [TXN]"
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L1_HIT] / [TXN]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [instructions]"
     },
     {
-        "name": "metric_LLC total HITM (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]",
-        "origin": "perfspect"
+        "name": "L1I code read misses (includes prefetches) per txn",
+        "expression": "[L2_RQSTS.ALL_CODE_RD] / [TXN]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]",
-        "origin": "perfspect"
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [instructions]"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency (in ns)",
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_HIT] / [TXN]"
+    },
+    {
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [instructions]"
+    },
+    {
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[L2_LINES_IN.ALL] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read MPI",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand data read misses per txn",
+        "expression": "[MEM_LOAD_RETIRED.L2_MISS] / [TXN]"
+    },
+    {
+        "name": "L2 demand code MPI",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 demand code misses per txn",
+        "expression": "[L2_RQSTS.CODE_RD_MISS] / [TXN]"
+    },
+    {
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [instructions]"
+    },
+    {
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "[UNC_CHA_TOR_INSERTS.IA_MISS_CRD] / [TXN]"
+    },
+    {
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [instructions]"
+    },
+    {
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF]) / [TXN]"
+    },
+    {
+        "name": "LLC total HITM (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]"
+    },
+    {
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards (per instr) (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+    },
+    {
+        "name": "Average LLC demand data read miss latency (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for LOCAL requests (in ns)",
+        "name": "Average LLC demand data read miss latency for LOCAL requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_LOCAL] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency for REMOTE requests (in ns)",
+        "name": "Average LLC demand data read miss latency for REMOTE requests (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_REMOTE] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_UPI Data transmit BW (MB/sec) (only data)",
+        "name": "UPI Data transmit BW (MB/sec) (only data)",
         "expression": "([UNC_UPI_TxL_FLITS.ALL_DATA] * (64 / 9.0) / 1000000) / 1"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
-        "expression": "[power/energy-ram/]",
-        "origin": "perfspect"
+        "name": "DRAM power (watts)",
+        "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
-        "expression": "100 * [cstate_core/c6-residency/] / [TSC]",
-        "origin": "perfspect"
+        "name": "core c6 residency %",
+        "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
-        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]",
-        "origin": "perfspect"
+        "name": "package c6 residency %",
+        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_% Uops delivered from decoded Icache (DSB)",
+        "name": "% Uops delivered from decoded Icache (DSB)",
         "expression": "100 * ([IDQ.DSB_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_% Uops delivered from legacy decode pipeline (MITE)",
+        "name": "% Uops delivered from legacy decode pipeline (MITE)",
         "expression": "100 * ([IDQ.MITE_UOPS] / ([IDQ.DSB_UOPS] + [IDQ.MITE_UOPS] + [IDQ.MS_UOPS] + [LSD.UOPS]) )"
     },
     {
-        "name": "metric_core initiated local dram read bandwidth (MB/sec)",
-        "expression": "([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated local dram read bandwidth (MB/sec)",
+        "expression": "([OCR.READS_TO_CORE.LOCAL_DRAM] + [OCR.HWPF_L3.L3_MISS_LOCAL]) * 64 / 1000000"
     },
     {
-        "name": "metric_core initiated remote dram read bandwidth (MB/sec)",
-        "expression": "([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated remote dram read bandwidth (MB/sec)",
+        "expression": "([OCR.READS_TO_CORE.REMOTE_DRAM] + [OCR.HWPF_L3.REMOTE]) * 64 / 1000000"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.RD] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "([UNC_M_CAS_COUNT.WR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT.RD] + [UNC_M_CAS_COUNT.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_ITLB (2nd level) MPI",
-        "name-txn": "metric_ITLB (2nd level) misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) load MPI",
-        "name-txn": "metric_DTLB (2nd level) load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB (2nd level) 2MB large page load MPI",
-        "name-txn": "metric_DTLB (2nd level) 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "DTLB (2nd level) load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) store MPI",
-        "name-txn": "metric_DTLB (2nd level) store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "DTLB (2nd level) load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to local DRAM",
+        "name": "DTLB (2nd level) 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB (2nd level) store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "NUMA %_Reads addressed to local DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_NUMA %_Reads addressed to remote DRAM",
+        "name": "NUMA %_Reads addressed to remote DRAM",
         "expression": "100 * ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE]) / ([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_LOCAL] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_REMOTE] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_PREF_REMOTE])"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_writes (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_writes (MB/sec)",
         "expression": "([UNC_CHA_TOR_INSERTS.IO_PCIRDCUR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_reads (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_reads (MB/sec)",
         "expression": "(([UNC_CHA_TOR_INSERTS.IO_ITOM] + [UNC_CHA_TOR_INSERTS.IO_ITOMCACHENEAR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Latency(%)",
+        "name": "TMA_..Fetch_Latency(%)",
         "expression": "100 * ( ( [IDQ_BUBBLES.CYCLES_0_UOPS_DELIV.CORE] * ( 6 ) - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( [ICACHE_DATA.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( [ICACHE_TAG.STALLS] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....MS_Switches(%)",
+        "name": "TMA_....MS_Switches(%)",
         "expression": "100 * ( ( 3 ) * [UOPS_RETIRED.MS:c1:e1] / ( [UOPS_RETIRED.SLOTS] / [UOPS_ISSUED.ANY] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....LCP(%)",
+        "name": "TMA_....LCP(%)",
         "expression": "100 * ( [DECODE.LCP] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....DSB_Switches(%)",
+        "name": "TMA_....DSB_Switches(%)",
         "expression": "100 * ( [DSB2MITE_SWITCHES.PENALTY_CYCLES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Bandwidth(%)",
+        "name": "TMA_..Fetch_Bandwidth(%)",
         "expression": "100 * ( max( 0 , ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) - ( ( [IDQ_BUBBLES.CYCLES_0_UOPS_DELIV.CORE] * ( 6 ) - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....MITE(%)",
+        "name": "TMA_....MITE(%)",
         "expression": "100 * ( ( [IDQ.MITE_CYCLES_ANY] - [IDQ.MITE_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_....DSB(%)",
+        "name": "TMA_....DSB(%)",
         "expression": "100 * ( ( [IDQ.DSB_CYCLES_ANY] - [IDQ.DSB_CYCLES_OK] ) / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) / 2 )"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( max( 1 - ( ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( [TOPDOWN.BACKEND_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100 * ( [TOPDOWN.BR_MISPREDICT_SLOTS] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100 * ( max( 0 , ( max( 1 - ( ( ( [IDQ_UOPS_NOT_DELIVERED.CORE] - [INT_MISC.UOP_DROPPING] ) / ( [TOPDOWN.SLOTS_P] ) ) + ( [TOPDOWN.BACKEND_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) + ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) , 0 ) ) - ( [TOPDOWN.BR_MISPREDICT_SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( [TOPDOWN.BACKEND_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100 * ( [TOPDOWN.MEMORY_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100 * ( max( ( [EXE_ACTIVITY.BOUND_ON_LOADS] - [MEMORY_ACTIVITY.STALLS_L1D_MISS] ) / ( [cpu-cycles] ) , 0 ) )"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L1D_MISS] - [MEMORY_ACTIVITY.STALLS_L2_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L2_MISS] - [MEMORY_ACTIVITY.STALLS_L3_MISS] ) / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....DRAM_Bound(%)",
+        "name": "TMA_....DRAM_Bound(%)",
         "expression": "100 * ( ( [MEMORY_ACTIVITY.STALLS_L3_MISS] / ( [cpu-cycles] ) ) )"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100 * ( [EXE_ACTIVITY.BOUND_ON_STORES] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100 * ( max( 0 , ( [TOPDOWN.BACKEND_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( [TOPDOWN.MEMORY_BOUND_SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Divider(%)",
+        "name": "TMA_....Divider(%)",
         "expression": "100 * ( [ARITH.DIV_ACTIVE] / ( [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....AMX_Busy(%)",
+        "name": "TMA_....AMX_Busy(%)",
         "expression": "100 * ( [EXE.AMX_BUSY] / ( [CPU_CLK_UNHALTED.DISTRIBUTED] ) )"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_..Light_Operations(%)",
+        "name": "TMA_..Light_Operations(%)",
         "expression": "100 * ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Memory_Operations(%)",
+        "name": "TMA_....Memory_Operations(%)",
         "expression": "100 * ( ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) ) ) ) * [MEM_UOP_RETIRED.ANY] / ( ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [TOPDOWN.SLOTS_P] ) ) )"
     },
     {
-        "name": "metric_TMA_....Fused_Instructions(%)",
+        "name": "TMA_....Fused_Instructions(%)",
         "expression": "100 * ( ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) ) ) ) * [INST_RETIRED.MACRO_FUSED] / ( ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [TOPDOWN.SLOTS_P] ) ) )"
     },
     {
-        "name": "metric_TMA_....Non_Fused_Branches(%)",
+        "name": "TMA_....Non_Fused_Branches(%)",
         "expression": "100 * ( ( max( 0 , ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) - ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) ) ) ) * ( [BR_INST_RETIRED.ALL_BRANCHES] - [INST_RETIRED.MACRO_FUSED] ) / ( ( [UOPS_RETIRED.SLOTS] / ( [TOPDOWN.SLOTS_P] ) ) * ( [TOPDOWN.SLOTS_P] ) ) )"
     },
     {
-        "name": "metric_TMA_..Heavy_Operations(%)",
+        "name": "TMA_..Heavy_Operations(%)",
         "expression": "100 * ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) )"
     },
     {
-        "name": "metric_TMA_....Few_Uops_Instructions(%)",
+        "name": "TMA_....Few_Uops_Instructions(%)",
         "expression": "100 * ( max( 0 , ( [UOPS_RETIRED.HEAVY] / ( [TOPDOWN.SLOTS_P] ) ) - ( [UOPS_RETIRED.MS] / ( [TOPDOWN.SLOTS_P] ) ) ) )"
     },
     {
-        "name": "metric_TMA_....Microcode_Sequencer(%)",
+        "name": "TMA_....Microcode_Sequencer(%)",
         "expression": "100 * ( [UOPS_RETIRED.MS] / ( [TOPDOWN.SLOTS_P] ) )"
     }
 ]

--- a/cmd/metrics/resources/metrics/x86_64/GenuineIntel/srf.json
+++ b/cmd/metrics/resources/metrics/x86_64/GenuineIntel/srf.json
@@ -1,310 +1,350 @@
 [
     {
-        "name": "metric_CPU operating frequency (in GHz)",
+        "name": "CPU operating frequency (in GHz)",
         "expression": "(([cpu-cycles] / [ref-cycles] * [SYSTEM_TSC_FREQ]) / 1000000000)"
     },
     {
-        "name": "metric_CPU utilization %",
+        "name": "CPU utilization %",
         "expression": "100 * [ref-cycles] / [TSC]"
     },
     {
-        "name": "metric_CPU utilization% in kernel mode",
-        "expression": "100 * [ref-cycles:k] / [TSC]",
-        "origin": "perfspect"
+        "name": "CPU utilization% in kernel mode",
+        "expression": "100 * [ref-cycles:k] / [TSC]"
     },
     {
-        "name": "metric_CPI",
-        "name-txn": "metric_cycles per txn",
-        "expression": "[cpu-cycles] / [instructions]",
-        "expression-txn": "[cpu-cycles] / [TXN]"
+        "name": "CPI",
+        "expression": "[cpu-cycles] / [instructions]"
     },
     {
-        "name": "metric_kernel_CPI",
-        "name-txn": "metric_kernel_cycles per txn",
-        "expression": "[cpu-cycles:k] / [instructions:k]",
-        "expression-txn": "[cpu-cycles:k] / [TXN]",
-        "origin": "perfspect"
+        "name": "cycles per txn",
+        "expression": "[cpu-cycles] / [TXN]"
     },
     {
-        "name": "metric_IPC",
-        "name-txn": "metric_txn per cycle",
-        "expression": "[instructions] / [cpu-cycles]",
-        "expression-txn": "[TXN] / [cpu-cycles]",
-        "origin": "perfspect"
+        "name": "kernel_CPI",
+        "expression": "[cpu-cycles:k] / [instructions:k]"
     },
     {
-        "name": "metric_giga_instructions_per_sec",
-        "expression": "[instructions] / 1000000000",
-        "origin": "perfspect"
+        "name": "kernel_cycles per txn",
+        "expression": "[cpu-cycles:k] / [TXN]"
     },
     {
-        "name": "metric_branch misprediction ratio",
-        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]",
-        "origin": "perfspect"
+        "name": "IPC",
+        "expression": "[instructions] / [cpu-cycles]"
     },
     {
-        "name": "metric_locks retired per instr",
-        "name-txn": "metric_locks retired per txn",
-        "expression": "[MEM_UOPS_RETIRED.LOCK_LOADS] / [instructions]",
-        "expression-txn": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
+        "name": "txn per cycle",
+        "expression": "[TXN] / [cpu-cycles]"
     },
     {
-        "name": "metric_L1D demand data read MPI",
-        "name-txn": "metric_L1D demand data read misses per txn",
-        "expression": "[MEM_LOAD_UOPS_RETIRED.L1_MISS] / [instructions]",
-        "expression-txn": "[MEM_LOAD_UOPS_RETIRED.L1_MISS] / [TXN]"
+        "name": "giga_instructions_per_sec",
+        "expression": "[instructions] / 1000000000"
     },
     {
-        "name": "metric_L1D demand data read hits per instr",
-        "name-txn": "metric_L1D demand data read hits per txn",
-        "expression": "[MEM_LOAD_UOPS_RETIRED.L1_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_UOPS_RETIRED.L1_HIT] / [TXN]"
+        "name": "branch misprediction ratio",
+        "expression": "[BR_MISP_RETIRED.ALL_BRANCHES] / [BR_INST_RETIRED.ALL_BRANCHES]"
     },
     {
-        "name": "metric_L1-I code read misses (w/ prefetches) per instr",
-        "name-txn": "metric_L1-I code read misses (w/ prefetches) per txn",
-        "expression": "[ICACHE.MISSES] / [instructions]",
-        "expression-txn": "[ICACHE.MISSES] / [TXN]"
+        "name": "locks retired per instr",
+        "expression": "[MEM_UOPS_RETIRED.LOCK_LOADS] / [instructions]"
     },
     {
-        "name": "metric_L2 demand data read hits per instr",
-        "name-txn": "metric_L2 demand data read hits per txn",
-        "expression": "[MEM_LOAD_UOPS_RETIRED.L2_HIT] / [instructions]",
-        "expression-txn": "[MEM_LOAD_UOPS_RETIRED.L2_HIT] / [TXN]"
+        "name": "locks retired per txn",
+        "expression": "[MEM_INST_RETIRED.LOCK_LOADS] / [TXN]"
     },
     {
-        "name": "metric_L2 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L2 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[LONGEST_LAT_CACHE.REFERENCE] / [instructions]",
-        "expression-txn": "[LONGEST_LAT_CACHE.REFERENCE] / [TXN]"
+        "name": "L1D demand data read MPI",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L1_MISS] / [instructions]"
     },
     {
-        "name": "metric_L2 code MPI",
-        "name-txn": "metric_L2 code misses per txn",
-        "expression": "[OCR.L2_CODE_MISS] / [instructions]",
-        "expression-txn": "[OCR.L2_CODE_MISS] / [TXN]"
+        "name": "L1D demand data read misses per txn",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L1_MISS] / [TXN]"
     },
     {
-        "name": "metric_L2 Any local request that HITM in another module (per instr)",
-        "name-txn": "metric_L2 Any local request that HITM in another module per txn",
-        "expression": "[OCR.READS_TO_CORE.L3_HIT.SNOOP_HITM] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.L3_HIT.SNOOP_HITM] / [TXN]"
+        "name": "L1D demand data read hits per instr",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L1_HIT] / [instructions]"
     },
     {
-        "name": "metric_L2 Any local request that HIT in another module and forwarded(per instr)",
-        "name-txn": "metric_L2 Any local request that HIT in another module and forwarded per txn",
-        "expression": "[OCR.READS_TO_CORE.L3_HIT.SNOOP_HIT_WITH_FWD] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.L3_HIT.SNOOP_HIT_WITH_FWD] / [TXN]"
+        "name": "L1D demand data read hits per txn",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L1_HIT] / [TXN]"
     },
     {
-        "name": "metric_L2 all L2 prefetches(per instr)",
-        "name-txn": "metric_L2 all L2 prefetches per txn",
-        "expression": "[OCR.HWPF_L2.ANY_RESPONSE] / [instructions]",
-        "expression-txn": "[OCR.HWPF_L2.ANY_RESPONSE] / [TXN]"
+        "name": "L1-I code read misses (w/ prefetches) per instr",
+        "expression": "[ICACHE.MISSES] / [instructions]"
     },
     {
-        "name": "metric_data_read_L2_Miss_Latency_using_ORO_events(ns)",
+        "name": "L1-I code read misses (w/ prefetches) per txn",
+        "expression": "[ICACHE.MISSES] / [TXN]"
+    },
+    {
+        "name": "L2 demand data read hits per instr",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L2_HIT] / [instructions]"
+    },
+    {
+        "name": "L2 demand data read hits per txn",
+        "expression": "[MEM_LOAD_UOPS_RETIRED.L2_HIT] / [TXN]"
+    },
+    {
+        "name": "L2 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[LONGEST_LAT_CACHE.REFERENCE] / [instructions]"
+    },
+    {
+        "name": "L2 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[LONGEST_LAT_CACHE.REFERENCE] / [TXN]"
+    },
+    {
+        "name": "L2 code MPI",
+        "expression": "[OCR.L2_CODE_MISS] / [instructions]"
+    },
+    {
+        "name": "L2 code misses per txn",
+        "expression": "[OCR.L2_CODE_MISS] / [TXN]"
+    },
+    {
+        "name": "L2 Any local request that HITM in another module (per instr)",
+        "expression": "[OCR.READS_TO_CORE.L3_HIT.SNOOP_HITM] / [instructions]"
+    },
+    {
+        "name": "L2 Any local request that HITM in another module per txn",
+        "expression": "[OCR.READS_TO_CORE.L3_HIT.SNOOP_HITM] / [TXN]"
+    },
+    {
+        "name": "L2 Any local request that HIT in another module and forwarded(per instr)",
+        "expression": "[OCR.READS_TO_CORE.L3_HIT.SNOOP_HIT_WITH_FWD] / [instructions]"
+    },
+    {
+        "name": "L2 Any local request that HIT in another module and forwarded per txn",
+        "expression": "[OCR.READS_TO_CORE.L3_HIT.SNOOP_HIT_WITH_FWD] / [TXN]"
+    },
+    {
+        "name": "L2 all L2 prefetches(per instr)",
+        "expression": "[OCR.HWPF_L2.ANY_RESPONSE] / [instructions]"
+    },
+    {
+        "name": "L2 all L2 prefetches per txn",
+        "expression": "[OCR.HWPF_L2.ANY_RESPONSE] / [TXN]"
+    },
+    {
+        "name": "data_read_L2_Miss_Latency_using_ORO_events(ns)",
         "expression": "( 1000000000 * ([OCR.READS_TO_CORE.OUTSTANDING] / [OCR.READS_TO_CORE.ANY_RESPONSE]) / ([cpu-cycles] / [TSC] * [SYSTEM_TSC_FREQ]) )"
     },
     {
-        "name": "metric_L3 MPI (includes code+data+rfo w/ prefetches)",
-        "name-txn": "metric_L3 misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression": "[LONGEST_LAT_CACHE.MISS] / [instructions]",
-        "expression-txn": "[LONGEST_LAT_CACHE.MISS] / [TXN]"
+        "name": "L3 MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "[LONGEST_LAT_CACHE.MISS] / [instructions]"
     },
     {
-        "name": "metric_LLC MPI (includes code+data+rfo w/ prefetches)",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_RFO] + [UNC_CHA_TOR_INSERTS.IA_MISS_RFO_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFRFO]) / [instructions]",
-        "name-txn": "metric_LLC misses per txn (includes code+data+rfo w/ prefetches)",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_RFO] + [UNC_CHA_TOR_INSERTS.IA_MISS_RFO_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFRFO]) / [TXN]"
+        "name": "L3 misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "[LONGEST_LAT_CACHE.MISS] / [TXN]"
     },
     {
-        "name": "metric_LLC total HITM (per instr)",
-        "name-txn": "metric_LLC total HITM per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
+        "name": "LLC MPI (includes code+data+rfo w/ prefetches)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_RFO] + [UNC_CHA_TOR_INSERTS.IA_MISS_RFO_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFRFO]) / [instructions]"
     },
     {
-        "name": "metric_LLC total HIT clean line forwards (per instr)",
-        "name-txn": "metric_LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
-        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]",
-        "expression-txn": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+        "name": "LLC misses per txn (includes code+data+rfo w/ prefetches)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA] + [UNC_CHA_TOR_INSERTS.IA_MISS_RFO] + [UNC_CHA_TOR_INSERTS.IA_MISS_RFO_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFRFO]) / [TXN]"
     },
     {
-        "name": "metric_LLC data read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC data read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA]) / [TXN]"
+        "name": "LLC total HITM (per instr)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [instructions]"
     },
     {
-        "name": "metric_LLC code read MPI (demand+prefetch)",
-        "name-txn": "metric_LLC code read (demand+prefetch) misses per txn",
-        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [instructions]",
-        "expression-txn": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [TXN]"
+        "name": "LLC total HITM per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HITM] / [TXN]"
     },
     {
-        "name": "metric_Average LLC demand data read miss latency (in ns)",
+        "name": "LLC total HIT clean line forwards (per instr)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [instructions]"
+    },
+    {
+        "name": "LLC total HIT clean line forwards per txn (excludes LLC prefetches)",
+        "expression": "[OCR.READS_TO_CORE.REMOTE_CACHE.SNOOP_HIT_WITH_FWD] / [TXN]"
+    },
+    {
+        "name": "LLC data read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA]) / [instructions]"
+    },
+    {
+        "name": "LLC data read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT] + [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT_PREF] + [UNC_CHA_TOR_INSERTS.IA_MISS_LLCPREFDATA]) / [TXN]"
+    },
+    {
+        "name": "LLC code read MPI (demand+prefetch)",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [instructions]"
+    },
+    {
+        "name": "LLC code read (demand+prefetch) misses per txn",
+        "expression": "([UNC_CHA_TOR_INSERTS.IA_MISS_CRD] + [UNC_CHA_TOR_INSERTS.IA_MISS_CRD_PREF]) / [TXN]"
+    },
+    {
+        "name": "Average LLC demand data read miss latency (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_DRD_OPT] / [UNC_CHA_TOR_INSERTS.IA_MISS_DRD_OPT]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_Average LLC demand RFO miss latency (in ns)",
+        "name": "Average LLC demand RFO miss latency (in ns)",
         "expression": "( 1000000000 * ([UNC_CHA_TOR_OCCUPANCY.IA_MISS_RFO] / [UNC_CHA_TOR_INSERTS.IA_MISS_RFO]) / ([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) ) ) * 1"
     },
     {
-        "name": "metric_core initiated local dram read bandwidth (MB/sec)",
-        "expression": "([LONGEST_LAT_CACHE.MISS]) * 64 / 1000000",
-        "origin": "perfspect"
+        "name": "core initiated local dram read bandwidth (MB/sec)",
+        "expression": "([LONGEST_LAT_CACHE.MISS]) * 64 / 1000000"
     },
     {
-        "name": "metric_memory bandwidth read (MB/sec)",
+        "name": "memory bandwidth read (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT_SCH0.RD] + [UNC_M_CAS_COUNT_SCH1.RD]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth write (MB/sec)",
+        "name": "memory bandwidth write (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT_SCH0.WR] + [UNC_M_CAS_COUNT_SCH1.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_memory bandwidth total (MB/sec)",
+        "name": "memory bandwidth total (MB/sec)",
         "expression": "(([UNC_M_CAS_COUNT_SCH0.RD] + [UNC_M_CAS_COUNT_SCH1.RD] + [UNC_M_CAS_COUNT_SCH0.WR] + [UNC_M_CAS_COUNT_SCH1.WR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_writes (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_writes (MB/sec)",
         "expression": "([UNC_CHA_TOR_INSERTS.IO_PCIRDCUR] * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_IO_bandwidth_disk_or_network_reads (MB/sec)",
+        "name": "IO_bandwidth_disk_or_network_reads (MB/sec)",
         "expression": "(([UNC_CHA_TOR_INSERTS.IO_ITOM] + [UNC_CHA_TOR_INSERTS.IO_ITOMCACHENEAR]) * 64 / 1000000) / 1"
     },
     {
-        "name": "metric_package power (watts)",
-        "expression": "[power/energy-pkg/]",
-        "origin": "perfspect"
+        "name": "package power (watts)",
+        "expression": "[power/energy-pkg/]"
     },
     {
-        "name": "metric_DRAM power (watts)",
-        "expression": "[power/energy-ram/]",
-        "origin": "perfspect"
+        "name": "DRAM power (watts)",
+        "expression": "[power/energy-ram/]"
     },
     {
-        "name": "metric_core c6 residency %",
-        "expression": "100 * [cstate_core/c6-residency/] / [TSC]",
-        "origin": "perfspect"
+        "name": "core c6 residency %",
+        "expression": "100 * [cstate_core/c6-residency/] / [TSC]"
     },
     {
-        "name": "metric_package c6 residency %",
-        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]",
-        "origin": "perfspect"
+        "name": "package c6 residency %",
+        "expression": "100 * [cstate_pkg/c6-residency/] * [CORES_PER_SOCKET] / [TSC]"
     },
     {
-        "name": "metric_uncore frequency GHz",
+        "name": "uncore frequency GHz",
         "expression": "([UNC_CHA_CLOCKTICKS] / ([CHAS_PER_SOCKET] * [SOCKET_COUNT]) / 1000000000) / 1"
     },
     {
-        "name": "metric_ITLB (2nd level) MPI",
-        "name-txn": "metric_ITLB (2nd level) misses per txn",
-        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) MPI",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) load MPI",
-        "name-txn": "metric_DTLB (2nd level) load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "ITLB (2nd level) misses per txn",
+        "expression": "[ITLB_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB  (2nd level) 4KB page load MPI",
-        "name-txn": "metric_DTLB  (2nd level) 4KB page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [TXN]"
+        "name": "DTLB (2nd level) load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) 2MB large page load MPI",
-        "name-txn": "metric_DTLB (2nd level) 2MB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+        "name": "DTLB (2nd level) load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED] / [TXN]"
     },
     {
-        "name": "metric_DTLB (2nd level) 1GB large page load MPI",
-        "name-txn": "metric_DTLB (2nd level) 1GB large page load misses per txn",
-        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [instructions]",
-        "expression-txn": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [TXN]"
+        "name": "DTLB  (2nd level) 4KB page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [instructions]"
     },
     {
-        "name": "metric_DTLB (2nd level) store MPI",
-        "name-txn": "metric_DTLB (2nd level) store misses per txn",
-        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]",
-        "expression-txn": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+        "name": "DTLB  (2nd level) 4KB page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_4K] / [TXN]"
     },
     {
-        "name": "metric_TMA_Frontend_Bound(%)",
+        "name": "DTLB (2nd level) 2MB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) 2MB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_2M_4M] / [TXN]"
+    },
+    {
+        "name": "DTLB (2nd level) 1GB large page load MPI",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) 1GB large page load misses per txn",
+        "expression": "[DTLB_LOAD_MISSES.WALK_COMPLETED_1G] / [TXN]"
+    },
+    {
+        "name": "DTLB (2nd level) store MPI",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [instructions]"
+    },
+    {
+        "name": "DTLB (2nd level) store misses per txn",
+        "expression": "[DTLB_STORE_MISSES.WALK_COMPLETED] / [TXN]"
+    },
+    {
+        "name": "TMA_Frontend_Bound(%)",
         "expression": "100 * ( [TOPDOWN_FE_BOUND.ALL] / ( 6 * [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Fetch_Latency(%)",
+        "name": "TMA_..Fetch_Latency(%)",
         "expression": "100*([TOPDOWN_FE_BOUND.FRONTEND_LATENCY] / (6.0 * [cpu-cycles]))"
     },
     {
-        "name": "metric_TMA_....ICache_Misses(%)",
+        "name": "TMA_....ICache_Misses(%)",
         "expression": "100 * ( [TOPDOWN_FE_BOUND.ICACHE] / ( 6 * [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....ITLB_Misses(%)",
+        "name": "TMA_....ITLB_Misses(%)",
         "expression": "100 * ( [TOPDOWN_FE_BOUND.ITLB_MISS] / ( 6 * [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_....Branch_Resteer(%)",
+        "name": "TMA_....Branch_Resteer(%)",
         "expression": "100*([TOPDOWN_FE_BOUND.BRANCH_RESTEER] / (6.0 * [cpu-cycles]))"
     },
     {
-        "name": "metric_TMA_..Fetch_Bandwidth(%)",
+        "name": "TMA_..Fetch_Bandwidth(%)",
         "expression": "100*([TOPDOWN_FE_BOUND.FRONTEND_BANDWIDTH] / (6.0 * [cpu-cycles]))"
     },
     {
-        "name": "metric_TMA_Bad_Speculation(%)",
+        "name": "TMA_Bad_Speculation(%)",
         "expression": "100 * ( [TOPDOWN_BAD_SPECULATION.ALL] / ( 6 * [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Branch_Mispredicts(%)",
+        "name": "TMA_..Branch_Mispredicts(%)",
         "expression": "100*([TOPDOWN_BAD_SPECULATION.MISPREDICT] / (6.0 * [cpu-cycles]))"
     },
     {
-        "name": "metric_TMA_..Machine_Clears(%)",
+        "name": "TMA_..Machine_Clears(%)",
         "expression": "100*([TOPDOWN_BAD_SPECULATION.MACHINE_CLEARS] / (6.0 * [cpu-cycles]))"
     },
     {
-        "name": "metric_TMA_Backend_Bound(%)",
+        "name": "TMA_Backend_Bound(%)",
         "expression": "100 * ( [TOPDOWN_BE_BOUND.ALL] / ( 6 * [cpu-cycles] ) )"
     },
     {
-        "name": "metric_TMA_..Memory_Bound(%)",
+        "name": "TMA_..Memory_Bound(%)",
         "expression": "100*min(1*([TOPDOWN_BE_BOUND.ALL] / (6.0 * [cpu-cycles])), 1*([LD_HEAD.ANY_AT_RET] / [cpu-cycles] + ([TOPDOWN_BE_BOUND.MEM_SCHEDULER] / (6.0 * [cpu-cycles])) * [MEM_SCHEDULER_BLOCK.ST_BUF] / [MEM_SCHEDULER_BLOCK.ALL]))"
     },
     {
-        "name": "metric_TMA_....L1_Bound(%)",
+        "name": "TMA_....L1_Bound(%)",
         "expression": "100*([LD_HEAD.L1_BOUND_AT_RET] / [cpu-cycles])"
     },
     {
-        "name": "metric_TMA_....L2_Bound(%)",
+        "name": "TMA_....L2_Bound(%)",
         "expression": "100*([MEM_BOUND_STALLS_LOAD.L2_HIT] / [cpu-cycles] - (max(1*(([MEM_BOUND_STALLS_LOAD.ALL] - [LD_HEAD.L1_MISS_AT_RET]) / [cpu-cycles]), 0) * [MEM_BOUND_STALLS_LOAD.L2_HIT] / [MEM_BOUND_STALLS_LOAD.ALL]))"
     },
     {
-        "name": "metric_TMA_....L3_Bound(%)",
+        "name": "TMA_....L3_Bound(%)",
         "expression": "100*([MEM_BOUND_STALLS_LOAD.LLC_HIT] / [cpu-cycles] - (max(1*(([MEM_BOUND_STALLS_LOAD.ALL] - [LD_HEAD.L1_MISS_AT_RET]) / [cpu-cycles]), 0) * [MEM_BOUND_STALLS_LOAD.LLC_HIT] / [MEM_BOUND_STALLS_LOAD.ALL]))"
     },
     {
-        "name": "metric_TMA_....Store_Bound(%)",
+        "name": "TMA_....Store_Bound(%)",
         "expression": "100*(([TOPDOWN_BE_BOUND.MEM_SCHEDULER] / (6.0 * [cpu-cycles])) * [MEM_SCHEDULER_BLOCK.ST_BUF] / [MEM_SCHEDULER_BLOCK.ALL])"
     },
     {
-        "name": "metric_TMA_..Core_Bound(%)",
+        "name": "TMA_..Core_Bound(%)",
         "expression": "100*max(0, 1*([TOPDOWN_BE_BOUND.ALL] / (6.0 * [cpu-cycles]) - min(1*([TOPDOWN_BE_BOUND.ALL] / (6.0 * [cpu-cycles])), 1*([LD_HEAD.ANY_AT_RET] / [cpu-cycles] + ([TOPDOWN_BE_BOUND.MEM_SCHEDULER] / (6.0 * [cpu-cycles])) * [MEM_SCHEDULER_BLOCK.ST_BUF] / [MEM_SCHEDULER_BLOCK.ALL]))))"
     },
     {
-        "name": "metric_TMA_....Serialization(%)",
+        "name": "TMA_....Serialization(%)",
         "expression": "100*([TOPDOWN_BE_BOUND.SERIALIZATION] / (6.0 * [cpu-cycles]))"
     },
     {
-        "name": "metric_TMA_Retiring(%)",
+        "name": "TMA_Retiring(%)",
         "expression": "100 * ( [TOPDOWN_RETIRING.ALL] / ( 6 * [cpu-cycles] ) )"
     }
 ]


### PR DESCRIPTION
… metric name handling

This PR removes the special handling of metrics that are defined only when Transaction Rate (--txnrate N) is included on the command line. The effect is that transaction-oriented metrics will no longer replace their original associated non-transactional metric. Instead, when --txnrate N is specified by the user, additional transaction-related metrics will be produced.