### PR TITLE
refactor NIC info collection

### DIFF
--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -109,8 +109,8 @@ const (
 	flagMemoryName         = "memory"
 	flagDimmName           = "dimm"
 	flagNicName            = "nic"
-	flagNetIrqName         = "netirq"
 	flagNetConfigName      = "netconfig"
+	flagNetIrqName         = "netirq"
 	flagDiskName           = "disk"
 	flagFilesystemName     = "filesystem"
 	flagGpuName            = "gpu"
@@ -172,8 +172,8 @@ var categories = []common.Category{
 	{FlagName: flagMemoryName, FlagVar: &flagMemory, Help: "Memory Configuration", TableNames: []string{report.MemoryTableName}},
 	{FlagName: flagDimmName, FlagVar: &flagDimm, Help: "DIMM Population", TableNames: []string{report.DIMMTableName}},
 	{FlagName: flagNicName, FlagVar: &flagNic, Help: "Network Cards", TableNames: []string{report.NICTableName}},
-	{FlagName: flagNetIrqName, FlagVar: &flagNetIrq, Help: "Network IRQ to CPU Mapping", TableNames: []string{report.NetworkIRQMappingTableName}},
 	{FlagName: flagNetConfigName, FlagVar: &flagNetConfig, Help: "Network Configuration", TableNames: []string{report.NetworkConfigTableName}},
+	{FlagName: flagNetIrqName, FlagVar: &flagNetIrq, Help: "Network IRQ to CPU Mapping", TableNames: []string{report.NetworkIRQMappingTableName}},
 	{FlagName: flagDiskName, FlagVar: &flagDisk, Help: "Storage Devices", TableNames: []string{report.DiskTableName}},
 	{FlagName: flagFilesystemName, FlagVar: &flagFilesystem, Help: "File Systems", TableNames: []string{report.FilesystemTableName}},
 	{FlagName: flagGpuName, FlagVar: &flagGpu, Help: "GPUs", TableNames: []string{report.GPUTableName}},

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -369,17 +369,8 @@ var tableDefinitions = map[string]TableDefinition{
 		MenuLabel: NetworkMenuLabel,
 		ScriptNames: []string{
 			script.NicInfoScriptName,
-			script.LshwScriptName,
 		},
 		FieldsFunc: nicTableValues},
-	NetworkIRQMappingTableName: {
-		Name:    NetworkIRQMappingTableName,
-		HasRows: true,
-		ScriptNames: []string{
-			script.LshwScriptName,
-			script.NicInfoScriptName,
-		},
-		FieldsFunc: networkIRQMappingTableValues},
 	NetworkConfigTableName: {
 		Name:    NetworkConfigTableName,
 		HasRows: false,
@@ -387,6 +378,13 @@ var tableDefinitions = map[string]TableDefinition{
 			script.SysctlScriptName,
 		},
 		FieldsFunc: networkConfigTableValues},
+	NetworkIRQMappingTableName: {
+		Name:    NetworkIRQMappingTableName,
+		HasRows: true,
+		ScriptNames: []string{
+			script.NicInfoScriptName,
+		},
+		FieldsFunc: networkIRQMappingTableValues},
 	DiskTableName: {
 		Name:      DiskTableName,
 		HasRows:   true,
@@ -510,7 +508,6 @@ var tableDefinitions = map[string]TableDefinition{
 			script.PrefetchersName,
 			script.PrefetchersAtomName,
 			script.PPINName,
-			script.LshwScriptName,
 			script.MeminfoScriptName,
 			script.TransparentHugePagesScriptName,
 			script.NumaBalancingScriptName,
@@ -540,7 +537,6 @@ var tableDefinitions = map[string]TableDefinition{
 			script.LspciDevicesScriptName,
 			script.MaximumFrequencyScriptName,
 			script.SpecCoreFrequenciesScriptName,
-			script.LshwScriptName,
 			script.MeminfoScriptName,
 			script.NicInfoScriptName,
 			script.DiskInfoScriptName,
@@ -1518,6 +1514,7 @@ func dimmTableInsights(outputs map[string]script.ScriptOutput, tableValues Table
 func nicTableValues(outputs map[string]script.ScriptOutput) []Field {
 	fields := []Field{
 		{Name: "Name"},
+		{Name: "Vendor"},
 		{Name: "Model"},
 		{Name: "Speed"},
 		{Name: "Link"},
@@ -1529,19 +1526,20 @@ func nicTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "NUMA Node"},
 		{Name: "IRQBalance"},
 	}
-	allNicsInfo := nicInfoFromOutput(outputs)
+	allNicsInfo := parseNicInfo(outputs[script.NicInfoScriptName].Stdout)
 	for _, nicInfo := range allNicsInfo {
 		fields[0].Values = append(fields[0].Values, nicInfo.Name)
-		fields[1].Values = append(fields[1].Values, nicInfo.Model)
-		fields[2].Values = append(fields[2].Values, nicInfo.Speed)
-		fields[3].Values = append(fields[3].Values, nicInfo.Link)
-		fields[4].Values = append(fields[4].Values, nicInfo.Bus)
-		fields[5].Values = append(fields[5].Values, nicInfo.Driver)
-		fields[6].Values = append(fields[6].Values, nicInfo.DriverVersion)
-		fields[7].Values = append(fields[7].Values, nicInfo.FirmwareVersion)
-		fields[8].Values = append(fields[8].Values, nicInfo.MACAddress)
-		fields[9].Values = append(fields[9].Values, nicInfo.NUMANode)
-		fields[10].Values = append(fields[10].Values, nicInfo.IRQBalance)
+		fields[1].Values = append(fields[1].Values, nicInfo.Vendor)
+		fields[2].Values = append(fields[2].Values, nicInfo.Model)
+		fields[3].Values = append(fields[3].Values, nicInfo.Speed)
+		fields[4].Values = append(fields[4].Values, nicInfo.Link)
+		fields[5].Values = append(fields[5].Values, nicInfo.Bus)
+		fields[6].Values = append(fields[6].Values, nicInfo.Driver)
+		fields[7].Values = append(fields[7].Values, nicInfo.DriverVersion)
+		fields[8].Values = append(fields[8].Values, nicInfo.FirmwareVersion)
+		fields[9].Values = append(fields[9].Values, nicInfo.MACAddress)
+		fields[10].Values = append(fields[10].Values, nicInfo.NUMANode)
+		fields[11].Values = append(fields[11].Values, nicInfo.IRQBalance)
 	}
 	return fields
 }
@@ -1549,7 +1547,7 @@ func nicTableValues(outputs map[string]script.ScriptOutput) []Field {
 func networkIRQMappingTableValues(outputs map[string]script.ScriptOutput) []Field {
 	fields := []Field{
 		{Name: "Interface"},
-		{Name: "CPU:IRQs CPU:IRQs ..."},
+		{Name: "IRQ:CPUs|IRQ:CPUs|..."},
 	}
 	nicIRQMappings := nicIRQMappingsFromOutput(outputs)
 	for _, nicIRQMapping := range nicIRQMappings {

--- a/internal/report/table_helpers_test.go
+++ b/internal/report/table_helpers_test.go
@@ -351,3 +351,198 @@ Content B1`,
 		})
 	}
 }
+func TestParseNicInfo(t *testing.T) {
+	nics := parseNicInfo(nicinfo)
+	if len(nics) != 3 {
+		t.Errorf("expected 3 NICs, got %d", len(nics))
+	}
+
+	// Test first NIC
+	first := nics[0]
+	if first.Name != "ens7f0np0" {
+		t.Errorf("expected Name 'ens7f0np0', got '%s'", first.Name)
+	}
+	if first.Vendor != "Broadcom Inc. and subsidiaries" {
+		t.Errorf("expected Vendor 'Broadcom Inc. and subsidiaries', got '%s'", first.Vendor)
+	}
+	if first.Model == "" {
+		t.Errorf("expected non-empty Model")
+	}
+	if first.Speed != "1000Mb/s" {
+		t.Errorf("expected Speed '1000Mb/s', got '%s'", first.Speed)
+	}
+	if first.Link != "yes" {
+		t.Errorf("expected Link 'yes', got '%s'", first.Link)
+	}
+	if first.Bus != "0000:4c:00.0" {
+		t.Errorf("expected Bus '0000:4c:00.0', got '%s'", first.Bus)
+	}
+	if first.Driver != "bnxt_en" {
+		t.Errorf("expected Driver 'bnxt_en', got '%s'", first.Driver)
+	}
+	if first.DriverVersion == "" {
+		t.Errorf("expected non-empty DriverVersion")
+	}
+	if first.FirmwareVersion == "" {
+		t.Errorf("expected non-empty FirmwareVersion")
+	}
+	if first.MACAddress != "04:32:01:f3:e1:a4" {
+		t.Errorf("expected MACAddress '04:32:01:f3:e1:a4', got '%s'", first.MACAddress)
+	}
+	if first.NUMANode != "0" {
+		t.Errorf("expected NUMANode '0', got '%s'", first.NUMANode)
+	}
+	if first.CPUAffinity == "" {
+		t.Errorf("expected non-empty CPUAffinity")
+	}
+	if first.IRQBalance != "Disabled" {
+		t.Errorf("expected IRQBalance 'Disabled', got '%s'", first.IRQBalance)
+	}
+
+	// Spot check second NIC
+	second := nics[1]
+	if second.Name != "ens7f1np1" {
+		t.Errorf("expected Name 'ens7f1np1', got '%s'", second.Name)
+	}
+	if second.Model != "BCM57416 NetXtreme-E Dual-Media 10G RDMA Ethernet Controller" {
+		t.Errorf("expected Model 'BCM57416 NetXtreme-E Dual-Media 10G RDMA Ethernet Controller', got '%s'", second.Model)
+	}
+	if second.Link != "no" {
+		t.Errorf("expected Link 'no', got '%s'", second.Link)
+	}
+
+	// Spot check third NIC
+	third := nics[2]
+	if third.Name != "enx2aecf92702ac" {
+		t.Errorf("expected Name 'enx2aecf92702ac', got '%s'", third.Name)
+	}
+	if third.Vendor != "Netchip Technology, Inc." {
+		t.Errorf("expected Vendor 'Netchip Technology, Inc.', got '%s'", third.Vendor)
+	}
+}
+
+var nicinfo = `
+Interface: ens7f0np0
+Vendor: Broadcom Inc. and subsidiaries
+Model: BCM57416 NetXtreme-E Dual-Media 10G RDMA Ethernet Controller (NetXtreme-E Dual-port 10GBASE-T Ethernet OCP 3.0 Adapter (BCM957416N4160C))
+Settings for ens7f0np0:
+        Supported ports: [ TP ]
+        Supported link modes:   1000baseT/Full
+                                10000baseT/Full
+        Supported pause frame use: Symmetric Receive-only
+        Supports auto-negotiation: Yes
+        Supported FEC modes: Not reported
+        Advertised link modes:  1000baseT/Full
+                                10000baseT/Full
+        Advertised pause frame use: No
+        Advertised auto-negotiation: Yes
+        Advertised FEC modes: Not reported
+        Speed: 1000Mb/s
+        Lanes: 1
+        Duplex: Full
+        Auto-negotiation: on
+        Port: Twisted Pair
+        PHYAD: 12
+        Transceiver: internal
+        MDI-X: Unknown
+        Supports Wake-on: g
+        Wake-on: g
+        Current message level: 0x00002081 (8321)
+                               drv tx_err hw
+        Link detected: yes
+driver: bnxt_en
+version: 6.13.7-061307-generic
+firmware-version: 227.0.134.0/pkg 227.1.111.0
+expansion-rom-version:
+bus-info: 0000:4c:00.0
+supports-statistics: yes
+supports-test: yes
+supports-eeprom-access: yes
+supports-register-dump: yes
+supports-priv-flags: no
+MAC Address: 04:32:01:f3:e1:a4
+NUMA Node: 0
+CPU Affinity: 124:0-143;125:0-143;126:0-143;127:0-143;128:0-143;129:0-143;130:0-143;131:0-143;132:0-143;133:0-143;134:0-143;135:0-143;136:0-143;137:0-143;138:0-143;139:0-143;140:0-143;141:0-143;142:0-143;143:0-143;144:0-143;145:0-143;146:0-143;147:0-143;148:0-143;149:0-143;150:0-143;151:0-143;152:0-143;153:0-143;154:0-143;155:0-143;156:0-143;157:0-143;158:0-143;159:0-143;160:0-143;161:0-143;162:0-143;163:0-143;164:0-143;165:0-143;166:0-143;167:0-143;168:0-143;169:0-143;170:0-143;171:0-143;172:0-143;173:0-143;174:0-143;175:0-143;176:0-143;177:0-143;178:0-143;179:0-143;180:0-143;181:0-143;182:0-143;184:0-143;185:0-143;186:0-143;187:0-143;188:0-143;189:0-143;190:0-143;191:0-143;192:0-143;193:0-143;194:0-143;195:0-143;196:0-143;197:0-143;198:0-143;
+IRQ Balance: Disabled
+----------------------------------------
+Interface: ens7f1np1
+Vendor: Broadcom Inc. and subsidiaries
+Model: BCM57416 NetXtreme-E Dual-Media 10G RDMA Ethernet Controller (NetXtreme-E Dual-port 10GBASE-T Ethernet OCP 3.0 Adapter (BCM957416N4160C))
+Settings for ens7f1np1:
+        Supported ports: [ TP ]
+        Supported link modes:   1000baseT/Full
+                                10000baseT/Full
+        Supported pause frame use: Symmetric Receive-only
+        Supports auto-negotiation: Yes
+        Supported FEC modes: Not reported
+        Advertised link modes:  1000baseT/Full
+                                10000baseT/Full
+        Advertised pause frame use: Symmetric
+        Advertised auto-negotiation: Yes
+        Advertised FEC modes: Not reported
+        Speed: Unknown!
+        Duplex: Unknown! (255)
+        Auto-negotiation: on
+        Port: Twisted Pair
+        PHYAD: 13
+        Transceiver: internal
+        MDI-X: Unknown
+        Supports Wake-on: g
+        Wake-on: g
+        Current message level: 0x00002081 (8321)
+                               drv tx_err hw
+        Link detected: no
+driver: bnxt_en
+version: 6.13.7-061307-generic
+firmware-version: 227.0.134.0/pkg 227.1.111.0
+expansion-rom-version:
+bus-info: 0000:4c:00.1
+supports-statistics: yes
+supports-test: yes
+supports-eeprom-access: yes
+supports-register-dump: yes
+supports-priv-flags: no
+MAC Address: 04:32:01:f3:e1:a5
+NUMA Node: 0
+CPU Affinity: 454:0-143;455:0-143;456:0-143;457:0-143;458:0-143;459:0-143;460:0-143;461:0-143;462:0-143;463:0-143;464:0-143;465:0-143;466:0-143;467:0-143;468:0-143;469:0-143;470:0-143;471:0-143;472:0-143;473:0-143;474:0-143;475:0-143;476:0-143;477:0-143;478:0-143;479:0-143;480:0-143;481:0-143;482:0-143;483:0-143;484:0-143;485:0-143;486:0-143;487:0-143;488:0-143;489:0-143;490:0-143;491:0-143;492:0-143;493:0-143;494:0-143;495:0-143;496:0-143;497:0-143;498:0-143;499:0-143;500:0-143;501:0-143;502:0-143;503:0-143;504:0-143;505:0-143;506:0-143;507:0-143;508:0-143;509:0-143;510:0-143;511:0-143;512:0-143;513:0-143;514:0-143;515:0-143;516:0-143;517:0-143;518:0-143;519:0-143;520:0-143;521:0-143;522:0-143;523:0-143;524:0-143;525:0-143;526:0-143;527:0-143;
+IRQ Balance: Disabled
+----------------------------------------
+Interface: enx2aecf92702ac
+Vendor: Netchip Technology, Inc.
+Model: Linux-USB Ethernet/RNDIS Gadget
+Settings for enx2aecf92702ac:
+        Supported ports: [  ]
+        Supported link modes:   Not reported
+        Supported pause frame use: No
+        Supports auto-negotiation: No
+        Supported FEC modes: Not reported
+        Advertised link modes:  Not reported
+        Advertised pause frame use: No
+        Advertised auto-negotiation: No
+        Advertised FEC modes: Not reported
+        Speed: 425Mb/s
+        Duplex: Half
+        Auto-negotiation: off
+        Port: Twisted Pair
+        PHYAD: 0
+        Transceiver: internal
+        MDI-X: Unknown
+        Current message level: 0x00000007 (7)
+                               drv probe link
+        Link detected: yes
+driver: cdc_ether
+version: 6.13.7-061307-generic
+firmware-version: CDC Ethernet Device
+expansion-rom-version:
+bus-info: usb-0000:2c:00.0-3.1
+supports-statistics: no
+supports-test: no
+supports-eeprom-access: no
+supports-register-dump: no
+supports-priv-flags: no
+MAC Address: 2a:ec:f9:27:02:ac
+NUMA Node:
+CPU Affinity:
+IRQ Balance: Disabled
+----------------------------------------
+`


### PR DESCRIPTION
This pull request introduces significant updates to the handling of network interface data, focusing on improving data parsing, enhancing script functionality, and refining table definitions. The changes eliminate reliance on the `lshw` tool, replace it with `udevadm` and `ethtool`, and introduce a new parsing function for network interface information. Additionally, test coverage has been expanded to ensure correctness of the new parsing logic.

### Network Interface Data Parsing Enhancements:
* [`internal/report/table_helpers.go`](diffhunk://#diff-74f57111747df6d7e50f502eb3b2009992af236b07af3298ae22be7b5feb2cf5L1345-R1398): Replaced the `nicInfoFromOutput` function with `parseNicInfo`, which now parses NIC information using structured output from `ethtool` and `udevadm`. This change improves accuracy and eliminates dependency on `lshw`. [[1]](diffhunk://#diff-74f57111747df6d7e50f502eb3b2009992af236b07af3298ae22be7b5feb2cf5L1345-R1398) [[2]](diffhunk://#diff-74f57111747df6d7e50f502eb3b2009992af236b07af3298ae22be7b5feb2cf5L1769-R1768)
* [`internal/report/table_helpers_test.go`](diffhunk://#diff-8917c49009ee5a0caf64a78b87faf3f8cdc37fa551ff923256581da7c1bc37c7R354-R548): Added a comprehensive test case (`TestParseNicInfo`) to validate the correctness of the new `parseNicInfo` function.

### Script Updates:
* [`internal/script/script_defs.go`](diffhunk://#diff-eb14347ecb8d0457d616ea7458b375fa88206bb53ac21fa59c48106c1c975536L726-R755): Updated the `NicInfoScriptName` script to use `ethtool` and `udevadm` for fetching NIC details, replacing the previous `lshw`-based approach. This change ensures better compatibility and reduces dependency on external tools.

### Table Definitions Improvements:
* [`internal/report/table_defs.go`](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL372-R387): Adjusted table definitions for `NetworkIRQMappingTableName` and other related tables to align with the new data parsing logic. Removed `lshw` references and streamlined script dependencies. [[1]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL372-R387) [[2]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL513) [[3]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL543)

### Data Model Updates:
* [`internal/report/table_helpers.go`](diffhunk://#diff-74f57111747df6d7e50f502eb3b2009992af236b07af3298ae22be7b5feb2cf5R1332): Extended the `nicInfo` struct to include a new `Vendor` field for capturing vendor information, enhancing the comprehensiveness of NIC data.

### Table Insights Refinement:
* [`internal/report/table_defs.go`](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cR1517): Updated `nicTableValues` to include the new `Vendor` field and adjusted field population logic to utilize the `parseNicInfo` function. [[1]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cR1517) [[2]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL1532-R1550)