### PR TITLE
Cross compile tools for ARM (aarch64)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -51,7 +51,7 @@ jobs:
           name: perfspect
       - name: run test
         run: |
-          tar -xf perfspect*
+          tar -xf perfspect.tgz
           cp .github/mock_mlc perfspect/tools/x86_64/
           cd perfspect
           mkdir output

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,16 +19,26 @@ jobs:
       - name: build perfspect
         run: |
           builder/build.sh
-      - name: upload perfspect
+      - name: upload perfspect x86_64
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: perfspect
-          path: dist/perfspect*.tgz
-      - name: upload md5
+          name: perfspect-x86_64
+          path: dist/perfspect.tgz
+      - name: upload md5 for x86_64
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: md5
-          path: dist/perfspect*.md5.txt
+          name: md5-x86_64
+          path: dist/perfspect.tgz.md5.txt
+      - name: upload perfspect aarch64
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: perfspect-aarch64
+          path: dist/perfspect-aarch64.tgz
+      - name: upload md5 for aarch64
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: md5-aarch64
+          path: dist/perfspect-aarch64.tgz.md5.txt
       - name: upload manifest
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
@@ -48,11 +58,34 @@ jobs:
       - name: download perspect
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: perfspect
+          name: perfspect-x86_64
       - name: run test
         run: |
           tar -xf perfspect.tgz
           cp .github/mock_mlc perfspect/tools/x86_64/
+          cd perfspect
+          mkdir output
+          ./perfspect report --output output
+          cp -f perfspect.log output/
+      - name: upload report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: ${{ matrix.runner }} report
+          path: perfspect/output/
+  test-arm:
+    needs: [build]
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: download perspect aarch64
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: perfspect-aarch64
+      - name: run test
+        run: |
+          tar -xf perfspect-aarch64.tgz
           cd perfspect
           mkdir output
           ./perfspect report --output output

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 /perfspect
+/perfspect-aarch64
 /perfspect.log
 /perfspect_202*
 /debug_out
 /tools/bin
+/tools/bin-aarch64
 /dist
 /internal/script/resources/x86_64
-/test
+/internal/script/resources/aarch64
+//test
 /__debug_bin*.log

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,18 @@ VERSION := $(VERSION_NUMBER)_$(COMMIT_DATE)_$(COMMIT_ID)
 
 default: perfspect
 
-GO=CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go
-GOFLAGS=-trimpath -mod=readonly -gcflags="all=-spectre=all -N -l" -asmflags="all=-spectre=all" -ldflags="-X perfspect/cmd.gVersion=$(VERSION) -s -w"
+GOFLAGS_COMMON=-trimpath -mod=readonly -ldflags="-X perfspect/cmd.gVersion=$(VERSION) -s -w"
+GO=CGO_ENABLED=0 GOOS=linux go
 
 # Build the perfspect binary
 .PHONY: perfspect
 perfspect:
-	$(GO) build $(GOFLAGS) -o $@
+	GOARCH=amd64 $(GO) build $(GOFLAGS_COMMON) -gcflags="all=-spectre=all -N -l" -asmflags="all=-spectre=all" -o $@
+
+# Build the perfspect binary for AARCH64
+.PHONY: perfspect-aarch64
+perfspect-aarch64:
+	GOARCH=arm64 $(GO) build $(GOFLAGS_COMMON) -o $@
 
 # Copy prebuilt tools to script resources
 .PHONY: resources
@@ -33,6 +38,10 @@ ifneq ("$(wildcard tools/bin)","")
 else # no prebuilt tools found
 		@echo "No prebuilt tools found in /prebuilt/tools or tools/bin"
 endif
