### PR TITLE
prepare target for configuration changes to avoid conflict and/or race condition

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -149,7 +149,32 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// prepareTarget prepares the target for configuration changes
+// almost all set scripts require the msr kernel module to be loaded and
+// use wrmsr and rdmsr, so we do that here so that the goroutines for the
+// set scripts can run in parallel without conflicts
+func prepareTarget(myTarget target.Target, localTempDir string) (err error) {
+	prepareScript := script.ScriptDefinition{
+		Name:           "prepare-target",
+		ScriptTemplate: "exit 0",
+		Superuser:      true,
+		Vendors:        []string{"GenuineIntel"},
+		Depends:        []string{"wrmsr", "rdmsr"},
+		Lkms:           []string{"msr"},
+	}
+	_, err = runScript(myTarget, prepareScript, localTempDir)
+	return err
+}
+
 func setOnTarget(cmd *cobra.Command, myTarget target.Target, flagGroups []flagGroup, localTempDir string, channelError chan error, statusUpdate progress.MultiSpinnerUpdateFunc) {
+	// prepare the target for configuration changes
+	_ = statusUpdate(myTarget.GetName(), "preparing target for configuration changes")
+	if err := prepareTarget(myTarget, localTempDir); err != nil {
+		_ = statusUpdate(myTarget.GetName(), fmt.Sprintf("error preparing target: %v", err))
+		slog.Error(fmt.Sprintf("error preparing target %s: %v", myTarget.GetName(), err))
+		channelError <- nil
+		return
+	}
 	channelSetComplete := make(chan setOutput)
 	var successMessages []string
 	var errorMessages []string

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -172,8 +172,8 @@ func setLlcSize(desiredLlcSize float64, myTarget target.Target, localTempDir str
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0xC90 %d", msrVal),
 		Superuser:      true,
 		Vendors:        []string{"GenuineIntel"},
-		Depends:        []string{"wrmsr"},
-		Lkms:           []string{"msr"},
+		// Depends:        []string{"wrmsr"},
+		// Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -227,7 +227,8 @@ func setCoreFrequency(coreFrequency float64, myTarget target.Target, localTempDi
 				ScriptTemplate: fmt.Sprintf("wrmsr 0x774 %d", value),
 				Superuser:      true,
 				Vendors:        []string{"GenuineIntel"},
-				Depends:        []string{"wrmsr"},
+				// Depends:        []string{"wrmsr"},
+				// Lkms:           []string{"msr"},
 			}
 		} else {
 			value := freqInt << uint(2*8)
@@ -236,7 +237,8 @@ func setCoreFrequency(coreFrequency float64, myTarget target.Target, localTempDi
 				ScriptTemplate: fmt.Sprintf("wrmsr 0x199 %d", value),
 				Superuser:      true,
 				Vendors:        []string{"GenuineIntel"},
-				Depends:        []string{"wrmsr"},
+				// Depends:        []string{"wrmsr"},
+				// Lkms:           []string{"msr"},
 			}
 		}
 	} else {
@@ -250,7 +252,8 @@ func setCoreFrequency(coreFrequency float64, myTarget target.Target, localTempDi
 			ScriptTemplate: fmt.Sprintf("wrmsr -a 0x1AD %d", value),
 			Superuser:      true,
 			Vendors:        []string{"GenuineIntel"},
-			Depends:        []string{"wrmsr"},
+			// Depends:        []string{"wrmsr"},
+			// Lkms:           []string{"msr"},
 		}
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
@@ -333,9 +336,9 @@ func setUncoreFrequency(maxFreq bool, uncoreFrequency float64, myTarget target.T
 		Name:           "get uncore frequency MSR",
 		ScriptTemplate: "rdmsr 0x620",
 		Vendors:        []string{"GenuineIntel"},
-		Depends:        []string{"rdmsr"},
-		Lkms:           []string{"msr"},
 		Superuser:      true,
+		// Depends:        []string{"rdmsr"},
+		// Lkms:           []string{"msr"},
 	})
 	outputs, err := script.RunScripts(myTarget, scripts, true, localTempDir)
 	if err != nil {
@@ -379,8 +382,8 @@ func setUncoreFrequency(maxFreq bool, uncoreFrequency float64, myTarget target.T
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0x620 %d", newVal),
 		Superuser:      true,
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"wrmsr"},
+		// Depends:        []string{"wrmsr"},
+		// Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -395,8 +398,8 @@ func setTDP(power int, myTarget target.Target, localTempDir string, completeChan
 		ScriptTemplate: "rdmsr 0x610",
 		Superuser:      true,
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"rdmsr"},
+		// Lkms:           []string{"msr"},
+		// Depends:        []string{"rdmsr"},
 	}
 	readOutput, err := script.RunScript(myTarget, readScript, localTempDir)
 	if err != nil {
@@ -418,8 +421,8 @@ func setTDP(power int, myTarget target.Target, localTempDir string, completeChan
 				ScriptTemplate: fmt.Sprintf("wrmsr -a 0x610 %d", newVal),
 				Superuser:      true,
 				Vendors:        []string{"GenuineIntel"},
-				Lkms:           []string{"msr"},
-				Depends:        []string{"wrmsr"},
+				// Depends:        []string{"wrmsr"},
+				// Lkms:           []string{"msr"},
 			}
 			_, err := runScript(myTarget, setScript, localTempDir)
 			if err != nil {
@@ -457,9 +460,9 @@ func setEPB(epb int, myTarget target.Target, localTempDir string, completeChanne
 		Name:           "read " + msr,
 		ScriptTemplate: "rdmsr " + msr,
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"rdmsr"},
 		Superuser:      true,
+		// Lkms:           []string{"msr"},
+		// Depends:        []string{"rdmsr"},
 	}
 	readOutput, err := runScript(myTarget, readScript, localTempDir)
 	if err != nil {
@@ -481,8 +484,8 @@ func setEPB(epb int, myTarget target.Target, localTempDir string, completeChanne
 		ScriptTemplate: fmt.Sprintf("wrmsr -a %s %d", msr, msrValue),
 		Superuser:      true,
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"wrmsr"},
+		// Depends:        []string{"wrmsr"},
+		// Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -500,9 +503,9 @@ func setEPP(epp int, myTarget target.Target, localTempDir string, completeChanne
 		Name:           "get epp msr",
 		ScriptTemplate: "rdmsr 0x774", // IA32_HWP_REQUEST
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"rdmsr"},
 		Superuser:      true,
+		// Lkms:           []string{"msr"},
+		// Depends:        []string{"rdmsr"},
 	}
 	stdout, err := runScript(myTarget, getScript, localTempDir)
 	if err != nil {
@@ -524,8 +527,8 @@ func setEPP(epp int, myTarget target.Target, localTempDir string, completeChanne
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0x774 %d", eppValue),
 		Superuser:      true,
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"wrmsr"},
+		// Depends:        []string{"wrmsr"},
+		// Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -537,9 +540,9 @@ func setEPP(epp int, myTarget target.Target, localTempDir string, completeChanne
 		Name:           "get epp pkg msr",
 		ScriptTemplate: "rdmsr 0x772", // IA32_HWP_REQUEST_PKG
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"rdmsr"},
 		Superuser:      true,
