### PR TITLE
Enhance core frequency reporting for multi-die architectures

### DIFF
--- a/internal/report/benchmarking_table_helpers.go
+++ b/internal/report/benchmarking_table_helpers.go
@@ -223,33 +223,43 @@ func avxTurboFrequenciesFromOutput(output string) (instructionFreqs map[string][
 	return
 }
 
-// bucketsToCounts expands the core frequency buckets to a list of core counts (from column 1) and associated spec sse frequencies (from column 2)
+// bucketsToCounts expands the core frequency buckets to a list of core counts (from column 0) and associated spec sse frequencies (from column 1 or 2)
+// the first column is the bucket range, e.g. 1-44, the second (or third) column is the spec sse frequency
 func bucketsToCoresFreqs(specCoreFreqs [][]string) (cores []string, freqs []string, err error) {
-	// the first column is the core count, the second column is the spec sse frequency
+	if len(specCoreFreqs) < 2 || len(specCoreFreqs[0]) < 2 {
+		err = fmt.Errorf("unable to parse core frequency buckets")
+		return
+	}
+	rangeIdx := 0
+	sseIdx := 1
+	if len(specCoreFreqs[0]) > 2 && specCoreFreqs[0][2] == "SSE" {
+		sseIdx = 2
+	}
 	for i := 1; i < len(specCoreFreqs); i++ {
-		// parse the bucket into start/end parts
-		bucket := strings.Split(specCoreFreqs[i][0], "-")
-		if len(bucket) != 2 {
-			err = fmt.Errorf("unable to parse bucket %s", specCoreFreqs[i][0])
+		bucketRange := strings.TrimSpace(specCoreFreqs[i][rangeIdx])
+		// parse the bucketParts into start/end parts
+		bucketParts := strings.Split(bucketRange, "-")
+		if len(bucketParts) != 2 {
+			err = fmt.Errorf("unable to parse bucket range %s", bucketRange)
 			return
 		}
 		// parse the start and end parts into integers
 		var start int
 		var end int
-		start, err = strconv.Atoi(strings.TrimSpace(bucket[0]))
+		start, err = strconv.Atoi(strings.TrimSpace(bucketParts[0]))
 		if err != nil {
-			err = fmt.Errorf("unable to parse start %s", bucket[0])
+			err = fmt.Errorf("unable to parse start %s", bucketParts[0])
 			return
 		}
-		end, err = strconv.Atoi(strings.TrimSpace(bucket[1]))
+		end, err = strconv.Atoi(strings.TrimSpace(bucketParts[1]))
 		if err != nil {
-			err = fmt.Errorf("unable to parse end %s", bucket[1])
+			err = fmt.Errorf("unable to parse end %s", bucketParts[1])
 			return
 		}
 		// add the core count to the list
 		for j := start; j <= end; j++ {
 			cores = append(cores, strconv.Itoa(j))
-			freqs = append(freqs, specCoreFreqs[i][1])
+			freqs = append(freqs, specCoreFreqs[i][sseIdx])
 		}
 	}
 	return

--- a/internal/report/table_helpers.go
+++ b/internal/report/table_helpers.go
@@ -218,7 +218,7 @@ func convertMsrToDecimals(msr string) (decVals []int, err error) {
 	return
 }
 
-// getSpecCoreFrequenciesFromOutput
+// getSpecFrequencyBuckets
 // returns slice of rows
 // first row is header
 // each row is a slice of strings
@@ -228,7 +228,7 @@ func convertMsrToDecimals(msr string) (decVals []int, err error) {
 // "64-85", "32-43", "3.5", "3.5", "3.3", "3.2", "3.1"
 // ...
 // the "cores per die" column is only present for some architectures
-func getSpecCoreFrequenciesFromOutput(outputs map[string]script.ScriptOutput) ([][]string, error) {
+func getSpecFrequencyBuckets(outputs map[string]script.ScriptOutput) ([][]string, error) {
 	arch := uarchFromOutput(outputs)
 	if arch == "" {
 		return nil, fmt.Errorf("uarch is required")
@@ -357,7 +357,7 @@ func maxFrequencyFromOutput(outputs map[string]script.ScriptOutput) string {
 		}
 	}
 	// get the max frequency from the MSR/tpmi
-	specCoreFrequencies, err := getSpecCoreFrequenciesFromOutput(outputs)
+	specCoreFrequencies, err := getSpecFrequencyBuckets(outputs)
 	if err == nil && len(specCoreFrequencies) > 1 && len(specCoreFrequencies[1]) > 1 {
 		return specCoreFrequencies[1][1] + "GHz"
 	}
@@ -365,7 +365,7 @@ func maxFrequencyFromOutput(outputs map[string]script.ScriptOutput) string {
 }
 
 func allCoreMaxFrequencyFromOutput(outputs map[string]script.ScriptOutput) string {
-	specCoreFrequencies, err := getSpecCoreFrequenciesFromOutput(outputs)
+	specCoreFrequencies, err := getSpecFrequencyBuckets(outputs)
 	if err == nil && len(specCoreFrequencies) >= 2 && len(specCoreFrequencies[1]) > 1 {
 		// the last entry in the 2nd column is the max all-core frequency
 		return specCoreFrequencies[len(specCoreFrequencies)-1][1] + "GHz"

--- a/internal/report/table_helpers.go
+++ b/internal/report/table_helpers.go
@@ -222,7 +222,7 @@ func convertMsrToDecimals(msr string) (decVals []int, err error) {
 // returns slice of rows
 // first row is header
 // each row is a slice of strings
-// "cores", "cores per die" "sse", "avx2", "avx512", "avx512h", "amx"
+// "cores", "cores per die", "sse", "avx2", "avx512", "avx512h", "amx"
 // "0-41", "0-20", "3.5", "3.5", "3.3", "3.2", "3.1"
 // "42-63", "21-31", "3.5", "3.5", "3.3", "3.2", "3.1"
 // "64-85", "32-43", "3.5", "3.5", "3.3", "3.2", "3.1"

--- a/internal/report/table_helpers.go
+++ b/internal/report/table_helpers.go
@@ -197,22 +197,22 @@ func baseFrequencyFromOutput(outputs map[string]script.ScriptOutput) string {
 	return ""
 }
 
-func convertMsrToDecimals(msr string) (decVals []int64, err error) {
+func convertMsrToDecimals(msr string) (decVals []int, err error) {
 	re := regexp.MustCompile(`[0-9a-fA-F][0-9a-fA-F]`)
 	hexVals := re.FindAll([]byte(msr), -1)
 	if hexVals == nil {
 		err = fmt.Errorf("no hex values found in msr")
 		return
 	}
-	decVals = make([]int64, len(hexVals))
+	decVals = make([]int, len(hexVals))
 	decValsIndex := len(decVals) - 1
 	for _, hexVal := range hexVals {
 		var decVal int64
-		decVal, err = strconv.ParseInt(string(hexVal), 16, 64)
+		decVal, err = strconv.ParseInt(string(hexVal), 16, 0)
 		if err != nil {
 			return
 		}
-		decVals[decValsIndex] = decVal
+		decVals[decValsIndex] = int(decVal)
 		decValsIndex--
 	}
 	return
@@ -271,7 +271,7 @@ func getSpecCoreFrequenciesFromOutput(outputs map[string]script.ScriptOutput) ([
 	}
 	for _, count := range bucketCoreCounts {
 		if archMultiplier > 1 {
-			totalCoreCount := count * int64(archMultiplier)
+			totalCoreCount := count * archMultiplier
 			if totalCoreStartRange > int(totalCoreCount) {
 				break
 			}
@@ -285,7 +285,7 @@ func getSpecCoreFrequenciesFromOutput(outputs map[string]script.ScriptOutput) ([
 	var allIsaFreqs [][]string
 	for _, isaHex := range values[1:] {
 		var isaFreqs []string
-		var freqs []int64
+		var freqs []int
 		if isaHex != "0" {
 			var err error
 			freqs, err = convertMsrToDecimals(isaHex)
@@ -294,7 +294,7 @@ func getSpecCoreFrequenciesFromOutput(outputs map[string]script.ScriptOutput) ([
 			}
 		} else {
 			// if the ISA is not supported, set the frequency to zero for all buckets
-			freqs = make([]int64, len(bucketCoreCounts))
+			freqs = make([]int, len(bucketCoreCounts))
 			for i := range freqs {
 				freqs[i] = 0
 			}


### PR DESCRIPTION
Add Cores per Die column, for multi-die architectures

```
Maximum Frequency
=================
Cores   Cores per Die   SSE   AVX2   AVX512   AVX512H   AMX
-----   -------------   ---   ----   ------   -------   ---
1-44    1-22            3.8   3.6    3.5      3.5       3.0
45-52   23-26           3.8   3.5    3.2      3.2       2.8
53-60   27-30           3.8   3.4    3.1      3.1       2.6
61-68   31-34           3.8   3.2    2.9      2.6       2.2
69-72   35-36           3.8   3.2    2.8      2.5       2.2
73-76   37-38           3.8   3.1    2.8      2.5       2.2
77-80   39-40           3.8   3.0    2.7      2.4       2.1
81-86   41-43           3.8   3.0    2.7      2.4       2.1
```