+endif
+ifneq ("$(wildcard /prebuild/tools/bin-aarch64)","")
+		cp -r tools/bin-aarch64/* internal/script/resources/aarch64
+else # copy dev system tools to script resources
 ifneq ("$(wildcard tools/bin-aarch64)","")
 		cp -r tools/bin-aarch64/* internal/script/resources/aarch64
 else # no prebuilt tools found
@@ -43,7 +52,7 @@ endif
 
 # Build the distribution package
 .PHONY: dist
-dist: resources check perfspect
+dist: resources check perfspect perfspect-aarch64
 	rm -rf dist/perfspect
 	mkdir -p dist/perfspect/tools/x86_64
 	mkdir -p dist/perfspect/tools/aarch64
@@ -54,6 +63,10 @@ dist: resources check perfspect
 	cp perfspect dist/perfspect/
 	cd dist && tar -czf perfspect.tgz perfspect
 	cd dist && md5sum perfspect.tgz > perfspect.tgz.md5.txt
+	# for aarch64 dist, overwrite perfspect binary
+	cp perfspect-aarch64 dist/perfspect/perfspect
+	cd dist && tar -czf perfspect-aarch64.tgz perfspect
+	cd dist && md5sum perfspect-aarch64.tgz > perfspect-aarch64.tgz.md5.txt
 	rm -rf dist/perfspect
 	echo '{"version": "$(VERSION_NUMBER)", "date": "$(COMMIT_DATE)", "time": "$(COMMIT_TIME)", "commit": "$(COMMIT_ID)" }' | jq '.' > dist/manifest.json
 ifneq ("$(wildcard /prebuilt)","") # /prebuilt is a directory in the container
@@ -157,3 +170,4 @@ clean: sweep
 	rm -f perfspect
 	sudo rm -rf dist
 	rm -rf internal/script/resources/x86_64/*
+	rm -rf internal/script/resources/aarch64/*

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ perfspect:
 .PHONY: resources
 resources:
 	mkdir -p internal/script/resources/x86_64
+	mkdir -p internal/script/resources/aarch64
 ifneq ("$(wildcard /prebuilt/tools)","") # /prebuilt/tools is a directory in the container
 	cp -r /prebuilt/tools/* internal/script/resources/x86_64
 else # copy dev system tools to script resources
@@ -31,6 +32,11 @@ ifneq ("$(wildcard tools/bin)","")
 		cp -r tools/bin/* internal/script/resources/x86_64
 else # no prebuilt tools found
 		@echo "No prebuilt tools found in /prebuilt/tools or tools/bin"
+endif
+ifneq ("$(wildcard tools/bin-aarch64)","")
+		cp -r tools/bin-aarch64/* internal/script/resources/aarch64
+else # no prebuilt tools found
+		@echo "No prebuilt tools (aarch64) found in /prebuilt/tools or tools/bin-aarch64"
 endif
 endif
 
@@ -40,6 +46,7 @@ endif
 dist: resources check perfspect
 	rm -rf dist/perfspect
 	mkdir -p dist/perfspect/tools/x86_64
+	mkdir -p dist/perfspect/tools/aarch64
 	cp LICENSE dist/perfspect/
 	cp THIRD_PARTY_PROGRAMS dist/perfspect/
 	cp NOTICE dist/perfspect/
@@ -94,7 +101,7 @@ check_static:
 .PHONY: check_license
 check_license:
 	@echo "Confirming source files have license headers..."
-	@for f in `find . -type f ! -path './perfspect_202*' ! -path './tools/bin/*' ! -path './internal/script/resources/*' ! -path './scripts/.venv/*' ! -path './test/output/*' ! -path './debug_out/*' ! -path './tools/perf-archive/*' ! -path './tools/avx-turbo/*' \( -name "*.go" -o -name "*.s" -o -name "*.html" -o -name "Makefile" -o -name "*.sh" -o -name "*.Dockerfile" -o -name "*.py" \)`; do \
+	@for f in `find . -type f ! -path './perfspect_202*' ! -path './tools/bin/*' ! -path './tools/bin-aarch64/*' ! -path './internal/script/resources/*' ! -path './scripts/.venv/*' ! -path './test/output/*' ! -path './debug_out/*' ! -path './tools/perf-archive/*' ! -path './tools/avx-turbo/*' \( -name "*.go" -o -name "*.s" -o -name "*.html" -o -name "Makefile" -o -name "*.sh" -o -name "*.Dockerfile" -o -name "*.py" \)`; do \
 		if ! grep -E 'SPDX-License-Identifier: BSD-3-Clause' "$$f" >/dev/null; then echo "Error: license not found: $$f"; fail=1; fi; \
 	done; if [ -n "$$fail" ]; then exit 1; fi
 

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -17,6 +17,7 @@ id=$(docker create perfspect-tools:$TAG foo)
 # Copy the tools from the temporary container to your local disk
 # Note: not used in build process, but useful to have around
 docker cp "$id":/bin ./tools
+docker cp "$id":/bin-aarch64 ./tools/bin-aarch64
 
 # Remove the temporary container
 docker rm "$id"

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -311,7 +311,7 @@ endif
 perf-archive:
 	mkdir -p bin
 	cp perf-archive/perf-archive.sh bin/perf-archive
-	chmod +x bin/perf-archive
+	chmod +rx bin/perf-archive
 
 PROCESSWATCH_VERSION := "c394065"	
 processwatch:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -47,7 +47,7 @@ tools-aarch64: async-profiler-aarch64 dmidecode-aarch64 ethtool-aarch64 fio-aarc
 	cp ipmitool-aarch64/src/ipmitool.static bin-aarch64/ipmitool
 	cp lshw-aarch64/src/lshw-static bin-aarch64/lshw
 	cp lspci-aarch64/lspci bin-aarch64/
-	cp lspci-aarch64/pci.ids bin-aarch64/
+	cp lspci-aarch64/pci.ids.gz bin-aarch64/
 	cp spectre-meltdown-checker/spectre-meltdown-checker.sh bin-aarch64/
 	cp sshpass-aarch64/sshpass bin-aarch64/
 	cp stress-ng-aarch64/stress-ng bin-aarch64/
@@ -111,7 +111,7 @@ else
 	cd dmidecode && git checkout master && git pull
 endif
 	cd dmidecode && git checkout $(DMIDECODE_VERSION)
-	cd dmidecode && make
+	cd dmidecode && make -j$(NPROC)
 
 dmidecode-aarch64:
 ifeq ("$(wildcard dmidecode-aarch64)","")
@@ -145,7 +145,7 @@ endif
 ifeq ("$(wildcard ethtool/Makefile)","")
 	cd ethtool && ./autogen.sh && ./configure enable_netlink=no
 endif
-	cd ethtool && make
+	cd ethtool && make -j$(NPROC)
 
 ethtool-aarch64:
 ifeq ("$(wildcard ethtool-aarch64)","")
@@ -170,7 +170,7 @@ endif
 ifeq ("$(wildcard fio/config.log)","")
 	cd fio && ./configure --build-static --disable-native
 endif
-	cd fio && make
+	cd fio && make -j$(NPROC)
 
 fio-aarch64:
 ifeq ("$(wildcard fio-aarch64)","")
@@ -195,7 +195,7 @@ ifeq ("$(wildcard ipmitool/Makefile)","")
 	sed -i "s#x\$$xenable_ipmishell#xno#" ipmitool/configure.ac
 	cd ipmitool && ./bootstrap && LDFLAGS=-static ./configure
 endif
-	cd ipmitool && make
+	cd ipmitool && make -j$(NPROC)
 	cd ipmitool/src && ../libtool --silent --tag=CC --mode=link gcc -fno-strict-aliasing -Wreturn-type -all-static -o ipmitool.static ipmitool.o ipmishell.o ../lib/libipmitool.la plugins/libintf.la
 
 ipmitool-aarch64:
@@ -248,7 +248,7 @@ else
 	cd lspci && git checkout master && git pull
 endif
 	cd lspci && git checkout $(LSPCI_VERSION)
-	cd lspci && make
+	cd lspci && make -j$(NPROC)
 	cd lspci && ./update-pciids.sh
 	cd lspci && gzip -c pci.ids > pci.ids.gz
 
@@ -259,13 +259,12 @@ else
 	cd lspci-aarch64 && git checkout master && git pull
 endif
 	cd lspci-aarch64 && git checkout $(LSPCI_VERSION)
-	#cd lspci-aarch64 && sed -i '/^.*cpu=/d' lib/configure
 	cd lspci-aarch64 && sed -i '/cpu=.*/cpu=aarch64/g' lib/configure
 	cd lspci-aarch64 && sed -i 's/^CROSS_COMPILE=/CROSS_COMPILE?=/g' Makefile
 	cd lspci-aarch64 && sed -i 's/^SHARED=/SHARED?=/g' Makefile