+		// Lkms:           []string{"msr"},
+		// Depends:        []string{"rdmsr"},
 	}
 	stdout, err = runScript(myTarget, getScript, localTempDir)
 	if err != nil {
@@ -561,8 +564,8 @@ func setEPP(epp int, myTarget target.Target, localTempDir string, completeChanne
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0x772 %d", eppValue),
 		Superuser:      true,
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"wrmsr"},
+		// Depends:        []string{"wrmsr"},
+		// Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -601,7 +604,7 @@ func setELC(elc string, myTarget target.Target, localTempDir string, completeCha
 		Superuser:      true,
 		Vendors:        []string{"GenuineIntel"},
 		Models:         []string{"173", "174", "175", "221"}, // GNR, GNR-D, SRF, CWF
-		Depends:        []string{"bhs-power-mode.sh"},
+		Depends:        []string{"bhs-power-mode.sh", "pcm-tpmi"},
 	}
 	_, err := runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -642,9 +645,9 @@ func setPrefetcher(enableDisable string, myTarget target.Target, localTempDir st
 		Name:           "get prefetcher msr",
 		ScriptTemplate: fmt.Sprintf("rdmsr %d", pf.Msr),
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"rdmsr"},
 		Superuser:      true,
+		// Lkms:           []string{"msr"},
+		// Depends:        []string{"rdmsr"},
 	}
 	stdout, err := runScript(myTarget, getScript, localTempDir)
 	if err != nil {
@@ -675,10 +678,10 @@ func setPrefetcher(enableDisable string, myTarget target.Target, localTempDir st
 	setScript := script.ScriptDefinition{
 		Name:           "set prefetcher" + prefetcherType,
 		ScriptTemplate: fmt.Sprintf("wrmsr -a %d %d", pf.Msr, newVal),
-		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"wrmsr"},
 		Superuser:      true,
+		Vendors:        []string{"GenuineIntel"},
+		// Depends:        []string{"wrmsr"},
+		// Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -747,9 +750,9 @@ func setC1Demotion(enableDisable string, myTarget target.Target, localTempDir st
 		Name:           "get C1 demotion",
 		ScriptTemplate: "rdmsr 0xe2",
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"rdmsr"},
 		Superuser:      true,
+		// Lkms:           []string{"msr"},
+		// Depends:        []string{"rdmsr"},
 	}
 	stdout, err := runScript(myTarget, getScript, localTempDir)
 	if err != nil {
@@ -782,9 +785,9 @@ func setC1Demotion(enableDisable string, myTarget target.Target, localTempDir st
 		Name:           "set C1 demotion",
 		ScriptTemplate: fmt.Sprintf("wrmsr -a %d %d", 0xe2, newVal),
 		Vendors:        []string{"GenuineIntel"},
-		Lkms:           []string{"msr"},
-		Depends:        []string{"wrmsr"},
 		Superuser:      true,
+		// Depends:        []string{"wrmsr"},
+		// Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces a new function to prepare targets for configuration changes and modifies dependencies and kernel module requirements across various configuration scripts. The changes aim to streamline the setup process and reduce potential conflicts during parallel execution of scripts.

### New Functionality:
* [`cmd/config/config.go`](diffhunk://#diff-c6dc0c872cdd5407c8299f5b807a80a79ddf78e91e86c3c618508ca84c048d68R152-R177): Added the `prepareTarget` function to handle pre-configuration setup, including loading the `msr` kernel module and preparing dependencies like `wrmsr` and `rdmsr`. This ensures that subsequent scripts can run in parallel without conflicts.

### Dependency Adjustments:
* [`cmd/config/set.go`](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L175-R176): Commented out `Depends` and `Lkms` fields for multiple scripts (e.g., `wrmsr`, `rdmsr`) across functions like `setLlcSize`, `setCoreFrequency`, `setUncoreFrequency`, `setTDP`, `setEPB`, `setEPP`, `setPrefetcher`, and `setC1Demotion`. These changes indicate that the dependencies are no longer explicitly required in the script definitions. [[1]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L175-R176) [[2]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L230-R231) [[3]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L336-R341) [[4]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L398-R402) [[5]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L460-R465) [[6]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L503-R508) [[7]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L645-R650) [[8]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L750-R755)

### Additional Dependency Inclusion:
* [`cmd/config/set.go`](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L604-R607): Updated the `Depends` field in the `setELC` function to include `"pcm-tpmi"` alongside `"bhs-power-mode.sh"`, reflecting new requirements for this script.