### PR TITLE
Add brief system summary to metrics, telemetry, flame, and lock reports

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -408,13 +408,14 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	if cmd.Parent().PersistentFlags().Lookup("debug").Value.String() != "true" {
 		for _, myTarget := range myTargets {
 			if myTarget.GetTempDirectory() != "" {
-				defer func() {
+				deferTarget := myTarget // create a new variable to capture the current value
+				defer func(deferTarget target.Target) {
 					err = myTarget.RemoveTempDirectory()
 					if err != nil {
 						fmt.Fprintf(os.Stderr, "Failed to remove target temp directory: %+v\n", err)
 						slog.Error(err.Error())
 					}
-				}()
+				}(deferTarget)
 			}
 		}
 	}

--- a/cmd/flame/flame.go
+++ b/cmd/flame/flame.go
@@ -38,15 +38,17 @@ var Cmd = &cobra.Command{
 }
 
 var (
-	flagDuration  int
-	flagFrequency int
-	flagPid       int
+	flagDuration        int
+	flagFrequency       int
+	flagPid             int
+	flagNoSystemSummary bool
 )
 
 const (
-	flagDurationName  = "duration"
-	flagFrequencyName = "frequency"
-	flagPidName       = "pid"
+	flagDurationName        = "duration"
+	flagFrequencyName       = "frequency"
+	flagPidName             = "pid"
+	flagNoSystemSummaryName = "no-summary"
 )
 
 func init() {
@@ -55,6 +57,7 @@ func init() {
 	Cmd.Flags().IntVar(&flagDuration, flagDurationName, 30, "")
 	Cmd.Flags().IntVar(&flagFrequency, flagFrequencyName, 11, "")
 	Cmd.Flags().IntVar(&flagPid, flagPidName, 0, "")
+	Cmd.Flags().BoolVar(&flagNoSystemSummary, flagNoSystemSummaryName, false, "")
 
 	common.AddTargetFlags(Cmd)
 
@@ -104,6 +107,10 @@ func getFlagGroups() []common.FlagGroup {
 		{
 			Name: common.FlagFormatName,
 			Help: fmt.Sprintf("choose output format(s) from: %s", strings.Join(append([]string{report.FormatAll}, report.FormatHtml, report.FormatTxt, report.FormatJson), ", ")),
+		},
+		{
+			Name: flagNoSystemSummaryName,
+			Help: "do not include system summary table in report",
 		},
 	}
 	groups = append(groups, common.FlagGroup{
@@ -166,6 +173,11 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 }
 
 func runCmd(cmd *cobra.Command, args []string) error {
+	var tableNames []string
+	if !flagNoSystemSummary {
+		tableNames = append(tableNames, report.BriefSysSummaryTableName)
+	}
+	tableNames = append(tableNames, report.CodePathFrequencyTableName)
 	reportingCommand := common.ReportingCommand{
 		Cmd:            cmd,
 		ReportNamePost: "flame",
@@ -174,7 +186,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 			"Duration":  strconv.Itoa(flagDuration),
 			"PID":       strconv.Itoa(flagPid),
 		},
-		TableNames: []string{report.CodePathFrequencyTableName},
+		TableNames: tableNames,
 	}
 	return reportingCommand.Run()
 }

--- a/cmd/lock/lock.go
+++ b/cmd/lock/lock.go
@@ -198,9 +198,6 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		tableNames = append(tableNames, report.BriefSysSummaryTableName)
 	}
 	tableNames = append(tableNames, report.KernelLockAnalysisTableName)
-	if !flagNoSystemSummary {
-		tableNames = append(tableNames, report.BriefSysSummaryTableName)
-	}
 	reportingCommand := common.ReportingCommand{
 		Cmd:            cmd,
 		ReportNamePost: "lock",

--- a/cmd/metrics/metadata.go
+++ b/cmd/metrics/metadata.go
@@ -251,12 +251,12 @@ func getMetadataScripts(noRoot bool, perfPath string, uarch string, noSystemSumm
 		},
 		{
 			Name:           "perf stat instructions",
-			ScriptTemplate: perfPath + " stat -a -e instructions" + " sleep 1",
+			ScriptTemplate: perfPath + " stat -a -e instructions sleep 1",
 			Superuser:      !noRoot,
 		},
 		{
 			Name:           "perf stat ref-cycles",
-			ScriptTemplate: perfPath + " stat -a -e ref-cycles" + " sleep 1",
+			ScriptTemplate: perfPath + " stat -a -e ref-cycles sleep 1",
 			Superuser:      !noRoot,
 		},
 		{
@@ -276,12 +276,12 @@ func getMetadataScripts(noRoot bool, perfPath string, uarch string, noSystemSumm
 		},
 		{
 			Name:           "perf stat fixed instructions",
-			ScriptTemplate: perfPath + " stat -a -e '{" + "{{.InstructionsList}}" + "}' sleep 1",
+			ScriptTemplate: perfPath + " stat -a -e '{{{.InstructionsList}}}' sleep 1",
 			Superuser:      !noRoot,
 		},
 		{
 			Name:           "perf stat fixed cpu-cycles",
-			ScriptTemplate: perfPath + " stat -a -e '{" + "{{.CpuCyclesList}}" + "}' sleep 1",
+			ScriptTemplate: perfPath + " stat -a -e '{{{.CpuCyclesList}}}' sleep 1",
 			Superuser:      !noRoot,
 		},
 		{

--- a/cmd/metrics/metadata.go
+++ b/cmd/metrics/metadata.go
@@ -241,7 +241,7 @@ func getMetadataScripts(noRoot bool, perfPath string, uarch string, noSystemSumm
 		},
 		{
 			Name:           "perf supported events",
-			ScriptTemplate: "perf list",
+			ScriptTemplate: perfPath + " list",
 			Superuser:      !noRoot,
 		},
 		{

--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -724,12 +724,13 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	if cmd.Parent().PersistentFlags().Lookup("debug").Value.String() != "true" {
 		for _, myTarget := range myTargets {
 			if myTarget.GetTempDirectory() != "" {
-				defer func() {
+				deferTarget := myTarget // create a new variable to capture the current value
+				defer func(deferTarget target.Target) {
 					err := myTarget.RemoveTempDirectory()
 					if err != nil {
 						slog.Error("error removing target temporary directory", slog.String("error", err.Error()))
 					}
-				}()
+				}(deferTarget)
 			}
 		}
 	}

--- a/cmd/metrics/resources/base.html
+++ b/cmd/metrics/resources/base.html
@@ -258,9 +258,8 @@
       }
 
       const metadata = <<.METADATA>>
-
-      const transactions = <<.TRANSACTIONS>>;
-
+      const system_info = <<.SYSTEMINFO>>
+      const transactions = <<.TRANSACTIONS>>
       const base_line = {
         xAxis: {
           type: "category",
@@ -422,6 +421,7 @@
               <Tab label="Memory" />
               <Tab label="Power" />
               <Tab label="All Metrics" />
+              <Tab label="System Info" />
               <Tab label="Metadata" />
             </Tabs>
           </Box>
@@ -740,6 +740,33 @@
             <TabPanel
               value={systemTabs}
               index={5}
+            >
+            <TableContainer component={Paper} sx={{ width: "fit-content" }}>
+                <Table size="small" style={{ tableLayout: 'auto' }}>
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Key</TableCell>
+                      <TableCell>Value</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {system_info.map(([key, value]) => (
+                      <TableRow key={key}>
+                      <TableCell sx={{ fontFamily: 'Monospace' }} component="th" scope="row" >
+                        {JSON.stringify(key)}
+                      </TableCell>
+                      <TableCell sx={{ fontFamily: 'Monospace' }} align="left">
+                        {JSON.stringify(value)}
+                      </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </TabPanel>
+            <TabPanel
+              value={systemTabs}
+              index={6}
             >
             <TableContainer component={Paper} sx={{ width: "fit-content" }}>
                 <Table size="small" style={{ tableLayout: 'auto' }}>

--- a/cmd/metrics/summary.go
+++ b/cmd/metrics/summary.go
@@ -401,15 +401,24 @@ func (m *metricsFromCSV) loadHTMLTemplateValues(metadata Metadata) (templateVals
 	}
 	jsonMetrics := string(jsonMetricsBytes)
 	templateVals["ALLMETRICS"] = jsonMetrics
-	// System Information Tab
+	// Metadata tab
 	jsonMetadata, err := metadata.JSON()
 	if err != nil {
 		return
 	}
 	// remove PerfSupportedEvents from json
 	re := regexp.MustCompile(`"PerfSupportedEvents":".*?",`)
-	jsonMetadataNoPerfEvents := re.ReplaceAll(jsonMetadata, []byte(""))
-	templateVals["METADATA"] = string(jsonMetadataNoPerfEvents)
+	jsonMetadataPurged := re.ReplaceAll(jsonMetadata, []byte(""))
+	// remove SystemSummaryFields from json
+	re = regexp.MustCompile(`,"SystemSummaryFields":\[\[.*?\]\]`)
+	jsonMetadataPurged = re.ReplaceAll(jsonMetadataPurged, []byte(""))
+	templateVals["METADATA"] = string(jsonMetadataPurged)
+	// system info tab
+	jsonSystemInfo, err := json.Marshal(metadata.SystemSummaryFields)
+	if err != nil {
+		return
+	}
+	templateVals["SYSTEMINFO"] = string(jsonSystemInfo)
 	return
 }
 

--- a/cmd/telemetry/telemetry.go
+++ b/cmd/telemetry/telemetry.go
@@ -59,6 +59,8 @@ var (
 	flagInstrMix bool
 	flagGaudi    bool
 
+	flagNoSystemSummary bool
+
 	flagInstrMixPid    int
 	flagInstrMixFilter []string
 )
@@ -76,6 +78,8 @@ const (
 	flagPowerName    = "power"
 	flagInstrMixName = "instrmix"
 	flagGaudiName    = "gaudi"
+
+	flagNoSystemSummaryName = "no-summary"
 
 	flagInstrMixPidName    = "instrmix-pid"
 	flagInstrMixFilterName = "instrmix-filter"
@@ -105,6 +109,7 @@ func init() {
 	Cmd.Flags().IntVar(&flagInterval, flagIntervalName, 2, "")
 	Cmd.Flags().IntVar(&flagInstrMixPid, flagInstrMixPidName, 0, "")
 	Cmd.Flags().StringSliceVar(&flagInstrMixFilter, flagInstrMixFilterName, []string{"SSE", "AVX", "AVX2", "AVX512", "AMX_TILE"}, "")
+	Cmd.Flags().BoolVar(&flagNoSystemSummary, flagNoSystemSummaryName, false, "")
 
 	common.AddTargetFlags(Cmd)
 
@@ -175,9 +180,13 @@ func getFlagGroups() []common.FlagGroup {
 			Name: flagInstrMixFilterName,
 			Help: "filter to apply to instruction mix",
 		},
+		{
+			Name: flagNoSystemSummaryName,
+			Help: "do not include system summary table in report",
+		},
 	}
 	groups = append(groups, common.FlagGroup{
-		GroupName: "Others Options",
+		GroupName: "Other Options",
 		Flags:     flags,
 	})
 	groups = append(groups, common.GetTargetFlagGroup())
@@ -256,6 +265,9 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 
 func runCmd(cmd *cobra.Command, args []string) error {
 	var tableNames []string
+	if !flagNoSystemSummary {
+		tableNames = append(tableNames, report.BriefSysSummaryTableName)
+	}
 	for _, cat := range categories {
 		if *cat.FlagVar || flagAll {
 			tableNames = append(tableNames, cat.TableNames...)

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -129,12 +129,13 @@ func (rc *ReportingCommand) Run() error {
 	if rc.Cmd.Parent().PersistentFlags().Lookup("debug").Value.String() != "true" {
 		for _, myTarget := range myTargets {
 			if myTarget.GetTempDirectory() != "" {
-				defer func() {
-					err := myTarget.RemoveTempDirectory()
+				target := myTarget // create a new variable to capture the current value
+				defer func(target target.Target) {
+					err := target.RemoveTempDirectory()
 					if err != nil {
 						slog.Error("error removing target temporary directory", slog.String("error", err.Error()))
 					}
-				}()
+				}(target)
 			}
 		}
 	}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -162,12 +162,17 @@ func (rc *ReportingCommand) Run() error {
 		return err
 	}
 
+	// Collect indices of targets to remove
+	var indicesToRemove []int
 	for i := range targetErrs {
 		if targetErrs[i] != nil {
 			_ = multiSpinner.Status(myTargets[i].GetName(), fmt.Sprintf("Error: %v", targetErrs[i]))
-			// remove target from targets list
-			myTargets = slices.Delete(myTargets, i, i+1)
+			indicesToRemove = append(indicesToRemove, i)
 		}
+	}
+	// Remove targets in reverse order of indices to avoid shifting issues
+	for i := len(indicesToRemove) - 1; i >= 0; i-- {
+		myTargets = slices.Delete(myTargets, indicesToRemove[i], indicesToRemove[i]+1)
 	}
 	// check if we have any remaining targets to run the scripts on
 	if len(myTargets) == 0 {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -129,13 +129,13 @@ func (rc *ReportingCommand) Run() error {
 	if rc.Cmd.Parent().PersistentFlags().Lookup("debug").Value.String() != "true" {
 		for _, myTarget := range myTargets {
 			if myTarget.GetTempDirectory() != "" {
-				target := myTarget // create a new variable to capture the current value
-				defer func(target target.Target) {
-					err := target.RemoveTempDirectory()
+				deferTarget := myTarget // create a new variable to capture the current value
+				defer func(deferTarget target.Target) {
+					err := deferTarget.RemoveTempDirectory()
 					if err != nil {
 						slog.Error("error removing target temporary directory", slog.String("error", err.Error()))
 					}
-				}(target)
+				}(deferTarget)
 			}
 		}
 	}

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -107,6 +107,7 @@ const (
 	SystemEventLogTableName    = "System Event Log"
 	KernelLogTableName         = "Kernel Log"
 	SystemSummaryTableName     = "System Summary"
+	BriefSysSummaryTableName   = "Brief System Summary"
 	// benchmark table names
 	CPUSpeedTableName       = "CPU Speed"
 	CPUPowerTableName       = "CPU Power"
@@ -295,9 +296,7 @@ var tableDefinitions = map[string]TableDefinition{
 		MenuLabel: PowerMenuLabel,
 		ScriptNames: []string{
 			script.PackagePowerLimitName,
-			script.EpbSourceScriptName,
-			script.EpbOSScriptName,
-			script.EpbBIOSScriptName,
+			script.EpbScriptName,
 			script.EppScriptName,
 			script.EppValidScriptName,
 			script.EppPackageControlScriptName,
@@ -551,9 +550,7 @@ var tableDefinitions = map[string]TableDefinition{
 			script.UnameScriptName,
 			script.EtcReleaseScriptName,
 			script.PackagePowerLimitName,
-			script.EpbSourceScriptName,
-			script.EpbOSScriptName,
-			script.EpbBIOSScriptName,
+			script.EpbScriptName,
 			script.ScalingDriverScriptName,
 			script.ScalingGovernorScriptName,
 			script.CstatesScriptName,
@@ -561,6 +558,30 @@ var tableDefinitions = map[string]TableDefinition{
 			script.CveScriptName,
 		},
 		FieldsFunc: systemSummaryTableValues},
+	BriefSysSummaryTableName: {
+		Name:    BriefSysSummaryTableName,
+		HasRows: false,
+		ScriptNames: []string{
+			script.HostnameScriptName,
+			script.DateScriptName,
+			script.LscpuScriptName,
+			script.LspciBitsScriptName,
+			script.LspciDevicesScriptName,
+			script.SpecCoreFrequenciesScriptName,
+			script.LshwScriptName,
+			script.MeminfoScriptName,
+			script.NicInfoScriptName,
+			script.DiskInfoScriptName,
+			script.UnameScriptName,
+			script.EtcReleaseScriptName,
+			script.PackagePowerLimitName,
+			script.EpbScriptName,
+			script.ScalingDriverScriptName,
+			script.ScalingGovernorScriptName,
+			script.CstatesScriptName,
+			script.ElcScriptName,
+		},
+		FieldsFunc: quickSummaryTableValues},
 	//
 	// configuration set table
 	//
@@ -574,9 +595,7 @@ var tableDefinitions = map[string]TableDefinition{
 			script.LspciDevicesScriptName,
 			script.L3WaySizeName,
 			script.PackagePowerLimitName,
-			script.EpbSourceScriptName,
-			script.EpbOSScriptName,
-			script.EpbBIOSScriptName,
+			script.EpbScriptName,
 			script.EppScriptName,
 			script.EppValidScriptName,
 			script.EppPackageControlScriptName,
@@ -1880,6 +1899,33 @@ func systemSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "Efficiency Latency Control", Values: []string{elcSummaryFromOutput(outputs)}},
 		{Name: "CVEs", Values: []string{cveSummaryFromOutput(outputs)}},
 		{Name: "System Summary", Values: []string{systemSummaryFromOutput(outputs)}},
+	}
+}
+
+func quickSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
+	return []Field{
+		{Name: "Host Name", Values: []string{strings.TrimSpace(outputs[script.HostnameScriptName].Stdout)}},                                          // Hostname
+		{Name: "Time", Values: []string{strings.TrimSpace(outputs[script.DateScriptName].Stdout)}},                                                   // Date
+		{Name: "CPU Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^[Mm]odel name:\s*(.+)$`)}},               // Lscpu
+		{Name: "Microarchitecture", Values: []string{uarchFromOutput(outputs)}},                                                                      // Lscpu, LspciBits, LspciDevices
+		{Name: "TDP", Values: []string{tdpFromOutput(outputs)}},                                                                                      // PackagePowerLimit
+		{Name: "Sockets", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(s\):\s*(.+)$`)}},                   // Lscpu
+		{Name: "Cores per Socket", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Core\(s\) per socket:\s*(.+)$`)}}, // Lscpu
+		{Name: "Hyperthreading", Values: []string{hyperthreadingFromOutput(outputs)}},                                                                // Lscpu, LspciBits, LspciDevices
+		{Name: "CPUs", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU\(s\):\s*(.+)$`)}},                         // Lscpu
+		{Name: "NUMA Nodes", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^NUMA node\(s\):\s*(.+)$`)}},             // Lscpu
+		{Name: "Scaling Driver", Values: []string{strings.TrimSpace(outputs[script.ScalingDriverScriptName].Stdout)}},                                // ScalingDriver
+		{Name: "Scaling Governor", Values: []string{strings.TrimSpace(outputs[script.ScalingGovernorScriptName].Stdout)}},                            // ScalingGovernor
+		{Name: "C-states", Values: []string{cstatesSummaryFromOutput(outputs)}},                                                                      // Cstates
+		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}},                                                               // MaxFrequency
+		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}},                                               // Lscpu, LspciBits, LspciDevices, SpecCoreFrequencies
+		{Name: "Energy Performance Bias", Values: []string{epbFromOutput(outputs)}},                                                                  // EpbSource, EpbBIOS, EpbOS
+		{Name: "Efficiency Latency Control", Values: []string{elcSummaryFromOutput(outputs)}},                                                        // Elc
+		{Name: "MemTotal", Values: []string{valFromRegexSubmatch(outputs[script.MeminfoScriptName].Stdout, `^MemTotal:\s*(.+?)$`)}},                  // Meminfo
+		{Name: "NIC", Values: []string{nicSummaryFromOutput(outputs)}},                                                                               // Lshw, NicInfo
+		{Name: "Disk", Values: []string{diskSummaryFromOutput(outputs)}},                                                                             // DiskInfo, Hdparm
+		{Name: "OS", Values: []string{operatingSystemFromOutput(outputs)}},                                                                           // EtcRelease
+		{Name: "Kernel", Values: []string{valFromRegexSubmatch(outputs[script.UnameScriptName].Stdout, `^Linux \S+ (\S+)`)}},                         // Uname
 	}
 }
 

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -567,6 +567,7 @@ var tableDefinitions = map[string]TableDefinition{
 			script.LscpuScriptName,
 			script.LspciBitsScriptName,
 			script.LspciDevicesScriptName,
+			script.MaximumFrequencyScriptName,
 			script.SpecCoreFrequenciesScriptName,
 			script.LshwScriptName,
 			script.MeminfoScriptName,
@@ -581,7 +582,7 @@ var tableDefinitions = map[string]TableDefinition{
 			script.CstatesScriptName,
 			script.ElcScriptName,
 		},
-		FieldsFunc: quickSummaryTableValues},
+		FieldsFunc: briefSummaryTableValues},
 	//
 	// configuration set table
 	//
@@ -1902,7 +1903,7 @@ func systemSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 	}
 }
 
-func quickSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
+func briefSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 	return []Field{
 		{Name: "Host Name", Values: []string{strings.TrimSpace(outputs[script.HostnameScriptName].Stdout)}},                                          // Hostname
 		{Name: "Time", Values: []string{strings.TrimSpace(outputs[script.DateScriptName].Stdout)}},                                                   // Date
@@ -1917,7 +1918,7 @@ func quickSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "Scaling Driver", Values: []string{strings.TrimSpace(outputs[script.ScalingDriverScriptName].Stdout)}},                                // ScalingDriver
 		{Name: "Scaling Governor", Values: []string{strings.TrimSpace(outputs[script.ScalingGovernorScriptName].Stdout)}},                            // ScalingGovernor
 		{Name: "C-states", Values: []string{cstatesSummaryFromOutput(outputs)}},                                                                      // Cstates
-		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}},                                                               // MaxFrequency
+		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}},                                                               // MaximumFrequency, SpecCoreFrequencies,
 		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}},                                               // Lscpu, LspciBits, LspciDevices, SpecCoreFrequencies
 		{Name: "Energy Performance Bias", Values: []string{epbFromOutput(outputs)}},                                                                  // EpbSource, EpbBIOS, EpbOS
 		{Name: "Efficiency Latency Control", Values: []string{elcSummaryFromOutput(outputs)}},                                                        // Elc

