### PR TITLE
Tables from all targets in multi-target report

### DIFF
--- a/internal/report/render_excel.go
+++ b/internal/report/render_excel.go
@@ -253,12 +253,12 @@ func createXlsxReportMultiTarget(allTargetsTableValues [][]TableValues, targetNa
 		}
 		// render the table, if system summary table put it in a separate sheet
 		if tableName == SystemSummaryTableName {
-			row = 1
+			summaryRow := 1
 			sheetName := XlsxBriefSheetName
 			_, _ = f.NewSheet(sheetName)
 			_ = f.SetColWidth(sheetName, "A", "A", 15)
 			_ = f.SetColWidth(sheetName, "B", "L", 25)
-			renderXlsxTableMultiTarget(tableValues, tableTargets, f, sheetName, &row)
+			renderXlsxTableMultiTarget(tableValues, tableTargets, f, sheetName, &summaryRow)
 		} else {
 			renderXlsxTableMultiTarget(tableValues, tableTargets, f, sheetName, &row)
 		}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -267,6 +267,38 @@ func UniqueAppend[T comparable](slice []T, item T) []T {
 	return append(slice, item)
 }
 
+// MergeOrderedUnique merges a slice of slices of type T, maintaining order and inserting new items in the order found in subsequent slices.
+// T must be comparable.
+func MergeOrderedUnique[T comparable](allSlices [][]T) []T {
+	var merged []T
+	if len(allSlices) == 0 {
+		return merged
+	}
+	merged = append(merged, allSlices[0]...)
+	for i := 1; i < len(allSlices); i++ {
+		slice := allSlices[i]
+		for idx, item := range slice {
+			if !slices.Contains(merged, item) {
+				inserted := false
+				if idx > 0 {
+					prev := slice[idx-1]
+					for j := len(merged) - 1; j >= 0; j-- {
+						if merged[j] == prev {
+							merged = append(merged[:j+1], append([]T{item}, merged[j+1:]...)...)
+							inserted = true
+							break
+						}
+					}
+				}
+				if !inserted {
+					merged = append(merged, item)
+				}
+			}
+		}
+	}
+	return merged
+}
+
 // CompareVersions compares two version strings
 // version format: major.minor.patch<-alpha|beta|rc><.build>
 // examples: 1.2.3, 1.2.3-alpha.4

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -280,10 +280,13 @@ func MergeOrderedUnique[T comparable](allSlices [][]T) []T {
 		for idx, item := range slice {
 			if !slices.Contains(merged, item) {
 				inserted := false
+				// If the current item has a preceding element in the slice, attempt to insert it after the preceding element in the merged slice.
 				if idx > 0 {
 					prev := slice[idx-1]
+					// Find the position of the preceding element (`prev`) in the merged slice.
 					for j := len(merged) - 1; j >= 0; j-- {
 						if merged[j] == prev {
+							// Insert the current item (`item`) immediately after `prev` in the merged slice.
 							merged = append(merged[:j+1], append([]T{item}, merged[j+1:]...)...)
 							inserted = true
 							break

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -403,3 +403,104 @@ func TestIsUint64BitSet(t *testing.T) {
 		})
 	}
 }
+func TestMergeOrderedUnique(t *testing.T) {
+	type testCase[T comparable] struct {
+		name     string
+		input    [][]T
+		expected []T
+	}
+
+	stringTests := []testCase[string]{
+		{
+			name:     "empty input",
+			input:    [][]string{},
+			expected: []string{},
+		},
+		{
+			name:     "single slice",
+			input:    [][]string{{"a", "b", "c"}},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "two slices, no overlap",
+			input:    [][]string{{"a", "b"}, {"c", "d"}},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			name:     "two slices, some overlap",
+			input:    [][]string{{"a", "b"}, {"b", "c"}},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "multiple slices, complex order",
+			input:    [][]string{{"a", "b"}, {"b", "c", "d"}, {"d", "e", "f"}, {"a", "f", "g"}},
+			expected: []string{"a", "b", "c", "d", "e", "f", "g"},
+		},
+		{
+			name:     "insertion after previous",
+			input:    [][]string{{"a", "b"}, {"a", "c", "b"}},
+			expected: []string{"a", "c", "b"},
+		},
+		{
+			name:     "all duplicates",
+			input:    [][]string{{"a", "b"}, {"a", "b"}, {"a", "b"}},
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "empty inner slices",
+			input:    [][]string{{}, {}, {}},
+			expected: []string{},
+		},
+		{
+			name:     "first slice empty, others non-empty",
+			input:    [][]string{{}, {"a", "b"}, {"b", "c"}},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "second slice empty",
+			input:    [][]string{{"a", "b"}, {}, {"c"}},
+			expected: []string{"a", "b", "c"},
+		},
+	}
+
+	intTests := []testCase[int]{
+		{
+			name:     "integers, no overlap",
+			input:    [][]int{{1, 2}, {3, 4}},
+			expected: []int{1, 2, 3, 4},
+		},
+		{
+			name:     "integers, with overlap",
+			input:    [][]int{{1, 2}, {2, 3, 4}, {4, 5}},
+			expected: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "integers, all duplicates",
+			input:    [][]int{{1, 2}, {1, 2}, {1, 2}},
+			expected: []int{1, 2},
+		},
+		{
+			name:     "integers, insertion after previous",
+			input:    [][]int{{1, 2}, {1, 3, 2}},
+			expected: []int{1, 3, 2},
+		},
+	}
+
+	for _, tc := range stringTests {
+		t.Run("string/"+tc.name, func(t *testing.T) {
+			got := MergeOrderedUnique(tc.input)
+			if !slices.Equal(got, tc.expected) {
+				t.Errorf("MergeOrderedUnique(%v) = %v, want %v", tc.input, got, tc.expected)
+			}
+		})
+	}
+
+	for _, tc := range intTests {
+		t.Run("int/"+tc.name, func(t *testing.T) {
+			got := MergeOrderedUnique(tc.input)
+			if !slices.Equal(got, tc.expected) {
+				t.Errorf("MergeOrderedUnique(%v) = %v, want %v", tc.input, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces enhancements to the reporting functionality and utility methods, focusing on table name extraction, merging logic, and comprehensive testing. The changes improve the handling of multi-target reports by ensuring ordered and unique table names are maintained across targets.

### Reporting Enhancements:
* Updated `createReports` in `internal/common/common.go` to use `mergedTableNames` for multi-target reports, ensuring table names are merged uniquely and in order.
* Added `extractTableNamesFromValues` function to extract table names from processed table values, enabling better organization of table names for multi-target reports.

### Utility Improvements:
* Introduced `MergeOrderedUnique` in `internal/util/util.go`, a utility function for merging slices while maintaining order and ensuring uniqueness. This is used to handle table names across multiple targets.

### Testing Enhancements:
* Added comprehensive unit tests for `MergeOrderedUnique` in `internal/util/util_test.go`, covering various edge cases such as empty slices, overlapping items, and complex orders.