### PR TITLE
Add support for Sierra Forest AP microarchitecture in CPU database

### DIFF
--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -465,7 +465,7 @@ var referenceData = map[ReferenceDataKey]ReferenceData{
 	{"SPR_XCC", "2"}: {Description: "Reference (Intel 2S Xeon 8480+)", CPUSpeed: 1678712, SingleCoreFreq: 3776, AllCoreFreq: 2996, MaxPower: 698.35, MaxTemp: 0, MinPower: 249.21, MemPeakBandwidth: 524.6, MemMinLatency: 111.8},
 	{"SPR_XCC", "1"}: {Description: "Reference (Intel 1S Xeon 8480+)", CPUSpeed: 845743, SingleCoreFreq: 3783, AllCoreFreq: 2999, MaxPower: 334.68, MaxTemp: 0, MinPower: 163.79, MemPeakBandwidth: 264.0, MemMinLatency: 112.2},
 	{"EMR_XCC", "2"}: {Description: "Reference (Intel 2S Xeon 8592V)", CPUSpeed: 1789534, SingleCoreFreq: 3862, AllCoreFreq: 2898, MaxPower: 664.4, MaxTemp: 0, MinPower: 166.36, MemPeakBandwidth: 553.5, MemMinLatency: 92.0},
-	{"SRF", "2"}:     {Description: "Reference (Intel 2S Xeon 6780E)", CPUSpeed: 2688949, SingleCoreFreq: 2997, AllCoreFreq: 3001, MaxPower: 606.47, MaxTemp: 0, MinPower: 123.34, MemPeakBandwidth: 534.3, MemMinLatency: 129.25},
+	{"SRF_SP", "2"}:  {Description: "Reference (Intel 2S Xeon 6780E)", CPUSpeed: 2688949, SingleCoreFreq: 2997, AllCoreFreq: 3001, MaxPower: 606.47, MaxTemp: 0, MinPower: 123.34, MemPeakBandwidth: 534.3, MemMinLatency: 129.25},
 	{"GNR_X2", "2"}:  {Description: "Reference (Intel 2S Xeon 6787P)", CPUSpeed: 3178562, SingleCoreFreq: 3797, AllCoreFreq: 3199, MaxPower: 679, MaxTemp: 0, MinPower: 248.49, MemPeakBandwidth: 749.6, MemMinLatency: 117.51},
 }
 

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -465,7 +465,7 @@ var referenceData = map[ReferenceDataKey]ReferenceData{
 	{"SPR_XCC", "2"}: {Description: "Reference (Intel 2S Xeon 8480+)", CPUSpeed: 1678712, SingleCoreFreq: 3776, AllCoreFreq: 2996, MaxPower: 698.35, MaxTemp: 0, MinPower: 249.21, MemPeakBandwidth: 524.6, MemMinLatency: 111.8},
 	{"SPR_XCC", "1"}: {Description: "Reference (Intel 1S Xeon 8480+)", CPUSpeed: 845743, SingleCoreFreq: 3783, AllCoreFreq: 2999, MaxPower: 334.68, MaxTemp: 0, MinPower: 163.79, MemPeakBandwidth: 264.0, MemMinLatency: 112.2},
 	{"EMR_XCC", "2"}: {Description: "Reference (Intel 2S Xeon 8592V)", CPUSpeed: 1789534, SingleCoreFreq: 3862, AllCoreFreq: 2898, MaxPower: 664.4, MaxTemp: 0, MinPower: 166.36, MemPeakBandwidth: 553.5, MemMinLatency: 92.0},
-	{"SRF_SP", "2"}:  {Description: "Reference (Intel 2S Xeon 6780E)", CPUSpeed: 2688949, SingleCoreFreq: 2997, AllCoreFreq: 3001, MaxPower: 606.47, MaxTemp: 0, MinPower: 123.34, MemPeakBandwidth: 534.3, MemMinLatency: 129.25},
+	{"SRF_SP", "2"}:  {Description: "Reference (Intel 2S Xeon 6780E)", CPUSpeed: 3022446, SingleCoreFreq: 3001, AllCoreFreq: 3001, MaxPower: 583.97, MaxTemp: 0, MinPower: 123.34, MemPeakBandwidth: 534.3, MemMinLatency: 129.25},
 	{"GNR_X2", "2"}:  {Description: "Reference (Intel 2S Xeon 6787P)", CPUSpeed: 3178562, SingleCoreFreq: 3797, AllCoreFreq: 3199, MaxPower: 679, MaxTemp: 0, MinPower: 248.49, MemPeakBandwidth: 749.6, MemMinLatency: 117.51},
 }
 

