### PR TITLE
cross-compile for ARM

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -74,7 +74,7 @@ jobs:
           name: ${{ matrix.runner }} report
           path: perfspect/output/
 
-  test aarch64:
+  test_aarch64:
     needs: [build]
     runs-on: ubuntu-latest-arm64
     steps:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,12 +23,22 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: perfspect
-          path: dist/perfspect*.tgz
-      - name: upload md5
+          path: dist/perfspect.tgz
+      - name: upload perfspect md5
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: md5
-          path: dist/perfspect*.md5.txt
+          path: dist/perfspect.tgz.md5.txt
+      - name: upload perfspect aarch64
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: perfspect-aarch64
+          path: dist/perfspect-aarch64.tgz
+      - name: upload perfspect md5 aarch64
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: md5-aarch64
+          path: dist/perfspect-aarch64.tgz.md5.txt
       - name: upload manifest
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
@@ -51,7 +61,7 @@ jobs:
           name: perfspect
       - name: run test
         run: |
-          tar -xf perfspect*
+          tar -xf perfspect.tgz
           cp .github/mock_mlc perfspect/tools/x86_64/
           cd perfspect
           mkdir output
@@ -62,4 +72,28 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: ${{ matrix.runner }} report
+          path: perfspect/output/
+
+  test aarch64:
+    needs: [build]
+    runs-on: ubuntu-latest-arm64
+    steps:
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: download perspect
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: perfspect-aarch64
+      - name: run test
+        run: |
+          tar -xf perfspect-aarch64.tgz
+          cd perfspect
+          mkdir output
+          ./perfspect report --output output
+          cp -f perfspect.log output/
+      - name: upload report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: ${{ matrix.runner }} report aarch64
           path: perfspect/output/

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -76,7 +76,7 @@ jobs:
 
   test_aarch64:
     needs: [build]
-    runs-on: ubuntu-latest-arm64
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 /perfspect
+/perfspect-aarch64
 /perfspect.log
 /perfspect_202*
 /debug_out
 /tools/bin
 /dist
 /internal/script/resources/x86_64
+/internal/script/resources/aarch64
 /test
 /__debug_bin*.log

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,12 @@ resources:
 	mkdir -p internal/script/resources/x86_64
 	mkdir -p internal/script/resources/aarch64
 ifneq ("$(wildcard /prebuilt/tools)","") # /prebuilt/tools is a directory in the container
-	cp -r /prebuilt/tools/* internal/script/resources/x86_64
+	cp -r /prebuilt/tools/x86_64/* internal/script/resources/x86_64
+	cp -r /prebuilt/tools/aarch64/* internal/script/resources/aarch64
 else # copy dev system tools to script resources
 ifneq ("$(wildcard tools/bin)","")
-		cp -r tools/bin/* internal/script/resources/x86_64
+		cp -r tools/bin/x86_64/* internal/script/resources/x86_64
+		cp -r tools/bin/aarch64/* internal/script/resources/aarch64
 else # no prebuilt tools found
 		@echo "No prebuilt tools found in /prebuilt/tools or tools/bin"
 endif

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -168,7 +168,7 @@ perf:
 	cd linux_perf/tools/perf && make LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1
 	mkdir -p bin
 	cp linux_perf/tools/perf/perf bin/
-	strip --strip-unneeded bin/perf
+	-strip --strip-unneeded bin/perf || true
 	cp linux_perf/tools/perf/perf-archive.sh bin/perf-archive
 	chmod +x bin/perf-archive
 


### PR DESCRIPTION
Use the Go compiler's cross-compilation feature to build perfspect for aarch64.

Much more to-do, e.g., build binary resources for aarch64.