### PR TITLE
Enhance script and table definitions to include vendor filtering for target compatibility

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -7,7 +7,7 @@
 # build the perfspect Go components using this image
 #    $ docker run --rm -v "$PWD":/workdir -w /workdir perfspect-builder:v1 make dist
 
-FROM golang:1.24.1@sha256:af0bb3052d6700e1bc70a37bca483dc8d76994fd16ae441ad72390eea6016d03
+FROM golang:1.24.2@sha256:1ecc479bc712a6bdb56df3e346e33edcc141f469f82840bab9f4bc2bc41bf91d
 WORKDIR /workdir
 # pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
 COPY go.mod go.sum ./

--- a/builder/build.Dockerfile
+++ b/builder/build.Dockerfile
@@ -18,5 +18,6 @@ FROM ${REGISTRY}${PREFIX}perfspect-builder:${TAG} AS perfspect
 RUN mkdir /prebuilt
 RUN mkdir /prebuilt/tools
 COPY --from=tools /bin/ /prebuilt/tools
-COPY --from=tools /oss_source* /prebuilt
+COPY --from=tools /oss_source.tgz /prebuilt/
+COPY --from=tools /oss_source.tgz.md5 /prebuilt/
 RUN git config --global --add safe.directory /localrepo

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -255,7 +255,7 @@ func getFlagGroups() []common.FlagGroup {
 		},
 		{
 			Name: flagPrefetcherAMPName,
-			Help: "AMP prefetcher (" + strings.Join(prefetcherOptions, ", ") + ") [SPR,EMR,GNR]",
+			Help: "Adaptive multipath probability prefetcher (" + strings.Join(prefetcherOptions, ", ") + ") [SPR,EMR,GNR]",
 		},
 		{
 			Name: flagPrefetcherLLCPPName,
@@ -271,7 +271,7 @@ func getFlagGroups() []common.FlagGroup {
 		},
 		{
 			Name: flagPrefetcherLLCName,
-			Help: "LLC prefetcher (" + strings.Join(prefetcherOptions, ", ") + ") [SPR,EMR,GNR]",
+			Help: "Last level cache prefetcher (" + strings.Join(prefetcherOptions, ", ") + ") [SPR,EMR,GNR]",
 		},
 	}
 	groups = append(groups, common.FlagGroup{
@@ -735,7 +735,6 @@ func setLlcSize(llcSize float64, myTarget target.Target, localTempDir string) {
 		Name:           "set LLC size",
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0xC90 %d", cacheWays[waysToSet]),
 		Superuser:      true,
-		Architectures:  []string{"x86_64"},
 		Families:       []string{"6"},                                                // Intel only
 		Models:         []string{"63", "79", "86", "85", "106", "108", "143", "207"}, // not SRF, GNR
 		Depends:        []string{"wrmsr"},
@@ -758,8 +757,7 @@ func setCoreFrequency(coreFrequency float64, myTarget target.Target, localTempDi
 		Name:           "set frequency bins",
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0x1AD %d", msr),
 		Superuser:      true,
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Depends:        []string{"wrmsr"},
 	}
 	_, err := runScript(myTarget, setScript, localTempDir)
@@ -839,8 +837,7 @@ func setUncoreDieFrequency(maxFreq bool, computeDie bool, uncoreFrequency float6
 		setScript := script.ScriptDefinition{
 			Name:           "write max and min uncore frequency TPMI",
 			ScriptTemplate: fmt.Sprintf("pcm-tpmi 2 0x18 -d -b %s -w %d -i %s -e %s", bits, value, die.instance, die.entry),
-			Architectures:  []string{"x86_64"},
-			Families:       []string{"6"}, // Intel only
+			Vendors:        []string{"GenuineIntel"},
 			Depends:        []string{"pcm-tpmi"},
 			Superuser:      true,
 		}
@@ -864,10 +861,9 @@ func setUncoreFrequency(maxFreq bool, uncoreFrequency float64, myTarget target.T
 	scripts = append(scripts, script.ScriptDefinition{
 		Name:           "get uncore frequency MSR",
 		ScriptTemplate: "rdmsr 0x620",
-		Lkms:           []string{"msr"},
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Depends:        []string{"rdmsr"},
+		Lkms:           []string{"msr"},
 		Superuser:      true,
 	})
 	outputs, err := script.RunScripts(myTarget, scripts, true, localTempDir)
@@ -918,8 +914,7 @@ func setUncoreFrequency(maxFreq bool, uncoreFrequency float64, myTarget target.T
 		Name:           "set uncore frequency MSR",
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0x620 %d", newVal),
 		Superuser:      true,
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Lkms:           []string{"msr"},
 		Depends:        []string{"wrmsr"},
 	}
@@ -935,8 +930,7 @@ func setPower(power int, myTarget target.Target, localTempDir string) {
 		Name:           "get power MSR",
 		ScriptTemplate: "rdmsr 0x610",
 		Superuser:      true,
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Lkms:           []string{"msr"},
 		Depends:        []string{"rdmsr"},
 	}
@@ -959,8 +953,7 @@ func setPower(power int, myTarget target.Target, localTempDir string) {
 				Name:           "set tdp",
 				ScriptTemplate: fmt.Sprintf("wrmsr -a 0x610 %d", newVal),
 				Superuser:      true,
-				Architectures:  []string{"x86_64"},
-				Families:       []string{"6"}, // Intel only
+				Vendors:        []string{"GenuineIntel"},
 				Lkms:           []string{"msr"},
 				Depends:        []string{"wrmsr"},
 			}
@@ -998,8 +991,7 @@ func setEpb(epb int, myTarget target.Target, localTempDir string) {
 	readScript := script.ScriptDefinition{
 		Name:           "read " + msr,
 		ScriptTemplate: "rdmsr " + msr,
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel
+		Vendors:        []string{"GenuineIntel"},
 		Lkms:           []string{"msr"},
 		Depends:        []string{"rdmsr"},
 		Superuser:      true,
@@ -1023,8 +1015,7 @@ func setEpb(epb int, myTarget target.Target, localTempDir string) {
 		Name:           "set epb",
 		ScriptTemplate: fmt.Sprintf("wrmsr -a %s %d", msr, msrValue),
 		Superuser:      true,
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Lkms:           []string{"msr"},
 		Depends:        []string{"wrmsr"},
 	}
@@ -1043,8 +1034,7 @@ func setEpp(epp int, myTarget target.Target, localTempDir string) {
 	getScript := script.ScriptDefinition{
 		Name:           "get epp msr",
 		ScriptTemplate: "rdmsr 0x774", // IA32_HWP_REQUEST
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Lkms:           []string{"msr"},
 		Depends:        []string{"rdmsr"},
 		Superuser:      true,
@@ -1068,8 +1058,7 @@ func setEpp(epp int, myTarget target.Target, localTempDir string) {
 		Name:           "set epp",
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0x774 %d", eppValue),
 		Superuser:      true,
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Lkms:           []string{"msr"},
 		Depends:        []string{"wrmsr"},
 	}
@@ -1083,8 +1072,7 @@ func setEpp(epp int, myTarget target.Target, localTempDir string) {
 	getScript = script.ScriptDefinition{
 		Name:           "get epp pkg msr",
 		ScriptTemplate: "rdmsr 0x772", // IA32_HWP_REQUEST_PKG
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Lkms:           []string{"msr"},
 		Depends:        []string{"rdmsr"},
 		Superuser:      true,
@@ -1109,8 +1097,7 @@ func setEpp(epp int, myTarget target.Target, localTempDir string) {
 		Name:           "set epp",
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0x772 %d", eppValue),
 		Superuser:      true,
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Lkms:           []string{"msr"},
 		Depends:        []string{"wrmsr"},
 	}
@@ -1149,8 +1136,7 @@ func setElc(elc string, myTarget target.Target, localTempDir string) {
 		Name:           "set elc",
 		ScriptTemplate: fmt.Sprintf("bhs-power-mode.sh --%s", mode),
 		Superuser:      true,
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"},          // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Models:         []string{"173", "175"}, // GNR and SRF only
 		Depends:        []string{"bhs-power-mode.sh"},
 	}
@@ -1196,8 +1182,7 @@ func setPrefetcher(enableDisable string, myTarget target.Target, localTempDir st
 	getScript := script.ScriptDefinition{
 		Name:           "get prefetcher msr",
 		ScriptTemplate: fmt.Sprintf("rdmsr %d", pf.Msr),
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Lkms:           []string{"msr"},
 		Depends:        []string{"rdmsr"},
 		Superuser:      true,
@@ -1232,8 +1217,7 @@ func setPrefetcher(enableDisable string, myTarget target.Target, localTempDir st
 	setScript := script.ScriptDefinition{
 		Name:           "set prefetcher",
 		ScriptTemplate: fmt.Sprintf("wrmsr -a %d %d", pf.Msr, newVal),
-		Architectures:  []string{"x86_64"},
-		Families:       []string{"6"}, // Intel only
+		Vendors:        []string{"GenuineIntel"},
 		Lkms:           []string{"msr"},
 		Depends:        []string{"wrmsr"},
 		Superuser:      true,

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -243,15 +243,15 @@ func getFlagGroups() []common.FlagGroup {
 		},
 		{
 			Name: flagPrefetcherDCUHWName,
-			Help: "L1 data cache unit hardware prefetcher (" + strings.Join(prefetcherOptions, ", ") + ")",
+			Help: "DCU hardware prefetcher (" + strings.Join(prefetcherOptions, ", ") + ")",
 		},
 		{
 			Name: flagPrefetcherDCUIPName,
-			Help: "L1 data cache unit instruction prefetcher (" + strings.Join(prefetcherOptions, ", ") + ")",
+			Help: "DCU instruction pointer prefetcher (" + strings.Join(prefetcherOptions, ", ") + ")",
 		},
 		{
 			Name: flagPrefetcherDCUNPName,
-			Help: "L1 data cache unit next page prefetcher (" + strings.Join(prefetcherOptions, ", ") + ")",
+			Help: "DCU next page prefetcher (" + strings.Join(prefetcherOptions, ", ") + ")",
 		},
 		{
 			Name: flagPrefetcherAMPName,
@@ -263,11 +263,11 @@ func getFlagGroups() []common.FlagGroup {
 		},
 		{
 			Name: flagPrefetcherAOPName,
-			Help: "array of pointers prefetcher (" + strings.Join(prefetcherOptions, ", ") + ") [GNR]",
+			Help: "Array of pointers prefetcher (" + strings.Join(prefetcherOptions, ", ") + ") [GNR]",
 		},
 		{
 			Name: flagPrefetcherHomelessName,
-			Help: "homeless prefetcher (" + strings.Join(prefetcherOptions, ", ") + ") [SPR,EMR,GNR]",
+			Help: "Homeless prefetcher (" + strings.Join(prefetcherOptions, ", ") + ") [SPR,EMR,GNR]",
 		},
 		{
 			Name: flagPrefetcherLLCName,

--- a/internal/report/prefetcher_defs.go
+++ b/internal/report/prefetcher_defs.go
@@ -52,7 +52,7 @@ var PrefetcherDefs = []Prefetcher{
 	},
 	{
 		ShortName:   "DCU NP",
-		Description: "DCU Next Page (DCU Next Page) is an L1 data cache prefetcher",
+		Description: "DCU Next Page is an L1 data cache prefetcher.",
 		Msr:         MsrPrefetchControl,
 		Bit:         4,
 		Uarchs:      []string{"all"},

--- a/internal/report/prefetcher_defs.go
+++ b/internal/report/prefetcher_defs.go
@@ -31,14 +31,14 @@ var PrefetcherDefs = []Prefetcher{
 	},
 	{
 		ShortName:   "L2 Adj",
-		Description: "Adjacent Cache Line (MLC Spatial) fetches the cache line that comprises a cache line pair.",
+		Description: "L2 Adjacent Cache Line (MLC Spatial) fetches the cache line that comprises a cache line pair.",
 		Msr:         MsrPrefetchControl,
 		Bit:         1,
 		Uarchs:      []string{"all"},
 	},
 	{
 		ShortName:   "DCU HW",
-		Description: "L1 Data Cache Unit Hardware (DCU Streamer) fetches the next cache line into the L1 cache.",
+		Description: "DCU Hardware (DCU Streamer) fetches the next cache line into the L1 cache.",
 		Msr:         MsrPrefetchControl,
 		Bit:         2,
 		Uarchs:      []string{"all"},

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -157,41 +157,47 @@ func GetTableByName(name string) TableDefinition {
 	panic(fmt.Sprintf("table not found: %s", name))
 }
 
-func TableForTarget(name string, myTarget target.Target) bool {
-	table := GetTableByName(name)
-	var err error
-	var architecture, family, model string
-	architecture, err = myTarget.GetArchitecture()
-	if err != nil {
-		slog.Error("failed to get architecture for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
-		return false
+func TableForTarget(tableName string, myTarget target.Target) bool {
+	table := GetTableByName(tableName)
+	if len(table.Architectures) > 0 {
+		architecture, err := myTarget.GetArchitecture()
+		if err != nil {
+			slog.Error("failed to get architecture for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
+			return false
+		}
+		if !slices.Contains(table.Architectures, architecture) {
+			return false
+		}
 	}
-	family, err = myTarget.GetFamily()
-	if err != nil {
-		slog.Error("failed to get family for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
-		return false
+	if len(table.Vendors) > 0 {
+		vendor, err := myTarget.GetVendor()
+		if err != nil {
+			slog.Error("failed to get vendor for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
+			return false
+		}
+		if !slices.Contains(table.Vendors, vendor) {
+			return false
+		}
 	}
-	model, err = myTarget.GetModel()
-	if err != nil {
-		slog.Error("failed to get model for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
-		return false
+	if len(table.Families) > 0 {
+		family, err := myTarget.GetFamily()
+		if err != nil {
+			slog.Error("failed to get family for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
+			return false
+		}
+		if !slices.Contains(table.Families, family) {
+			return false
+		}
 	}
-	vendor, err := myTarget.GetVendor()
-	if err != nil {
-		slog.Error("failed to get vendor for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
-		return false
-	}
-	if len(table.Architectures) > 0 && !slices.Contains(table.Architectures, architecture) {
-		return false
-	}
-	if len(table.Vendors) > 0 && !slices.Contains(table.Vendors, vendor) {
-		return false
-	}
-	if len(table.Families) > 0 && !slices.Contains(table.Families, family) {
-		return false
-	}
-	if len(table.Models) > 0 && !slices.Contains(table.Models, model) {
-		return false
+	if len(table.Models) > 0 {
+		model, err := myTarget.GetModel()
+		if err != nil {
+			slog.Error("failed to get model for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
+			return false
+		}
+		if !slices.Contains(table.Models, model) {
+			return false
+		}
 	}
 	return true
 }

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -38,6 +38,7 @@ type TableDefinition struct {
 	Name          string
 	ScriptNames   []string
 	Architectures []string // architectures, i.e., x86_64, arm64. If empty, it will be present for all architectures.
+	Vendors       []string // vendors, e.g., GenuineIntel, AuthenticAMD. If empty, it will be present for all vendors.
 	Families      []string // families, e.g., 6, 7. If empty, it will be present for all families.
 	Models        []string // models, e.g., 62, 63. If empty, it will be present for all models.
 	// Fields function is called to retrieve field values from the script outputs
@@ -175,7 +176,15 @@ func TableForTarget(name string, myTarget target.Target) bool {
 		slog.Error("failed to get model for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
 		return false
 	}
+	vendor, err := myTarget.GetVendor()
+	if err != nil {
+		slog.Error("failed to get vendor for target", slog.String("target", myTarget.GetName()), slog.String("error", err.Error()))
+		return false
+	}
 	if len(table.Architectures) > 0 && !slices.Contains(table.Architectures, architecture) {
+		return false
+	}
+	if len(table.Vendors) > 0 && !slices.Contains(table.Vendors, vendor) {
 		return false
 	}
 	if len(table.Families) > 0 && !slices.Contains(table.Families, family) {
@@ -264,10 +273,9 @@ var tableDefinitions = map[string]TableDefinition{
 		ScriptNames: []string{script.CpuidScriptName},
 		FieldsFunc:  isaTableValues},
 	AcceleratorTableName: {
-		Name:          AcceleratorTableName,
-		Architectures: []string{"x86_64"},
-		Families:      []string{"6"}, // Intel CPUs only
-		HasRows:       true,
+		Name:    AcceleratorTableName,
+		Vendors: []string{"GenuineIntel"},
+		HasRows: true,
 		ScriptNames: []string{
 			script.LshwScriptName,
 			script.IaaDevicesScriptName,
@@ -275,11 +283,10 @@ var tableDefinitions = map[string]TableDefinition{
 		FieldsFunc:   acceleratorTableValues,
 		InsightsFunc: acceleratorTableInsights},
 	PowerTableName: {
-		Name:          PowerTableName,
-		Architectures: []string{"x86_64"},
-		Families:      []string{"6"}, // Intel CPUs only
-		HasRows:       false,
-		MenuLabel:     PowerMenuLabel,
+		Name:      PowerTableName,
+		Vendors:   []string{"GenuineIntel"},
+		HasRows:   false,
+		MenuLabel: PowerMenuLabel,
 		ScriptNames: []string{
 			script.PackagePowerLimitName,
 			script.EpbSourceScriptName,
@@ -301,10 +308,9 @@ var tableDefinitions = map[string]TableDefinition{
 		},
 		FieldsFunc: cstateTableValues},
 	MaximumFrequencyTableName: {
-		Name:          MaximumFrequencyTableName,
-		Architectures: []string{"x86_64"},
-		Families:      []string{"6"}, // Intel CPUs only
-		HasRows:       true,
+		Name:    MaximumFrequencyTableName,
+		Vendors: []string{"GenuineIntel"},
+		HasRows: true,
 		ScriptNames: []string{
 			script.SpecCoreFrequenciesScriptName,
 			script.LscpuScriptName,
@@ -313,10 +319,9 @@ var tableDefinitions = map[string]TableDefinition{
 		},
 		FieldsFunc: maximumFrequencyTableValues},
 	UncoreTableName: {
-		Name:          UncoreTableName,
-		Architectures: []string{"x86_64"},
-		Families:      []string{"6"}, // Intel CPUs only
-		HasRows:       false,
+		Name:    UncoreTableName,
+		Vendors: []string{"GenuineIntel"},
+		HasRows: false,
 		ScriptNames: []string{
 			script.UncoreMaxFromMSRScriptName,
 			script.UncoreMinFromMSRScriptName,
@@ -329,32 +334,29 @@ var tableDefinitions = map[string]TableDefinition{
 			script.LspciDevicesScriptName},
 		FieldsFunc: uncoreTableValues},
 	ElcTableName: {
-		Name:          ElcTableName,
-		Architectures: []string{"x86_64"},
-		Families:      []string{"6"},          // Intel CPUs only
-		Models:        []string{"173", "175"}, // Granite Rapids, Sierra Forest
-		HasRows:       true,
+		Name:     ElcTableName,
+		Families: []string{"6"},          // Intel CPUs only
+		Models:   []string{"173", "175"}, // Granite Rapids, Sierra Forest
+		HasRows:  true,
 		ScriptNames: []string{
 			script.ElcScriptName,
 		},
 		FieldsFunc:   elcTableValues,
 		InsightsFunc: elcTableInsights},
 	SSTTFHPTableName: {
-		Name:          SSTTFHPTableName,
-		Architectures: []string{"x86_64"},
-		Families:      []string{"6"},          // Intel CPUs only
-		Models:        []string{"173", "175"}, // Granite Rapids, Sierra Forest
-		HasRows:       true,
+		Name:     SSTTFHPTableName,
+		Families: []string{"6"},          // Intel CPUs only
+		Models:   []string{"173", "175"}, // Granite Rapids, Sierra Forest
+		HasRows:  true,
 		ScriptNames: []string{
 			script.SstTfHighPriorityCoreFrequenciesScriptName,
 		},
 		FieldsFunc: sstTFHPTableValues},
 	SSTTFLPTableName: {
-		Name:          SSTTFLPTableName,
-		Architectures: []string{"x86_64"},
-		Families:      []string{"6"},          // Intel CPUs only
-		Models:        []string{"173", "175"}, // Granite Rapids, Sierra Forest
-		HasRows:       true,
+		Name:     SSTTFLPTableName,
+		Families: []string{"6"},          // Intel CPUs only
+		Models:   []string{"173", "175"}, // Granite Rapids, Sierra Forest
+		HasRows:  true,
 		ScriptNames: []string{
 			script.SstTfLowPriorityCoreFrequenciesScriptName,
 		},
@@ -491,10 +493,9 @@ var tableDefinitions = map[string]TableDefinition{
 		},
 		FieldsFunc: chassisStatusTableValues},
 	PMUTableName: {
-		Name:          PMUTableName,
-		Architectures: []string{"x86_64"},
-		Families:      []string{"6"}, // Intel CPUs only
-		HasRows:       false,
+		Name:    PMUTableName,
+		Vendors: []string{"GenuineIntel"},
+		HasRows: false,
 		ScriptNames: []string{
 			script.PMUBusyScriptName,
 			script.PMUDriverVersionScriptName,
@@ -558,10 +559,9 @@ var tableDefinitions = map[string]TableDefinition{
 	// configuration set table
 	//
 	ConfigurationTableName: {
-		Name:          ConfigurationTableName,
-		Architectures: []string{"x86_64"},
-		Families:      []string{"6"}, // Intel CPUs only
-		HasRows:       false,
+		Name:    ConfigurationTableName,
+		Vendors: []string{"GenuineIntel"},
+		HasRows: false,
 		ScriptNames: []string{
 			script.LscpuScriptName,
 			script.LspciBitsScriptName,


### PR DESCRIPTION
Intel families will expand in the future from the current "6" to other values. This change replaces most uses of "6" with the CPU vendor, e.g., "GenuineIntel".