--- a/internal/report/table_helpers.go
+++ b/internal/report/table_helpers.go
@@ -341,8 +341,8 @@ func maxFrequencyFromOutput(outputs map[string]script.ScriptOutput) string {
 	}
 	// get the max frequency from the MSR/tpmi
 	specCoreFrequencies, err := getSpecCoreFrequenciesFromOutput(outputs)
-	if err == nil && len(specCoreFrequencies) > 2 && len(specCoreFrequencies[1]) > 1 {
-		return specCoreFrequencies[len(specCoreFrequencies)-1][1] + "GHz"
+	if err == nil && len(specCoreFrequencies) > 1 && len(specCoreFrequencies[1]) > 1 {
+		return specCoreFrequencies[1][1] + "GHz"
 	}
 	return valFromDmiDecodeRegexSubmatch(outputs[script.DmidecodeScriptName].Stdout, "4", `Max Speed:\s(.*)`)
 }

--- a/internal/report/table_helpers.go
+++ b/internal/report/table_helpers.go
@@ -968,38 +968,15 @@ func elcSummaryFromOutput(outputs map[string]script.ScriptOutput) string {
 
 // epbFromOutput gets EPB value from script outputs
 func epbFromOutput(outputs map[string]script.ScriptOutput) string {
-	// if we couldn't read the EPB related MSR values, return empty string
-	if outputs[script.EpbSourceScriptName].Exitcode != 0 || len(outputs[script.EpbSourceScriptName].Stdout) == 0 ||
-		outputs[script.EpbOSScriptName].Exitcode != 0 || len(outputs[script.EpbOSScriptName].Stdout) == 0 ||
-		outputs[script.EpbBIOSScriptName].Exitcode != 0 || len(outputs[script.EpbBIOSScriptName].Stdout) == 0 {
+	if outputs[script.EpbScriptName].Exitcode != 0 || len(outputs[script.EpbScriptName].Stdout) == 0 {
 		slog.Warn("EPB scripts failed or produced no output")
 		return ""
 	}
-	// read the EPB source value
-	epbSource := strings.TrimSpace(outputs[script.EpbSourceScriptName].Stdout)
-	msr, err := strconv.ParseInt(epbSource, 16, 0)
+	epb := strings.TrimSpace(outputs[script.EpbScriptName].Stdout)
+	msr, err := strconv.ParseInt(epb, 16, 0)
 	if err != nil {
-		slog.Error("failed to parse EPB Source value", slog.String("error", err.Error()), slog.String("epbSource", epbSource))
+		slog.Error("failed to parse EPB value", slog.String("error", err.Error()), slog.String("epb", epb))
 		return ""
-	}
-	if msr == 1 { // BIOS
-		// read the EPB BIOS value
-		epbBIOS := strings.TrimSpace(outputs[script.EpbBIOSScriptName].Stdout)
-		msr, err = strconv.ParseInt(epbBIOS, 16, 0)
-		if err != nil {
-			slog.Error("failed to parse EPB BIOS value", slog.String("error", err.Error()), slog.String("epbBIOS", epbBIOS))
-			return ""
-		}
-		slog.Debug("EPB value from BIOS", slog.Int("msr", int(msr)))
-	} else { // OS
-		// read the EPB OS value
-		epbOS := strings.TrimSpace(outputs[script.EpbOSScriptName].Stdout)
-		msr, err = strconv.ParseInt(epbOS, 16, 0)
-		if err != nil {
-			slog.Error("failed to parse EPB OS value", slog.String("error", err.Error()), slog.String("epbOS", epbOS))
-			return ""
-		}
-		slog.Debug("EPB value from OS", slog.Int("msr", int(msr)))
 	}
 	return epbValToLabel(int(msr))
 }


### PR DESCRIPTION
disable with --no-summary

![image](https://github.com/user-attachments/assets/54bc4ba9-ff85-4085-9cde-88a5726226d0)