-	cd lspci-aarch64 && sed -i 's/^ZLIB=/ZLIB?=/g' Makefile
-	cd lspci-aarch64 && CROSS_COMPILE=aarch64-linux-gnu- SHARED=no ZLIB=no make -j$(NPROC)
+	cd lspci-aarch64 && CROSS_COMPILE=aarch64-linux-gnu- SHARED=no make -j$(NPROC)
 	cd lspci-aarch64 && ./update-pciids.sh
+	cd lspci-aarch64 && gzip -c pci.ids > pci.ids.gz
 
 MSR_TOOLS_VERSION := "master"
 msr-tools:
@@ -293,7 +292,7 @@ PERF_VERSION := "6.8.12"
 perf:
 	wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-$(PERF_VERSION).tar.xz
 	tar -xf linux-$(PERF_VERSION).tar.xz && mv linux-$(PERF_VERSION)/ linux_perf/
-	cd linux_perf/tools/perf && make LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1
+	cd linux_perf/tools/perf && make LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1 -j$(NPROC)
 	mkdir -p bin
 	cp linux_perf/tools/perf/perf bin/
 	strip --strip-unneeded bin/perf
@@ -304,7 +303,7 @@ ifeq ("$(wildcard perf-aarch64)","")
 	wget -N https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-$(PERF_VERSION).tar.xz
 	tar -xf linux-$(PERF_VERSION).tar.xz && mv linux-$(PERF_VERSION)/ linux_perf-aarch64/
 endif
