### PR TITLE
add Arrow Lake

### DIFF
--- a/internal/report/cpu_defs.go
+++ b/internal/report/cpu_defs.go
@@ -41,6 +41,7 @@ var cpuDefinitions = []CPUDefinition{
 	{MicroArchitecture: "TGL", Family: "6", Model: "(140|141)", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 2, LogicalThreadCount: 2, CacheWayCount: 0},              // Tiger Lake
 	{MicroArchitecture: "ADL", Family: "6", Model: "(151|154)", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 2, LogicalThreadCount: 2, CacheWayCount: 0},              // Alder Lake
 	{MicroArchitecture: "MTL", Family: "6", Model: "170", Stepping: "4", Architecture: "x86_64", MemoryChannelCount: 2, LogicalThreadCount: 2, CacheWayCount: 0},                   // Meteor Lake
+	{MicroArchitecture: "ARL", Family: "6", Model: "197", Stepping: "2", Architecture: "x86_64", MemoryChannelCount: 2, LogicalThreadCount: 2, CacheWayCount: 0},                   // Arrow Lake
 	// Intel Xeon CPUs
 	{MicroArchitecture: "HSX", Family: "6", Model: "63", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 4, LogicalThreadCount: 2, CacheWayCount: 20},            // Haswell
 	{MicroArchitecture: "BDX", Family: "6", Model: "(79|86)", Stepping: "", Architecture: "x86_64", MemoryChannelCount: 4, LogicalThreadCount: 2, CacheWayCount: 20},       // Broadwell


### PR DESCRIPTION
This pull request adds support for the Arrow Lake microarchitecture to the `cpuDefinitions` array in the `internal/report/cpu_defs.go` file.

Hardware support update:

* [`internal/report/cpu_defs.go`](diffhunk://#diff-106af3936374ffda2e6b338c7f1e79b97f5c4bfcbdf3bbf1b6b623aeb6c750e4R44): Added a new CPU definition for the Arrow Lake microarchitecture, specifying its family, model, stepping, architecture, memory channel count, logical thread count, and cache way count.