--- a/internal/cpudb/cpu_defs.go
+++ b/internal/cpudb/cpu_defs.go
@@ -42,7 +42,9 @@ var cpus = CPUDB{
 	{MicroArchitecture: "EMR", Family: "6", Model: "207", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 8, LogicalThreadCount: 2, CacheWayCount: 15},           // Emerald Rapids - generic
 	{MicroArchitecture: "EMR_MCC", Family: "6", Model: "207", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 8, LogicalThreadCount: 2, CacheWayCount: 15},       // Emerald Rapids - MCC
 	{MicroArchitecture: "EMR_XCC", Family: "6", Model: "207", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 8, LogicalThreadCount: 2, CacheWayCount: 20},       // Emerald Rapids - XCC
-	{MicroArchitecture: "SRF", Family: "6", Model: "175", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 8, LogicalThreadCount: 1, CacheWayCount: 12},           // Sierra Forest
+	{MicroArchitecture: "SRF", Family: "6", Model: "175", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 0, LogicalThreadCount: 1, CacheWayCount: 12},           // Sierra Forest
+	{MicroArchitecture: "SRF_SP", Family: "6", Model: "175", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 8, LogicalThreadCount: 1, CacheWayCount: 12},        // Sierra Forest
+	{MicroArchitecture: "SRF_AP", Family: "6", Model: "175", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 12, LogicalThreadCount: 1, CacheWayCount: 12},       // Sierra Forest
 	{MicroArchitecture: "GNR", Family: "6", Model: "173", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 0, LogicalThreadCount: 2, CacheWayCount: 16},           // Granite Rapids - generic
 	{MicroArchitecture: "GNR_X1", Family: "6", Model: "173", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 8, LogicalThreadCount: 2, CacheWayCount: 16},        // Granite Rapids - SP (MCC/LCC)
 	{MicroArchitecture: "GNR_X2", Family: "6", Model: "173", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 8, LogicalThreadCount: 2, CacheWayCount: 16},        // Granite Rapids - SP (XCC)

--- a/internal/cpudb/cpudb.go
+++ b/internal/cpudb/cpudb.go
@@ -58,7 +58,7 @@ func (c *CPUDB) GetCPUExtended(family, model, stepping, capid4, devices string) 
 					}
 				}
 				cpu = info
-				if cpu.Family == "6" && (cpu.Model == "143" || cpu.Model == "207" || cpu.Model == "173") { // SPR, EMR, GNR
+				if cpu.Family == "6" && (cpu.Model == "143" || cpu.Model == "207" || cpu.Model == "173" || cpu.Model == "175") { // SPR, EMR, GNR, SRF
 					cpu, err = c.getSpecificCPU(family, model, capid4, devices)
 				}
 				return
@@ -87,6 +87,8 @@ func (c *CPUDB) getSpecificCPU(family, model, capid4, devices string) (cpu CPU, 
 		cpu, err = c.getEMRCPU(capid4)
 	} else if family == "6" && model == "173" { // GNR
 		cpu, err = c.getGNRCPU(devices)
+	} else if family == "6" && model == "175" { // SRF
+		cpu, err = c.getSRFCPU(devices)
 	}
 	return
 }
@@ -173,6 +175,31 @@ func (c *CPUDB) getGNRCPU(devices string) (cpu CPU, err error) {
 		}
 	}
 	err = fmt.Errorf("did not find matching GNR architecture in CPU database: %s", uarch)
+	return
+}
+
+func (c *CPUDB) getSRFCPU(devices string) (cpu CPU, err error) {
+	var uarch string
+	if devices != "" {
+		d, err := strconv.Atoi(devices)
+		if err == nil && d != 0 {
+			if d%3 == 0 { // device count is multiple of 3
+				uarch = "SRF_SP"
+			} else if d%4 == 0 { // device count is multiple of 4
+				uarch = "SRF_AP"
+			}
+		}
+	}
+	if uarch == "" {
+		uarch = "SRF"
+	}
+	for _, info := range *c {
+		if info.MicroArchitecture == uarch {
+			cpu = info
+			return
+		}
+	}
+	err = fmt.Errorf("did not find matching SRF architecture in CPU database: %s", uarch)
 	return
 }
 

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -195,16 +195,16 @@ var scripts = map[string]ScriptDefinition{
 	LspciBitsScriptName: {
 		Name:           LspciBitsScriptName,
 		ScriptTemplate: `lspci -s $(lspci | grep 325b | awk 'NR==1{{"{"}}print $1{{"}"}}') -xxx |  awk '$1 ~ /^90/{{"{"}}print $9 $8 $7 $6; exit{{"}"}}'`,
-		Families:       []string{"6"},                 // Intel
-		Models:         []string{"143", "207", "173"}, // SPR, EMR, GNR
+		Families:       []string{"6"},          // Intel
+		Models:         []string{"143", "207"}, // SPR, EMR
 		Superuser:      true,
 		Depends:        []string{"lspci"},
 	},
 	LspciDevicesScriptName: {
 		Name:           LspciDevicesScriptName,
 		ScriptTemplate: "lspci -d 8086:3258 | wc -l",
-		Families:       []string{"6"},                 // Intel
-		Models:         []string{"143", "207", "173"}, // SPR, EMR, GNR
+		Families:       []string{"6"},          // Intel
+		Models:         []string{"173", "175"}, // GNR, SRF
 		Depends:        []string{"lspci"},
 	},
 	LspciVmmScriptName: {


### PR DESCRIPTION
Report now differentiates between SRF-SP and SRF-AP.