-	cd linux_perf-aarch64/tools/perf && make LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1 ARCH=arm64 NO_LIBTRACEEVENT=1 CROSS_COMPILE=aarch64-linux-gnu-
+	cd linux_perf-aarch64/tools/perf && make LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1 ARCH=arm64 NO_LIBTRACEEVENT=1 CROSS_COMPILE=aarch64-linux-gnu- -j$(NPROC)
 	mkdir -p bin-aarch64
 	cp linux_perf-aarch64/tools/perf/perf bin-aarch64/
 	aarch64-linux-gnu-strip --strip-unneeded bin-aarch64/perf
@@ -345,7 +344,7 @@ ifeq ("$(wildcard sshpass)","")
 	rm sshpass-$(SSHPASS_VERSION).tar.gz
 	cd sshpass && ./configure
 endif
-	cd sshpass && make
+	cd sshpass && make -j$(NPROC)
 
 sshpass-aarch64:
 ifeq ("$(wildcard sshpass-aarch64)","")
@@ -393,7 +392,7 @@ endif
 ifeq ("$(wildcard sysstat/Makefile)","")
 	cd sysstat && ./configure
 endif
-	cd sysstat && make
+	cd sysstat && make -j$(NPROC)
 
 sysstat-aarch64:
 ifeq ("$(wildcard sysstat-aarch64)","")

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+NPROC := $(shell nproc)
+
 default: tools
 .PHONY: default tools async-profiler avx-turbo cpuid dmidecode ethtool fio ipmitool lshw lspci msr-tools pcm perf perf-archive processwatch spectre-meltdown-checker sshpass stackcollapse-perf stress-ng sysstat tsc turbostat
 
@@ -35,6 +37,28 @@ tools: async-profiler avx-turbo cpuid dmidecode ethtool fio ipmitool lshw lspci 
 	cp linux_turbostat/tools/power/x86/turbostat/turbostat bin/
 	-cd bin && strip --strip-unneeded *
 
