### PR TITLE
Add kernel parameter table to report

### DIFF
--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -151,7 +151,7 @@ var benchmarkSummaryTableName = "Benchmark Summary"
 var categories = []common.Category{
 	{FlagName: flagHostName, FlagVar: &flagHost, Help: "Host", TableNames: []string{report.HostTableName}},
 	{FlagName: flagBiosName, FlagVar: &flagBios, Help: "BIOS", TableNames: []string{report.BIOSTableName}},
-	{FlagName: flagOsName, FlagVar: &flagOs, Help: "Operating System", TableNames: []string{report.OperatingSystemTableName, report.KernelParameterTableName}},
+	{FlagName: flagOsName, FlagVar: &flagOs, Help: "Operating System", TableNames: []string{report.OperatingSystemTableName, report.KernelParametersTableName}},
 	{FlagName: flagSoftwareName, FlagVar: &flagSoftware, Help: "Software Versions", TableNames: []string{report.SoftwareVersionTableName}},
 	{FlagName: flagCpuName, FlagVar: &flagCpu, Help: "Processor Details", TableNames: []string{report.CPUTableName}},
 	{FlagName: flagIsaName, FlagVar: &flagIsa, Help: "Instruction Sets", TableNames: []string{report.ISATableName}},

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -48,9 +48,9 @@ var (
 	flagAll bool
 	// categories
 	flagHost           bool
-	flagPcie           bool
 	flagBios           bool
 	flagOs             bool
+	flagKernelParams   bool
 	flagSoftware       bool
 	flagCpu            bool
 	flagIsa            bool
@@ -70,6 +70,7 @@ var (
 	flagGpu            bool
 	flagGaudi          bool
 	flagCxl            bool
+	flagPcie           bool
 	flagCve            bool
 	flagProcess        bool
 	flagSensor         bool
@@ -88,9 +89,9 @@ const (
 	flagAllName = "all"
 	// categories
 	flagHostName           = "host"
-	flagPcieName           = "pcie"
 	flagBiosName           = "bios"
 	flagOsName             = "os"
+	flagKernelParamsName   = "params"
 	flagSoftwareName       = "software"
 	flagCpuName            = "cpu"
 	flagIsaName            = "isa"
@@ -110,6 +111,7 @@ const (
 	flagGpuName            = "gpu"
 	flagGaudiName          = "gaudi"
 	flagCxlName            = "cxl"
+	flagPcieName           = "pcie"
 	flagCveName            = "cve"
 	flagProcessName        = "process"
 	flagSensorName         = "sensor"
@@ -151,7 +153,8 @@ var benchmarkSummaryTableName = "Benchmark Summary"
 var categories = []common.Category{
 	{FlagName: flagHostName, FlagVar: &flagHost, Help: "Host", TableNames: []string{report.HostTableName}},
 	{FlagName: flagBiosName, FlagVar: &flagBios, Help: "BIOS", TableNames: []string{report.BIOSTableName}},
-	{FlagName: flagOsName, FlagVar: &flagOs, Help: "Operating System", TableNames: []string{report.OperatingSystemTableName, report.KernelParametersTableName}},
+	{FlagName: flagOsName, FlagVar: &flagOs, Help: "Operating System", TableNames: []string{report.OperatingSystemTableName}},
+	{FlagName: flagKernelParamsName, FlagVar: &flagKernelParams, Help: "Kernel Parameters", TableNames: []string{report.KernelParametersTableName}},
 	{FlagName: flagSoftwareName, FlagVar: &flagSoftware, Help: "Software Versions", TableNames: []string{report.SoftwareVersionTableName}},
 	{FlagName: flagCpuName, FlagVar: &flagCpu, Help: "Processor Details", TableNames: []string{report.CPUTableName}},
 	{FlagName: flagIsaName, FlagVar: &flagIsa, Help: "Instruction Sets", TableNames: []string{report.ISATableName}},

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -151,7 +151,7 @@ var benchmarkSummaryTableName = "Benchmark Summary"
 var categories = []common.Category{
 	{FlagName: flagHostName, FlagVar: &flagHost, Help: "Host", TableNames: []string{report.HostTableName}},
 	{FlagName: flagBiosName, FlagVar: &flagBios, Help: "BIOS", TableNames: []string{report.BIOSTableName}},
-	{FlagName: flagOsName, FlagVar: &flagOs, Help: "Operating System", TableNames: []string{report.OperatingSystemTableName}},
+	{FlagName: flagOsName, FlagVar: &flagOs, Help: "Operating System", TableNames: []string{report.OperatingSystemTableName, report.KernelParameterTableName}},
 	{FlagName: flagSoftwareName, FlagVar: &flagSoftware, Help: "Software Versions", TableNames: []string{report.SoftwareVersionTableName}},
 	{FlagName: flagCpuName, FlagVar: &flagCpu, Help: "Processor Details", TableNames: []string{report.CPUTableName}},
 	{FlagName: flagIsaName, FlagVar: &flagIsa, Help: "Instruction Sets", TableNames: []string{report.ISATableName}},

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -1371,6 +1371,7 @@ func kernelParameterTableHtmlRenderer(tableValues TableValues, targetName string
 		node.Value += tableValues.Fields[1].Values[i]
 	}
 	// render the tree as HTML list
+	// HTML/CSS for tree adapted from: https://iamkate.com/code/tree-views/, License CC0 1.0 (https://creativecommons.org/publicdomain/zero/1.0/legalcode)
 	var renderKernelParameterNode func(node *kernelParameterNode, level int) string
 	renderKernelParameterNode = func(node *kernelParameterNode, level int) string {
 		out := ""

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -1490,11 +1490,10 @@ func kernelParameterTableHtmlRenderer(tableValues TableValues, targetName string
 	</style>
 	`
 	parameterTree := renderKernelParameterNode(root, 0)
-	values := [][]string{{"sysctl parameters", parameterTree}}
+	values := [][]string{{"Sysctl Parameters", parameterTree}}
 	rowStyles := []string{}
 	var tableValueStyles [][]string
 	rowStyles = append(rowStyles, "font-weight:bold")
-	//rowStyles = append(rowStyles, "white-space: pre-wrap")
 	tableValueStyles = append(tableValueStyles, rowStyles)
 	return style + renderHTMLTable([]string{}, values, "pure-table pure-table-striped", tableValueStyles)
 }

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -1352,12 +1352,11 @@ func kernelParameterTableHtmlRenderer(tableValues TableValues, targetName string
 		Children: make(map[string]*kernelParameterNode),
 	}
 	// assemble the tree
-	// for debugging, use only the first 6 parameters
-	//for i := range 6 {
-	for i := 0; i < len(tableValues.Fields[0].Values); i++ {
-		parameter := strings.Split(tableValues.Fields[0].Values[i], ".")
+	for i := range tableValues.Fields[0].Values {
+		// split the parameter name at the dots
+		parameterNameLevels := strings.Split(tableValues.Fields[0].Values[i], ".")
 		node := root
-		for _, level := range parameter {
+		for _, level := range parameterNameLevels {
 			if _, ok := node.Children[level]; !ok {
 				node.Children[level] = &kernelParameterNode{
 					Name:     level,
@@ -1366,7 +1365,10 @@ func kernelParameterTableHtmlRenderer(tableValues TableValues, targetName string
 			}
 			node = node.Children[level]
 		}
-		node.Value = tableValues.Fields[1].Values[i]
+		if node.Value != "" {
+			node.Value += ", "
+		}
+		node.Value += tableValues.Fields[1].Values[i]
 	}
 	// render the tree as HTML list
 	var renderKernelParameterNode func(node *kernelParameterNode, level int) string
@@ -1377,18 +1379,14 @@ func kernelParameterTableHtmlRenderer(tableValues TableValues, targetName string
 		}
 		out += "<li>\n"
 		if level == 0 {
-			out += "<details open>\n"
+			out += "<details open>\n" // initialize the root to open
 		} else if len(node.Children) > 0 {
 			out += "<details>\n"
 		}
 		if level == 0 || len(node.Children) > 0 {
 			out += fmt.Sprintf("<summary>%s</summary>\n", node.Name)
 		} else { // this is a leaf node
-			value := ""
-			if node.Value != "" {
-				value = fmt.Sprintf(" = %s", node.Value)
-			}
-			out += fmt.Sprintf("%s%s\n", node.Name, value)
+			out += fmt.Sprintf("%s = %s\n", node.Name, node.Value)
 		}
 		if len(node.Children) > 0 {
 			out += "<ul>\n"

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -1392,7 +1392,14 @@ func kernelParameterTableHtmlRenderer(tableValues TableValues, targetName string
 		}
 		if len(node.Children) > 0 {
 			out += "<ul>\n"
-			for _, child := range node.Children {
+			// render children in alphabetical order
+			keys := make([]string, 0, len(node.Children))
+			for k := range node.Children {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				child := node.Children[key]
 				out += renderKernelParameterNode(child, level+1)
 			}
 			out += "</ul>\n"
@@ -1486,10 +1493,10 @@ func kernelParameterTableHtmlRenderer(tableValues TableValues, targetName string
 	`
 	parameterTree := renderKernelParameterNode(root, 0)
 	values := [][]string{{"sysctl parameters", parameterTree}}
-	//rowStyles := []string{}
+	rowStyles := []string{}
 	var tableValueStyles [][]string
-	//rowStyles = append(rowStyles, "font-weight:bold")
+	rowStyles = append(rowStyles, "font-weight:bold")
 	//rowStyles = append(rowStyles, "white-space: pre-wrap")
-	//tableValueStyles = append(tableValueStyles, rowStyles)
+	tableValueStyles = append(tableValueStyles, rowStyles)
 	return style + renderHTMLTable([]string{}, values, "pure-table pure-table-striped", tableValueStyles)
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -417,6 +417,18 @@ func kernelParameterTableXlsxRenderer(tableValues TableValues, f *excelize.File,
 	_ = f.SetCellValue(sheetName, cellName(2, rowSave-1), "Note: Unhide rows to view parameters")
 }
 
+// kernelParameterTableTextRenderer renders the kernel parameter table in text format. It is the same as the default renderer except...
+// - it only prints the first few rows of the table
+// - it puts a note at the end to view the full table in the xlsx or HTML report
+func kernelParameterTableTextRenderer(tableValues TableValues) string {
+	// limit tableValues to the first 5 rows
+	if len(tableValues.Fields[0].Values) > 5 {
+		tableValues.Fields[0].Values = tableValues.Fields[0].Values[:5]
+	}
+	// call default renderer, then add a note to view the full table in the xlsx or HTML report
+	return DefaultTextTableRendererFunc(tableValues) + "...\nNote: View the full table in the xlsx or HTML report.\n"
+}
+
 const (
 	XlsxPrimarySheetName = "Report"
 	XlsxBriefSheetName   = "Brief"

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -402,6 +402,21 @@ func DefaultXlsxTableRendererFunc(tableValues TableValues, f *excelize.File, she
 	}
 }
 
+// kernelParameterTableXlsxRenderer renders the kernel parameter table in xlsx format. It is the same as the default renderer except...
+// - it hides the rows containing the kernel parameters
+// - it puts a note in the first row to un-hide the rows to view the parameters
+func kernelParameterTableXlsxRenderer(tableValues TableValues, f *excelize.File, sheetName string, row *int) {
+	rowSave := *row
+	// call default renderer, then hide the rows containing the kernel parameters
+	DefaultXlsxTableRendererFunc(tableValues, f, sheetName, row)
+	// hide the rows containing the kernel parameters
+	for i := range len(tableValues.Fields[0].Values) + 1 {
+		_ = f.SetRowVisible(sheetName, rowSave+i, false)
+	}
+	// put a message in the first row
+	_ = f.SetCellValue(sheetName, cellName(2, rowSave-1), "Note: Unhide rows to view parameters")
+}
+
 const (
 	XlsxPrimarySheetName = "Report"
 	XlsxBriefSheetName   = "Brief"

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -77,7 +77,7 @@ const (
 	PCIeSlotsTableName          = "PCIe Slots"
 	BIOSTableName               = "BIOS"
 	OperatingSystemTableName    = "Operating System"
-	KernelParameterTableName    = "Kernel Parameter"
+	KernelParametersTableName   = "Kernel Parameters"
 	SoftwareVersionTableName    = "Software Version"
 	CPUTableName                = "CPU"
 	ISATableName                = "ISA"
@@ -217,8 +217,8 @@ var tableDefinitions = map[string]TableDefinition{
 			script.ProcCmdlineScriptName,
 			script.ProcCpuinfoScriptName},
 		FieldsFunc: operatingSystemTableValues},
-	KernelParameterTableName: {
-		Name:    KernelParameterTableName,
+	KernelParametersTableName: {
+		Name:    KernelParametersTableName,
 		HasRows: true,
 		ScriptNames: []string{
 			script.SysctlScriptName},

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -77,6 +77,7 @@ const (
 	PCIeSlotsTableName          = "PCIe Slots"
 	BIOSTableName               = "BIOS"
 	OperatingSystemTableName    = "Operating System"
+	KernelParameterTableName    = "Kernel Parameter"
 	SoftwareVersionTableName    = "Software Version"
 	CPUTableName                = "CPU"
 	ISATableName                = "ISA"
@@ -215,6 +216,13 @@ var tableDefinitions = map[string]TableDefinition{
 			script.ProcCmdlineScriptName,
 			script.ProcCpuinfoScriptName},
 		FieldsFunc: operatingSystemTableValues},
+	KernelParameterTableName: {
+		Name:    KernelParameterTableName,
+		HasRows: true,
+		ScriptNames: []string{
+			script.SysctlScriptName},
+		FieldsFunc:            kernelParameterTableValues,
+		HTMLTableRendererFunc: kernelParameterTableHtmlRenderer},
 	SoftwareVersionTableName: {
 		Name:    SoftwareVersionTableName,
 		HasRows: false,
@@ -879,6 +887,22 @@ func operatingSystemTableValues(outputs map[string]script.ScriptOutput) []Field 
 		{Name: "Boot Parameters", Values: []string{strings.TrimSpace(outputs[script.ProcCmdlineScriptName].Stdout)}},
 		{Name: "Microcode", Values: []string{valFromRegexSubmatch(outputs[script.ProcCpuinfoScriptName].Stdout, `^microcode.*:\s*(.+?)$`)}},
 	}
+}
+
+func kernelParameterTableValues(outputs map[string]script.ScriptOutput) []Field {
+	fields := []Field{
+		{Name: "Parameter"},
+		{Name: "Value"},
+	}
+	for _, line := range strings.Split(outputs[script.SysctlScriptName].Stdout, "\n") {
+		parts := strings.SplitN(line, " = ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		fields[0].Values = append(fields[0].Values, parts[0])
+		fields[1].Values = append(fields[1].Values, parts[1])
+	}
+	return fields
 }
 
 func softwareVersionTableValues(outputs map[string]script.ScriptOutput) []Field {

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -224,7 +224,8 @@ var tableDefinitions = map[string]TableDefinition{
 			script.SysctlScriptName},
 		FieldsFunc:            kernelParameterTableValues,
 		HTMLTableRendererFunc: kernelParameterTableHtmlRenderer,
-		XlsxTableRendererFunc: kernelParameterTableXlsxRenderer},
+		XlsxTableRendererFunc: kernelParameterTableXlsxRenderer,
+		TextTableRendererFunc: kernelParameterTableTextRenderer},
 	SoftwareVersionTableName: {
 		Name:    SoftwareVersionTableName,
 		HasRows: false,

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -223,7 +223,8 @@ var tableDefinitions = map[string]TableDefinition{
 		ScriptNames: []string{
 			script.SysctlScriptName},
 		FieldsFunc:            kernelParameterTableValues,
-		HTMLTableRendererFunc: kernelParameterTableHtmlRenderer},
+		HTMLTableRendererFunc: kernelParameterTableHtmlRenderer,
+		XlsxTableRendererFunc: kernelParameterTableXlsxRenderer},
 	SoftwareVersionTableName: {
 		Name:    SoftwareVersionTableName,
 		HasRows: false,

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -36,6 +36,7 @@ const (
 	UnameScriptName                             = "uname"
 	ProcCmdlineScriptName                       = "proc cmdline"
 	ProcCpuinfoScriptName                       = "proc cpuinfo"
+	SysctlScriptName                            = "sysctl"
 	EtcReleaseScriptName                        = "etc release"
 	GccVersionScriptName                        = "gcc version"
 	BinutilsVersionScriptName                   = "binutils version"
@@ -223,6 +224,11 @@ var scripts = map[string]ScriptDefinition{
 	ProcCpuinfoScriptName: {
 		Name:           ProcCpuinfoScriptName,
 		ScriptTemplate: "cat /proc/cpuinfo",
+	},
+	SysctlScriptName: {
+		Name:           SysctlScriptName,
+		ScriptTemplate: "sysctl -a",
+		Superuser:      true,
 	},
 	EtcReleaseScriptName: {
 		Name:           EtcReleaseScriptName,


### PR DESCRIPTION
runs sysctl -a to capture all the parameters

Because there are 100s of parameters, we need to consider how they are represented in the various report formats.

HTML: presents parameters in a collapsed, but expandable, tree format
Excel: presents them in a table, but hides the rows by default
Text: presents the first few parameters, with a note indicating to view the full list in one of the other formats
Json: default approach