### PR TITLE
Replace `golang.org/x/exp` with stdlib

### DIFF
--- a/cmd/metrics/event_defs.go
+++ b/cmd/metrics/event_defs.go
@@ -13,10 +13,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	mapset "github.com/deckarep/golang-set/v2"
-	"golang.org/x/exp/slices"
 )
 
 // EventDefinition represents a single perf event

--- a/cmd/metrics/event_frame.go
+++ b/cmd/metrics/event_frame.go
@@ -10,10 +10,9 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 )
 
 // EventGroup represents a group of perf events and their values

--- a/cmd/metrics/summary.go
+++ b/cmd/metrics/summary.go
@@ -15,11 +15,10 @@ import (
 	"math"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	texttemplate "text/template"
 	"time"
-
-	"golang.org/x/exp/slices"
 )
 
 // Summarize - generates formatted output from a CSV file containing metric values.

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/xuri/excelize/v2 v2.9.0
-	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67
 	golang.org/x/term v0.30.0
 	golang.org/x/text v0.23.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/xuri/nfp v0.0.0-20240318013403-ab9948c2c4a7 h1:hPVCafDV85blFTabnqKgNh
 github.com/xuri/nfp v0.0.0-20240318013403-ab9948c2c4a7/go.mod h1:WwHg+CVyzlv/TX9xqBFXEZAuxOPxn2k1GNHwG41IIUQ=
 golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
 golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
-golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/gXhegadRdwBIXEFWDo=
-golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=
 golang.org/x/image v0.18.0 h1:jGzIakQa/ZXI1I0Fxvaa9W7yP25TqT6cHIHn+6CqvSQ=
 golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
 golang.org/x/net v0.36.0 h1:vWF2fRbw4qslQsQzgFqZff+BItCvGFQqKzKIzx1rmoA=

--- a/internal/report/html.go
+++ b/internal/report/html.go
@@ -9,13 +9,12 @@ import (
 	"html"
 	"log/slog"
 	"math"
+	"math/rand/v2"
 	"slices"
 	"sort"
 	"strconv"
 	"strings"
 	texttemplate "text/template"
-
-	"golang.org/x/exp/rand"
 )
 
 func getHtmlReportBegin() string {
@@ -760,7 +759,7 @@ func coreTurboFrequencyTableHTMLRenderer(tableValues TableValues, targetName str
 		}
 	}
 	chartConfig := chartTemplateStruct{
-		ID:            fmt.Sprintf("turboFrequency%d", rand.Intn(10000)),
+		ID:            fmt.Sprintf("turboFrequency%d", rand.IntN(10000)),
 		XaxisText:     "Core Count",
 		YaxisText:     "Frequency (GHz)",
 		TitleText:     "",
@@ -806,7 +805,7 @@ func memoryLatencyTableMultiTargetHtmlRenderer(allTableValues []TableValues, tar
 		datasetNames = append(datasetNames, targetNames[targetIdx])
 	}
 	chartConfig := chartTemplateStruct{
-		ID:            fmt.Sprintf("latencyBandwidth%d", rand.Intn(10000)),
+		ID:            fmt.Sprintf("latencyBandwidth%d", rand.IntN(10000)),
 		XaxisText:     "Bandwidth (MB/s)",
 		YaxisText:     "Latency (ns)",
 		TitleText:     "",
@@ -873,7 +872,7 @@ func cpuUtilizationTableHTMLRenderer(tableValues TableValues, targetName string)
 		}
 	}
 	chartConfig := chartTemplateStruct{
-		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.Intn(10000)),
+		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.IntN(10000)),
 		XaxisText:     "Time",
 		YaxisText:     "% Utilization",
 		TitleText:     "",
@@ -908,7 +907,7 @@ func summaryCPUUtilizationTableHTMLRenderer(tableValues TableValues, targetName 
 		}
 	}
 	chartConfig := chartTemplateStruct{
-		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.Intn(10000)),
+		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.IntN(10000)),
 		XaxisText:     "Time",
 		YaxisText:     "% Utilization",
 		TitleText:     "",
