### PR TITLE
Refactor logging levels and improve event parsing error handling

### DIFF
--- a/cmd/metrics/event_defs.go
+++ b/cmd/metrics/event_defs.go
@@ -77,7 +77,7 @@ func LoadEventGroups(eventDefinitionOverridePath string, metadata Metadata) (gro
 			if len(group) > 0 {
 				groups = append(groups, group)
 			} else {
-				slog.Warn("No collectable events in group", slog.String("ending", line))
+				slog.Debug("No collectable events in group", slog.String("ending", line))
 			}
 			group = GroupDefinition{} // clear the list
 		}
@@ -90,7 +90,7 @@ func LoadEventGroups(eventDefinitionOverridePath string, metadata Metadata) (gro
 	groups, err = expandUncoreGroups(groups, metadata)
 
 	if uncollectable.Cardinality() != 0 {
-		slog.Warn("Events not collectable on target", slog.String("events", uncollectable.String()))
+		slog.Debug("Events not collectable on target", slog.String("events", uncollectable.String()))
 	}
 	return
 }


### PR DESCRIPTION
This pull request focuses on improving logging, refining error handling, and enhancing validation logic in the metrics collection codebase. The most significant changes include switching certain log levels from `Warn` to `Debug`, restructuring error handling in event parsing, and adding more detailed flag validation checks.

### Logging Improvements:
* Changed log levels from `Warn` to `Debug` for cases where there are no collectable events in a group or uncollectable events on the target in `cmd/metrics/event_defs.go`. [[1]](diffhunk://#diff-a20e5c9b922d2b0cb65050aa38c02112d43eb2a57c7a304e64fef929bff09496L80-R80) [[2]](diffhunk://#diff-a20e5c9b922d2b0cb65050aa38c02112d43eb2a57c7a304e64fef929bff09496L93-R93)
* Added debug logs for unsupported or uncounted events in `cmd/metrics/event_frame.go`. These logs provide more granular insights into event parsing.

### Error Handling Enhancements:
* Updated the `parseEvents` function in `cmd/metrics/event_frame.go` to return errors immediately when encountering unrecognized event formats, ensuring better error propagation.
* Improved the `parseEventJSON` function in `cmd/metrics/event_frame.go` to handle parsing failures more gracefully by logging errors and assigning `NaN` to invalid event values.

### Validation Logic Refinements:
* Enhanced flag validation in `cmd/metrics/metrics.go` to allow a `refresh` value of 0 (indicating no refresh) and added checks to ensure `refresh` and `perf print interval` values align correctly with other flags. [[1]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L439-L447) [[2]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L465-R477)
* Updated the help text for the `refresh` flag to clarify its behavior when set to 0.