+tools-aarch64: async-profiler-aarch64 dmidecode-aarch64 ethtool-aarch64 fio-aarch64 ipmitool-aarch64 lshw-aarch64 lspci-aarch64 spectre-meltdown-checker sshpass-aarch64 stackcollapse-perf-aarch64 stress-ng-aarch64 sysstat-aarch64 tsc-aarch64
+	mkdir -p bin-aarch64
+	cp -R async-profiler-aarch64 bin-aarch64/
+	cp dmidecode-aarch64/dmidecode bin-aarch64/
+	cp ethtool-aarch64/ethtool bin-aarch64/
+	cp fio-aarch64/fio bin-aarch64/	
+	cp stackcollapse-perf/stackcollapse-perf-aarch64 bin-aarch64/stackcollapse-perf
+	cp ipmitool-aarch64/src/ipmitool.static bin-aarch64/ipmitool
+	cp lshw-aarch64/src/lshw-static bin-aarch64/lshw
+	cp lspci-aarch64/lspci bin-aarch64/
+	cp lspci-aarch64/pci.ids bin-aarch64/
+	cp spectre-meltdown-checker/spectre-meltdown-checker.sh bin-aarch64/
+	cp sshpass-aarch64/sshpass bin-aarch64/
+	cp stress-ng-aarch64/stress-ng bin-aarch64/
+	cp sysstat-aarch64/mpstat bin-aarch64/
+	cp sysstat-aarch64/iostat bin-aarch64/
+	cp sysstat-aarch64/sar bin-aarch64/
+	cp sysstat-aarch64/sadc bin-aarch64/
+	cp tsc/tsc-aarch64 bin-aarch64/tsc
+	-cd bin-aarch64 && aarch64-linux-gnu-strip --strip-unneeded * || true
+
+
 ASYNC_PROFILER_VERSION := "4.0"
 async-profiler:
 ifeq ("$(wildcard async-profiler)","")