@@ -948,7 +947,7 @@ func irqRateTableHTMLRenderer(tableValues TableValues, targetName string) string
 		data = append(data, points)
 	}
 	chartConfig := chartTemplateStruct{
-		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.Intn(10000)),
+		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.IntN(10000)),
 		XaxisText:     "Time",
 		YaxisText:     "IRQ/s",
 		TitleText:     "",
@@ -1004,7 +1003,7 @@ func driveStatsTableHTMLRenderer(tableValues TableValues, targetName string) str
 			}
 		}
 		chartConfig := chartTemplateStruct{
-			ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.Intn(10000)),
+			ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.IntN(10000)),
 			XaxisText:     "Time",
 			YaxisText:     "",
 			TitleText:     drive,
@@ -1062,7 +1061,7 @@ func networkStatsTableHTMLRenderer(tableValues TableValues, targetName string) s
 			}
 		}
 		chartConfig := chartTemplateStruct{
-			ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.Intn(10000)),
+			ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.IntN(10000)),
 			XaxisText:     "Time",
 			YaxisText:     "",
 			TitleText:     nic,
@@ -1099,7 +1098,7 @@ func memoryStatsTableHTMLRenderer(tableValues TableValues, targetName string) st
 		}
 	}
 	chartConfig := chartTemplateStruct{
-		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.Intn(10000)),
+		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.IntN(10000)),
 		XaxisText:     "Time",
 		YaxisText:     "kilobytes",
 		TitleText:     "",
@@ -1134,7 +1133,7 @@ func summaryCpuFreqTelemetryTableHTMLRenderer(tableValues TableValues, targetNam
 		}
 	}
 	chartConfig := chartTemplateStruct{
-		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.Intn(10000)),
+		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.IntN(10000)),
 		XaxisText:     "Time",
 		YaxisText:     "MHz",
 		TitleText:     "",
@@ -1169,7 +1168,7 @@ func powerStatsTableHTMLRenderer(tableValues TableValues, targetName string) str
 		}
 	}
 	chartConfig := chartTemplateStruct{
-		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.Intn(10000)),
+		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.IntN(10000)),
 		XaxisText:     "Time",
 		YaxisText:     "Watts",
 		TitleText:     "",
@@ -1204,7 +1203,7 @@ func instructionMixTableHTMLRenderer(tableValues TableValues, targetname string)
 		}
 	}
 	chartConfig := chartTemplateStruct{
-		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.Intn(10000)),
+		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.IntN(10000)),
 		XaxisText:     "Time",
 		YaxisText:     "% Samples",
 		TitleText:     "",
@@ -1261,7 +1260,7 @@ func renderGaudiStatsChart(tableValues TableValues, chartStatFieldName string, t
 		}
 	}
 	chartConfig := chartTemplateStruct{
-		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.Intn(10000)),
+		ID:            fmt.Sprintf("%s%d", tableValues.Name, rand.IntN(10000)),
 		XaxisText:     "Time",
 		YaxisText:     yAxisText,
 		TitleText:     titleText,

--- a/internal/report/html_flamegraph.go
+++ b/internal/report/html_flamegraph.go
@@ -9,11 +9,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/rand/v2"
 	"strconv"
 	"strings"
 	texttemplate "text/template"
-
-	"golang.org/x/exp/rand"
 )
 
 const flameGraphTemplate = `
@@ -176,7 +175,7 @@ func renderFlameGraph(header string, tableValues TableValues, field string) (out
 	fg := texttemplate.Must(texttemplate.New("flameGraphTemplate").Parse(flameGraphTemplate))
 	buf := new(bytes.Buffer)
 	err = fg.Execute(buf, flameGraphTemplateStruct{
-		ID:     fmt.Sprintf("%d%s", rand.Intn(10000), header),
+		ID:     fmt.Sprintf("%d%s", rand.IntN(10000), header),
 		Data:   jsonStacks,
 		Header: header,
 	})


### PR DESCRIPTION
These experimental packages are now available in the Go standard library.

1. `golang.org/x/exp/slices` -> `slices` (https://go.dev/doc/go1.21#slices)
2. `golang.org/x/exp/rand` -> `math/rand/v2` (https://go.dev/doc/go1.22#math_rand_v2)

`golang.org/x/exp/rand` has been deprecated and scheduled to be deleted.

Reference: https://github.com/golang/exp/commit/f9890c6ad9f380fd3cdb66a33843f522d4790e03