### PR TITLE
Refactor temporary directory handling

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -233,7 +233,7 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 
 func runCmd(cmd *cobra.Command, args []string) error {
 	// appContext is the application context that holds common data and resources.
-	appContext := cmd.Context().Value(common.AppContext{}).(common.AppContext)
+	appContext := cmd.Parent().Context().Value(common.AppContext{}).(common.AppContext)
 	localTempDir := appContext.LocalTempDir
 	// get the targets
 	myTargets, targetErrs, err := common.GetTargets(cmd, true, true, localTempDir)

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -257,17 +257,17 @@ func runCmd(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-	// check for errors in target connections
-	for _, err := range targetErrs {
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			slog.Error(err.Error())
-			cmd.SilenceUsage = true
-			return err
+	// check for errors in target creation
+	for i := range targetErrs {
+		if targetErrs[i] != nil {
+			fmt.Fprintf(os.Stderr, "Error: target: %s, %v\n", myTargets[i].GetName(), targetErrs[i])
+			slog.Error(targetErrs[i].Error())
+			// remove target from targets list
+			myTargets = slices.Delete(myTargets, i, i+1)
 		}
 	}
 	if len(myTargets) == 0 {
-		err := fmt.Errorf("no targets specified")
+		err := fmt.Errorf("no targets remain")
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		slog.Error(err.Error())
 		cmd.SilenceUsage = true

--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -484,7 +484,6 @@ type targetContext struct {
 	target              target.Target
 	err                 error
 	perfPath            string
-	tempDir             string
 	metadata            Metadata
 	nmiDisabled         bool
 	perfMuxIntervalsSet bool
@@ -753,7 +752,8 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	}
 	// check if any targets remain
 	if len(myTargets) == 0 {
-		err := fmt.Errorf("no targets specified")
+		multiSpinner.Finish() // force print the spinner before printing the error
+		err := fmt.Errorf("no targets remain")
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		slog.Error(err.Error())
 		cmd.SilenceUsage = true
@@ -800,7 +800,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		targetContexts = append(targetContexts, targetContext{target: myTarget})
 	}
 	for i := range targetContexts {
-		go prepareTarget(&targetContexts[i], appContext.TargetTempRoot, localTempDir, localPerfPath, channelTargetError, multiSpinner.Status)
+		go prepareTarget(&targetContexts[i], localTempDir, localPerfPath, channelTargetError, multiSpinner.Status)
 	}
 	// wait for all targets to be prepared
 	numPreparedTargets := 0
@@ -811,19 +811,6 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		} else {
 			numPreparedTargets++
 		}
-	}
-	// schedule temporary directory cleanup
-	if cmd.Parent().PersistentFlags().Lookup("debug").Value.String() != "true" { // don't remove the directory if we're debugging
-		defer func() {
-			for _, targetContext := range targetContexts {
-				if targetContext.tempDir != "" {
-					err := targetContext.target.RemoveDirectory(targetContext.tempDir)
-					if err != nil {
-						slog.Error("failed to remove temp directory", slog.String("directory", targetContext.tempDir), slog.String("error", err.Error()))
-					}
-				}
-			}
-		}()
 	}
 	// schedule NMI watchdog reset
 	defer func() {
@@ -1007,17 +994,10 @@ func summarizeMetrics(localOutputDir string, targetName string, metadata Metadat
 	return filesCreated, nil
 }
 
-func prepareTarget(targetContext *targetContext, targetTempRoot string, localTempDir string, localPerfPath string, channelError chan targetError, statusUpdate progress.MultiSpinnerUpdateFunc) {
+func prepareTarget(targetContext *targetContext, localTempDir string, localPerfPath string, channelError chan targetError, statusUpdate progress.MultiSpinnerUpdateFunc) {
 	myTarget := targetContext.target
 	var err error
-	// create a temporary directory on the target
 	_ = statusUpdate(myTarget.GetName(), "configuring target")
-	if targetContext.tempDir, err = myTarget.CreateTempDirectory(targetTempRoot); err != nil {
-		_ = statusUpdate(myTarget.GetName(), fmt.Sprintf("Error: %v", err))
-		targetContext.err = err
-		channelError <- targetError{target: myTarget, err: err}
-		return
-	}
 	// make sure PMUs are not in use on target
 	if family, err := myTarget.GetFamily(); err == nil && family == "6" {
 		output, err := script.RunScript(myTarget, script.GetScriptByName(script.PMUBusyScriptName), localTempDir)

--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -658,7 +658,7 @@ func processRawData(localOutputDir string) error {
 }
 func runCmd(cmd *cobra.Command, args []string) error {
 	// appContext is the application context that holds common data and resources.
-	appContext := cmd.Context().Value(common.AppContext{}).(common.AppContext)
+	appContext := cmd.Parent().Context().Value(common.AppContext{}).(common.AppContext)
 	localTempDir := appContext.LocalTempDir
 	localOutputDir := appContext.OutputDir
 	// handle signals

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -338,6 +338,7 @@ func (rc *ReportingCommand) retrieveScriptOutputs(localTempDir string) ([]Target
 			}
 		}
 		multiSpinner.Start()
+		defer multiSpinner.Finish()
 		// check for errors in target creation
 		for i := range targetErrs {
 			if targetErrs[i] != nil {
@@ -348,14 +349,13 @@ func (rc *ReportingCommand) retrieveScriptOutputs(localTempDir string) ([]Target
 		}
 		// check if we have any remaining targets to run the scripts on
 		if len(myTargets) == 0 {
-			err := fmt.Errorf("no targets available to collect data on")
+			err := fmt.Errorf("no targets remain")
 			return nil, err
 		}
 		orderedTargetScriptOutputs, err = outputsFromTargets(myTargets, rc, multiSpinner.Status, localTempDir)
 		if err != nil {
 			return nil, err
 		}
-		multiSpinner.Finish()
 		fmt.Println()
 	}
 	return orderedTargetScriptOutputs, nil

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -26,9 +26,10 @@ var AppName = filepath.Base(os.Args[0])
 
 // AppContext represents the application context that can be accessed from all commands.
 type AppContext struct {
-	OutputDir string // OutputDir is the directory where the application will write output files.
-	TempDir   string // TempDir is the local host's temp directory.
-	Version   string // Version is the version of the application.
+	OutputDir      string // OutputDir is the directory where the application will write output files.
+	LocalTempDir   string // LocalTempDir is the temp directory on the local host (created by the application).
+	TargetTempRoot string // TargetTempRoot is the path to a directory on the target host where the application can create temporary directories.
+	Version        string // Version is the version of the application.
 }
 
 type Flag struct {
@@ -88,7 +89,7 @@ type ReportingCommand struct {
 func (rc *ReportingCommand) Run() error {
 	// appContext is the application context that holds common data and resources.
 	appContext := rc.Cmd.Context().Value(AppContext{}).(AppContext)
-	localTempDir := appContext.TempDir
+	localTempDir := appContext.LocalTempDir
 	outputDir := appContext.OutputDir
 	// handle signals
 	// child processes will exit when the signals are received which will
@@ -314,6 +315,20 @@ func (rc *ReportingCommand) retrieveScriptOutputs(localTempDir string) ([]Target
 		if err != nil {
 			return nil, err
 		}
+		// schedule the cleanup of the temporary directory on each target (if not debugging)
+		if rc.Cmd.Parent().PersistentFlags().Lookup("debug").Value.String() != "true" {
+			for _, myTarget := range myTargets {
+				if myTarget.GetTempDirectory() != "" {
+					defer func() {
+						err := myTarget.RemoveTempDirectory()
+						if err != nil {
+							slog.Error("error removing target temporary directory", slog.String("error", err.Error()))
+						}
+					}()
+				}
+			}
+		}
+
 		// setup and start the progress indicator
 		multiSpinner := progress.NewMultiSpinner()
 		for _, target := range myTargets {
@@ -372,9 +387,9 @@ func outputsFromInput(summaryTableName string) ([]TargetScriptOutputs, error) {
 // outputsFromTargets runs the scripts on the targets and returns the data in the order of the targets
 func outputsFromTargets(myTargets []target.Target, rc *ReportingCommand, statusUpdate progress.MultiSpinnerUpdateFunc, localTempDir string) ([]TargetScriptOutputs, error) {
 	orderedTargetScriptOutputs := []TargetScriptOutputs{}
-	// create the list of tables and scripts to run and then run them on the targets
 	channelTargetScriptOutputs := make(chan TargetScriptOutputs)
 	channelError := make(chan error)
+	// create the list of tables and associated scripts for each target
 	targetTableNames := [][]string{}
 	targetScriptNames := [][]string{}
 	for targetIdx, target := range myTargets {
@@ -392,6 +407,9 @@ func outputsFromTargets(myTargets []target.Target, rc *ReportingCommand, statusU
 				slog.Info("table not supported for target", slog.String("table", tableName), slog.String("target", target.GetName()))
 			}
 		}
+	}
+	// run the scripts on the targets
+	for targetIdx, target := range myTargets {
 		scriptsToRunOnTarget := []script.ScriptDefinition{}
 		for _, scriptName := range targetScriptNames[targetIdx] {
 			script := script.GetParameterizedScriptByName(scriptName, rc.ScriptParams)
@@ -440,26 +458,6 @@ func elevatedPrivilegesRequired(tableNames []string) bool {
 
 // collectOnTarget runs the scripts on the target and sends the results to the appropriate channels
 func collectOnTarget(cmd *cobra.Command, duration int, myTarget target.Target, scriptsToRun []script.ScriptDefinition, localTempDir string, channelTargetScriptOutputs chan TargetScriptOutputs, channelError chan error, statusUpdate progress.MultiSpinnerUpdateFunc) {
-	// create a temporary directory on the target
-	var targetTempDir string
-	var err error
-	_ = statusUpdate(myTarget.GetName(), "creating temporary directory")
-	targetTempRoot, _ := cmd.Flags().GetString(FlagTargetTempDirName)
-	if targetTempDir, err = myTarget.CreateTempDirectory(targetTempRoot); err != nil {
-		_ = statusUpdate(myTarget.GetName(), fmt.Sprintf("error creating temporary directory: %v", err))
-		err = fmt.Errorf("error creating temporary directory on %s: %v", myTarget.GetName(), err)
-		channelError <- err
-		return
-	}
-	// don't remove the directory if we're debugging
-	if cmd.Parent().PersistentFlags().Lookup("debug").Value.String() != "true" {
-		defer func() {
-			err := myTarget.RemoveDirectory(targetTempDir)
-			if err != nil {
-				slog.Error("error removing target temporary directory", slog.String("error", err.Error()))
-			}
-		}()
-	}
 	// run the scripts on the target
 	status := "collecting data"
 	if cmd.Name() == "telemetry" && duration == 0 { // telemetry is the only command that uses this common code that can run indefinitely

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -88,7 +88,7 @@ type ReportingCommand struct {
 // and then call this Run function.
 func (rc *ReportingCommand) Run() error {
 	// appContext is the application context that holds common data and resources.
-	appContext := rc.Cmd.Context().Value(AppContext{}).(AppContext)
+	appContext := rc.Cmd.Parent().Context().Value(AppContext{}).(AppContext)
 	localTempDir := appContext.LocalTempDir
 	outputDir := appContext.OutputDir
 	// handle signals

--- a/internal/common/targets.go
+++ b/internal/common/targets.go
@@ -130,8 +130,7 @@ func isNoExec(t target.Target, tempDir string) (bool, error) {
 	}
 	device := fields[0]
 	// Search for the device in the mount output and check for "noexec"
-	mountLines := strings.Split(string(mountOutput), "\n")
-	for _, line := range mountLines {
+	for line := range strings.SplitSeq(string(mountOutput), "\n") {
 		if strings.Contains(line, device) && strings.Contains(line, "noexec") {
 			return true, nil // Found "noexec" for the device
 		}

--- a/internal/progress/multispinner.go
+++ b/internal/progress/multispinner.go
@@ -54,6 +54,7 @@ func (ms *multiSpinner) AddSpinner(label string) (err error) {
 
 // Start starts the spinner
 func (ms *multiSpinner) Start() {
+	ms.draw(true)
 	ms.ticker = time.NewTicker(250 * time.Millisecond)
 	ms.spinning = true
 	go ms.onTick()

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -521,6 +521,7 @@ func copyDependenciesToTarget(myTarget target.Target, dependenciesToCopy map[str
 					return
 				}
 				slog.Warn("dependency not found", slog.String("dependency", dependency))
+				err = nil
 				continue
 			}
 		}

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -329,7 +329,7 @@ func (t *LocalTarget) RemoveTempDirectory() (err error) {
 			t.tempDir = ""
 		}
 	}
-	return nil
+	return
 }
 
 func (t *RemoteTarget) RemoveTempDirectory() (err error) {
@@ -339,14 +339,14 @@ func (t *RemoteTarget) RemoveTempDirectory() (err error) {
 			t.tempDir = ""
 		}
 	}
-	return nil
+	return
 }
 
-func (t *LocalTarget) GetTempDirectory() (tempDir string) {
+func (t *LocalTarget) GetTempDirectory() string {
 	return t.tempDir
 }
 
-func (t *RemoteTarget) GetTempDirectory() (tempDir string) {
+func (t *RemoteTarget) GetTempDirectory() string {
 	return t.tempDir
 }
 


### PR DESCRIPTION
- --tempdir flag overrides default (usually /tmp) in case /tmp is on a filesystem mounted with the 'noexec' option
- improve error messages, e.g., when temp dir lands on a 'noexec' file system
- eliminate --targettemp flag

There are two temporary directories created.
- for the application, this is where dependencies and scripts are written before being copied to the target
- for the target (remote or local), this is where the scripts and dependencies are stored and executed (must not be 'noexec')

Only the 2nd temporary directory location can be changed with --tempdir.  The 1st always lands in the system's default temp, e.g., /tmp.

Both directories are cleaned up (removed) when the application exits...unless the --debug flag is specified.