@@ -43,6 +67,15 @@ ifeq ("$(wildcard async-profiler-$(ASYNC_PROFILER_VERSION)-linux-x64.tar.gz)",""
 endif
 	tar -xf async-profiler-$(ASYNC_PROFILER_VERSION)-linux-x64.tar.gz && mv async-profiler-$(ASYNC_PROFILER_VERSION)-linux-x64 async-profiler
 endif
+
+async-profiler-aarch64:
+ifeq ("$(wildcard async-profiler-aarch64)","")
+ifeq ("$(wildcard async-profiler-$(ASYNC_PROFILER_VERSION)-linux-arm64.tar.gz)","")
+	wget https://github.com/jvm-profiling-tools/async-profiler/releases/download/v$(ASYNC_PROFILER_VERSION)/async-profiler-$(ASYNC_PROFILER_VERSION)-linux-arm64.tar.gz
+endif
+	tar -xf async-profiler-$(ASYNC_PROFILER_VERSION)-linux-arm64.tar.gz && mv async-profiler-$(ASYNC_PROFILER_VERSION)-linux-arm64 async-profiler-aarch64
+endif
+
 
 AVX_TURBO_VERSION := "9cfe8bf"
 avx-turbo:
@@ -80,6 +113,27 @@ endif
 	cd dmidecode && git checkout $(DMIDECODE_VERSION)
 	cd dmidecode && make
 
+dmidecode-aarch64:
+ifeq ("$(wildcard dmidecode-aarch64)","")
+	git clone https://github.com/mirror/dmidecode.git dmidecode-aarch64
+else
+	cd dmidecode-aarch64 && git checkout master && git pull
+endif
+	cd dmidecode-aarch64 && git checkout $(DMIDECODE_VERSION)
+	cd dmidecode-aarch64 && CC=aarch64-linux-gnu-gcc make -j$(NPROC)
+
+ELFUTILS_VERSION := "0.186"
+elfutils-aarch64: zlib-aarch64
+ifeq ("$(wildcard elfutils-aarch64)","")
+	wget https://sourceware.org/elfutils/ftp/0.186/elfutils-$(ELFUTILS_VERSION).tar.bz2 
+	mkdir -p elfutils-tmp
+	bzip2 -dc elfutils-$(ELFUTILS_VERSION).tar.bz2 | tar -C elfutils-tmp -xf -
+	mv elfutils-tmp/elfutils-$(ELFUTILS_VERSION) elfutils-aarch64 && rm -rf elfutils-tmp
+endif
+	cd elfutils-aarch64 && ./configure --host=aarch64-linux-gnu --disable-debuginfod --disable-libdebuginfod
+	cd elfutils-aarch64 && make -j$(NPROC)
+	cd elfutils-aarch64 && cp libelf/libelf.a /usr/lib/aarch64-linux-gnu/
+
 ETHTOOL_VERSION := "v6.5"
 ethtool:
 ifeq ("$(wildcard ethtool)","")
@@ -93,6 +147,18 @@ ifeq ("$(wildcard ethtool/Makefile)","")
 endif
 	cd ethtool && make
 
+ethtool-aarch64:
+ifeq ("$(wildcard ethtool-aarch64)","")
+	git clone https://git.kernel.org/pub/scm/network/ethtool/ethtool.git ethtool-aarch64
+else
+	cd ethtool-aarch64 && git checkout master && git pull
+endif
+	cd ethtool-aarch64 && git checkout $(ETHTOOL_VERSION)
+ifeq ("$(wildcard ethtool-aarch64/Makefile)","")
+	cd ethtool-aarch64 && ./autogen.sh && ./configure --host aarch64-linux-gnu enable_netlink=no
+endif
+	cd ethtool-aarch64 && make -j$(NPROC)
+
 FIO_VERSION := "fio-3.38"
 fio:
 ifeq ("$(wildcard fio)","")
@@ -105,6 +171,18 @@ ifeq ("$(wildcard fio/config.log)","")
 	cd fio && ./configure --build-static --disable-native
 endif
 	cd fio && make
+
+fio-aarch64:
+ifeq ("$(wildcard fio-aarch64)","")
+	git clone https://github.com/axboe/fio.git fio-aarch64
+else
+	cd fio-aarch64 && git checkout master && git pull
+endif
+	cd fio-aarch64 && git checkout $(FIO_VERSION)
+ifeq ("$(wildcard fio-aarch64/config.log)","")
+	cd fio-aarch64 && ./configure --build-static --disable-native --cc=aarch64-linux-gnu-gcc
+endif
+	cd fio-aarch64 && make -j$(NPROC)
 
 IPMITOOL_VERSION := "IPMITOOL_1_8_19"
 ipmitool:
@@ -120,6 +198,29 @@ endif
 	cd ipmitool && make
 	cd ipmitool/src && ../libtool --silent --tag=CC --mode=link gcc -fno-strict-aliasing -Wreturn-type -all-static -o ipmitool.static ipmitool.o ipmishell.o ../lib/libipmitool.la plugins/libintf.la
 
+ipmitool-aarch64:
+ifeq ("$(wildcard ipmitool-aarch64)","")
+	git clone https://github.com/ipmitool/ipmitool.git ipmitool-aarch64
+endif
+	cd ipmitool-aarch64 && git checkout $(IPMITOOL_VERSION)
+ifeq ("$(wildcard ipmitool-aarch64/Makefile)","")
+	# hack to get around static build problem - don't check for libreadline
+	sed -i "s#x\$$xenable_ipmishell#xno#" ipmitool-aarch64/configure.ac
+	cd ipmitool-aarch64 && ./bootstrap && LDFLAGS=-static ./configure --host=aarch64-linux-gnu
+endif
+	cd ipmitool-aarch64 && CC=aarch64-linux-gnu-gcc make -j$(NPROC)
+	cd ipmitool-aarch64/src && ../libtool --silent --tag=CC --mode=link aarch64-linux-gnu-gcc -fno-strict-aliasing -Wreturn-type -all-static -o ipmitool.static ipmitool.o ipmishell.o ../lib/libipmitool.la plugins/libintf.la
+
+LIBPFM4_VERSION := "v4.11.1"
+libpfm4-aarch64:
+ifeq ("$(wildcard libpfm4-aarch64)","")
+	git clone https://git.code.sf.net/p/perfmon2/libpfm4 libpfm4-aarch64
+endif
+	cd libpfm4-aarch64 && git checkout $(LIBPFM4_VERSION)
+	cd libpfm4-aarch64 && sed -i 's/^ARCH :=/ARCH ?=/' config.mk
+	cd libpfm4-aarch64 && ARCH=arm64 CC=aarch64-linux-gnu-gcc make -j$(NPROC)
+	cd libpfm4-aarch64 && cp lib/libpfm.a /usr/lib/aarch64-linux-gnu/
+
 LSHW_VERSION := "B.02.19"
 lshw:
 ifeq ("$(wildcard lshw)","")
@@ -129,6 +230,15 @@ else
 endif
 	cd lshw && git checkout $(LSHW_VERSION)
 	cd lshw/src && make static
+
+lshw-aarch64:
+ifeq ("$(wildcard lshw-aarch64)","")
+	git clone https://github.com/lyonel/lshw.git lshw-aarch64
+else
+	cd lshw-aarch64 && git checkout master && git pull
+endif
+	cd lshw-aarch64 && git checkout $(LSHW_VERSION)
+	cd lshw-aarch64/src && STRIP=aarch64-linux-gnu-strip CXX=aarch64-linux-gnu-g++ make static
 
 LSPCI_VERSION := "v3.13.0"
 lspci:
@@ -141,6 +251,21 @@ endif
 	cd lspci && make
 	cd lspci && ./update-pciids.sh
 	cd lspci && gzip -c pci.ids > pci.ids.gz
+
+lspci-aarch64: zlib-aarch64
+ifeq ("$(wildcard lspc-aarch64)","")
+	git clone https://github.com/pciutils/pciutils.git lspci-aarch64
+else
+	cd lspci-aarch64 && git checkout master && git pull
+endif
+	cd lspci-aarch64 && git checkout $(LSPCI_VERSION)
+	#cd lspci-aarch64 && sed -i '/^.*cpu=/d' lib/configure
+	cd lspci-aarch64 && sed -i '/cpu=.*/cpu=aarch64/g' lib/configure
+	cd lspci-aarch64 && sed -i 's/^CROSS_COMPILE=/CROSS_COMPILE?=/g' Makefile
+	cd lspci-aarch64 && sed -i 's/^SHARED=/SHARED?=/g' Makefile
+	cd lspci-aarch64 && sed -i 's/^ZLIB=/ZLIB?=/g' Makefile
+	cd lspci-aarch64 && CROSS_COMPILE=aarch64-linux-gnu- SHARED=no ZLIB=no make -j$(NPROC)
+	cd lspci-aarch64 && ./update-pciids.sh
 
 MSR_TOOLS_VERSION := "master"
 msr-tools:
@@ -172,6 +297,17 @@ perf:
 	mkdir -p bin
 	cp linux_perf/tools/perf/perf bin/
 	strip --strip-unneeded bin/perf
+
+perf-aarch64: PERF_VERSION := "6.15.3"
+perf-aarch64: zlib-aarch64 elfutils-aarch64 libpfm4-aarch64
+ifeq ("$(wildcard perf-aarch64)","")
+	wget -N https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-$(PERF_VERSION).tar.xz
+	tar -xf linux-$(PERF_VERSION).tar.xz && mv linux-$(PERF_VERSION)/ linux_perf-aarch64/
+endif
+	cd linux_perf-aarch64/tools/perf && make LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1 ARCH=arm64 NO_LIBTRACEEVENT=1 CROSS_COMPILE=aarch64-linux-gnu-
+	mkdir -p bin-aarch64
+	cp linux_perf-aarch64/tools/perf/perf bin-aarch64/
+	aarch64-linux-gnu-strip --strip-unneeded bin-aarch64/perf
 
 perf-archive:
 	mkdir -p bin
@@ -211,8 +347,21 @@ ifeq ("$(wildcard sshpass)","")
 endif
 	cd sshpass && make
 
+sshpass-aarch64:
+ifeq ("$(wildcard sshpass-aarch64)","")
+	wget https://sourceforge.net/projects/sshpass/files/sshpass/$(SSHPASS_VERSION)/sshpass-$(SSHPASS_VERSION).tar.gz
+	tar -xf sshpass-$(SSHPASS_VERSION).tar.gz
+	mv sshpass-$(SSHPASS_VERSION) sshpass-aarch64
+	rm sshpass-$(SSHPASS_VERSION).tar.gz
+	cd sshpass-aarch64 && ./configure --host=aarch64-linux-gnu
+endif
+	cd sshpass-aarch64 && make -j$(NPROC)
+
 stackcollapse-perf:
 	cd stackcollapse-perf && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
+
+stackcollapse-perf-aarch64:
+	cd stackcollapse-perf && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $@
 
 STRESS_NG_VERSION := "V0.13.08"
 stress-ng:
@@ -222,7 +371,16 @@ else
 	cd stress-ng && git checkout master && git pull
 endif
 	cd stress-ng && git checkout $(STRESS_NG_VERSION)
-	cd stress-ng && STATIC=1 make
+	cd stress-ng && STATIC=1 make -j$(NPROC)
+
+stress-ng-aarch64:
+ifeq ("$(wildcard stress-ng-aarch64)","")
+	git clone https://github.com/ColinIanKing/stress-ng.git stress-ng-aarch64
+else
+	cd stress-ng-aarch64 && git checkout master && git pull
+endif
+	cd stress-ng-aarch64 && git checkout $(STRESS_NG_VERSION)
+	cd stress-ng-aarch64 && CC=aarch64-linux-gnu-gcc STATIC=1 make -j$(NPROC)
 
 SYSSTAT_VERSION := "v12.7.6"
 sysstat:
@@ -237,8 +395,23 @@ ifeq ("$(wildcard sysstat/Makefile)","")
 endif
 	cd sysstat && make
 
+sysstat-aarch64:
+ifeq ("$(wildcard sysstat-aarch64)","")
+	git clone https://github.com/sysstat/sysstat.git sysstat-aarch64
+else
+	cd sysstat-aarch64 && git checkout master && git pull
+endif
+	cd sysstat-aarch64 && git checkout $(SYSSTAT_VERSION)
+ifeq ("$(wildcard sysstat-aarch64/Makefile)","")
+	cd sysstat-aarch64 && ./configure --host=aarch64-linux-gnu
+endif
+	cd sysstat-aarch64 && make -j$(NPROC)
+
 tsc:
 	cd tsc && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build
+
+tsc-aarch64:
+	cd tsc && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o tsc-aarch64
 
 TURBOSTAT_VERSION := "6.9.12"
 turbostat:
@@ -246,6 +419,14 @@ turbostat:
 	tar -xf linux-$(TURBOSTAT_VERSION).tar.xz && mv linux-$(TURBOSTAT_VERSION)/ linux_turbostat/
 	sed -i '/_Static_assert/d' linux_turbostat/tools/power/x86/turbostat/turbostat.c
 	cd linux_turbostat/tools/power/x86/turbostat && make
+
+zlib-aarch64:
+ifeq ("$(wildcard zlib-aarch64)","")
+	git clone https://github.com/madler/zlib.git zlib-aarch64
+endif
+	cd zlib-aarch64 && CHOST=aarch64-linux-gnu ./configure --archs="" --static
+	cd zlib-aarch64 && make -j$(NPROC)
+	cd zlib-aarch64 && cp libz.a /usr/lib/aarch64-linux-gnu/
 
 reset:
 	cd async-profiler

--- a/tools/build.Dockerfile
+++ b/tools/build.Dockerfile
@@ -59,7 +59,10 @@ RUN for i in {1..5}; do \
         add-apt-repository ppa:git-core/ppa -y && break; \
         echo "Retrying in 5 seconds... ($i/5)" && sleep 5; \
     done
-RUN for i in {1..5}; do \
+
+# Use relatively small ulimit. This is due to pycompile, see: https://github.com/MaastrichtUniversity/docker-dev/commit/97ab4fd04534f73c023371b07e188918b73ac9d0
+# This works around python-pkg-resources taking a extremely long time to install
+RUN ulimit -n 4096 && for i in {1..5}; do \
         apt-get update && apt-get install -y \
         automake autotools-dev binutils-dev bison build-essential clang cmake debuginfod \
         default-jdk default-jre docbook-utils flex gawk git libaio-dev libaio1 \


### PR DESCRIPTION
Cross compile supporting toolchain (where possible)
For perf, I bumped up the version to get a newer version of perf that supports Neoverse V2 cores

processwatch has ARM support, but we can't crosscompile right now as we need an ARM kernel to do the btf dump
e.g.
```
src/bpf/insn/build.sh
${BPFTOOL} btf dump file /sys/kernel/btf/vmlinux format c > ${DIR}/vmlinux.h
```

Did a basic perf test on a Neoverse V2 guest to validate perf:
```
$ sudo ./perf stat -- sleep 1

 Performance counter stats for 'sleep 1':

              0.53 msec task-clock                       #    0.001 CPUs utilized
                 2      context-switches                 #    3.784 K/sec
                 0      cpu-migrations                   #    0.000 /sec
                65      page-faults                      #  122.975 K/sec
           1547407      instructions                     #    1.10  insn per cycle
                                                  #    0.34  stalled cycles per insn
           1412410      cycles                           #    2.672 GHz
            504472      stalled-cycles-frontend          #   35.72% frontend cycles idle
            519564      stalled-cycles-backend           #   36.79% backend cycles idle
              8354      branch-misses
```