### PR TITLE
Add perf-archive dependency and script to Makefile

### DIFF
--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -1453,6 +1453,6 @@ if [ -f "${PERF_CONTENTION_DATA}" ]; then
 fi
 `,
 		Superuser: true,
-		Depends:   []string{"perf"},
+		Depends:   []string{"perf", "perf-archive"},
 	},
 }

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -154,7 +154,7 @@ endif
 	cd pcm/build &&	cmake -DNO_ASAN=1 ..
 	cd pcm/build && cmake --build .
 
-PERF_LINUX_VERSION := 6.1.52
+PERF_LINUX_VERSION := 6.8.12
 perf:
 	wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-$(PERF_LINUX_VERSION).tar.xz
 	tar -xf linux-$(PERF_LINUX_VERSION).tar.xz && mv linux-$(PERF_LINUX_VERSION)/ linux_perf/

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -162,6 +162,8 @@ perf:
 	mkdir -p bin
 	cp linux_perf/tools/perf/perf bin/
 	strip --strip-unneeded bin/perf
+	cp linux_perf/tools/perf/perf-archive.sh bin/perf-archive
+	chmod +x bin/perf-archive
 
 processwatch:
 ifeq ("$(wildcard processwatch)","")


### PR DESCRIPTION
@TianyouLi 
These changes are to demonstrate how to add the perf-archive script.  Not clear if there are other required dependencies.