### PR TITLE
x86_64 and aarch64 tools build as siblings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,6 @@ sweep:
 clean: sweep
 	@echo "Cleaning up..."
 	rm -f perfspect
+	rm -f perfspect-aarch64
 	sudo rm -rf dist
-	rm -rf internal/script/resources/x86_64/*
-	rm -rf internal/script/resources/aarch64/*
+	rm -rf internal/script/resources

--- a/Makefile
+++ b/Makefile
@@ -28,27 +28,18 @@ perfspect-aarch64:
 # Copy prebuilt tools to script resources
 .PHONY: resources
 resources:
-	mkdir -p internal/script/resources/x86_64
-	mkdir -p internal/script/resources/aarch64
+	mkdir -p internal/script/resources
 ifneq ("$(wildcard /prebuilt/tools)","") # /prebuilt/tools is a directory in the container
-	cp -r /prebuilt/tools/* internal/script/resources/x86_64
+	@echo "Copying prebuilt tools from /prebuilt/tools to script resources"
+	cp -r /prebuilt/tools/* internal/script/resources/
 else # copy dev system tools to script resources
 ifneq ("$(wildcard tools/bin)","")
-		cp -r tools/bin/* internal/script/resources/x86_64
+		@echo "Copying dev system tools from tools/bin to script resources"
+		cp -r tools/bin/* internal/script/resources/
 else # no prebuilt tools found
 		@echo "No prebuilt tools found in /prebuilt/tools or tools/bin"
 endif
 endif
-ifneq ("$(wildcard /prebuild/tools/bin-aarch64)","")
-		cp -r tools/bin-aarch64/* internal/script/resources/aarch64
-else # copy dev system tools to script resources
-ifneq ("$(wildcard tools/bin-aarch64)","")
-		cp -r tools/bin-aarch64/* internal/script/resources/aarch64
-else # no prebuilt tools found
-		@echo "No prebuilt tools (aarch64) found in /prebuilt/tools or tools/bin-aarch64"
-endif
-endif
-
 
 # Build the distribution package
 .PHONY: dist

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -11,17 +11,6 @@ TAG=v1
 # build tools image
 docker build -f tools/build.Dockerfile --tag perfspect-tools:$TAG ./tools
 
-# Create a temporary container from the tools image
-id=$(docker create perfspect-tools:$TAG foo)
-
-# Copy the tools from the temporary container to your local disk
-# Note: not used in build process, but useful to have around
-docker cp "$id":/bin ./tools
-docker cp "$id":/bin-aarch64 ./tools/bin-aarch64
-
-# Remove the temporary container
-docker rm "$id"
-
 # build the perfspect builder image
 docker build -f builder/build.Dockerfile --build-arg TAG=$TAG --tag perfspect-builder:$TAG .
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -6,58 +6,62 @@
 
 NPROC := $(shell nproc)
 
-default: tools
-.PHONY: default tools async-profiler avx-turbo cpuid dmidecode ethtool fio ipmitool lshw lspci msr-tools pcm perf perf-archive processwatch spectre-meltdown-checker sshpass stackcollapse-perf stress-ng sysstat tsc turbostat
+default: tools-x86_64
+.PHONY: default tools tools-aarch64 tools-x86_64 async-profiler avx-turbo cpuid dmidecode ethtool fio ipmitool lshw lspci msr-tools pcm perf-x86_64 processwatch spectre-meltdown-checker sshpass stackcollapse-perf stress-ng sysstat tsc turbostat
 
-tools: async-profiler avx-turbo cpuid dmidecode ethtool fio ipmitool lshw lspci msr-tools pcm perf-archive spectre-meltdown-checker sshpass stackcollapse-perf stress-ng sysstat tsc turbostat
-	mkdir -p bin
-	cp -R async-profiler bin/
-	cp avx-turbo/avx-turbo bin/
-	cp cpuid/cpuid bin/
-	cp dmidecode/dmidecode bin/
-	cp ethtool/ethtool bin/
-	cp fio/fio bin/
-	cp stackcollapse-perf/stackcollapse-perf bin/
-	cp ipmitool/src/ipmitool.static bin/ipmitool
-	cp lshw/src/lshw-static bin/lshw
-	cp lspci/lspci bin/
-	cp lspci/pci.ids.gz bin/
-	cp msr-tools/rdmsr bin/
-	cp msr-tools/wrmsr bin/
-	cp pcm/build/bin/pcm-tpmi bin/
-	cp pcm/scripts/bhs-power-mode.sh bin/
-	cp spectre-meltdown-checker/spectre-meltdown-checker.sh bin/
-	cp sshpass/sshpass bin/
-	cp stress-ng/stress-ng bin/
-	cp sysstat/mpstat bin/
-	cp sysstat/iostat bin/
-	cp sysstat/sar bin/
-	cp sysstat/sadc bin/
-	cp tsc/tsc bin/
-	cp linux_turbostat/tools/power/x86/turbostat/turbostat bin/
-	-cd bin && strip --strip-unneeded *
+tools-x86_64: async-profiler avx-turbo cpuid dmidecode ethtool fio ipmitool lshw lspci msr-tools pcm spectre-meltdown-checker sshpass stackcollapse-perf stress-ng sysstat tsc turbostat
+	mkdir -p bin/x86_64
+	cp -R async-profiler bin/x86_64/
+	cp avx-turbo/avx-turbo bin/x86_64/
+	cp cpuid/cpuid bin/x86_64/
+	cp dmidecode/dmidecode bin/x86_64/
+	cp ethtool/ethtool bin/x86_64/
+	cp fio/fio bin/x86_64/
+	cp stackcollapse-perf/stackcollapse-perf bin/x86_64/
+	cp ipmitool/src/ipmitool.static bin/x86_64/ipmitool
+	cp lshw/src/lshw-static bin/x86_64/lshw
+	cp lspci/lspci bin/x86_64/
+	cp lspci/pci.ids.gz bin/x86_64/
+	cp msr-tools/rdmsr bin/x86_64/
+	cp msr-tools/wrmsr bin/x86_64/
+	cp pcm/build/bin/pcm-tpmi bin/x86_64/
+	cp pcm/scripts/bhs-power-mode.sh bin/x86_64/
+	cp perf-archive/perf-archive.sh bin/x86_64/perf-archive && chmod +rx bin/x86_64/perf-archive
+	cp spectre-meltdown-checker/spectre-meltdown-checker.sh bin/x86_64/
+	cp sshpass/sshpass bin/x86_64/
+	cp stress-ng/stress-ng bin/x86_64/
+	cp sysstat/mpstat bin/x86_64/
+	cp sysstat/iostat bin/x86_64/
+	cp sysstat/sar bin/x86_64/
+	cp sysstat/sadc bin/x86_64/
+	cp tsc/tsc bin/x86_64/
+	cp linux_turbostat/tools/power/x86/turbostat/turbostat bin/x86_64/
+	-cd bin/x86_64 && strip --strip-unneeded *
 
 tools-aarch64: async-profiler-aarch64 dmidecode-aarch64 ethtool-aarch64 fio-aarch64 ipmitool-aarch64 lshw-aarch64 lspci-aarch64 spectre-meltdown-checker sshpass-aarch64 stackcollapse-perf-aarch64 stress-ng-aarch64 sysstat-aarch64 tsc-aarch64
-	mkdir -p bin-aarch64
-	cp -R async-profiler-aarch64 bin-aarch64/
-	cp dmidecode-aarch64/dmidecode bin-aarch64/
-	cp ethtool-aarch64/ethtool bin-aarch64/
-	cp fio-aarch64/fio bin-aarch64/	
-	cp stackcollapse-perf/stackcollapse-perf-aarch64 bin-aarch64/stackcollapse-perf
-	cp ipmitool-aarch64/src/ipmitool.static bin-aarch64/ipmitool
-	cp lshw-aarch64/src/lshw-static bin-aarch64/lshw
-	cp lspci-aarch64/lspci bin-aarch64/
-	cp lspci-aarch64/pci.ids.gz bin-aarch64/
-	cp spectre-meltdown-checker/spectre-meltdown-checker.sh bin-aarch64/
-	cp sshpass-aarch64/sshpass bin-aarch64/
-	cp stress-ng-aarch64/stress-ng bin-aarch64/
-	cp sysstat-aarch64/mpstat bin-aarch64/
-	cp sysstat-aarch64/iostat bin-aarch64/
-	cp sysstat-aarch64/sar bin-aarch64/
-	cp sysstat-aarch64/sadc bin-aarch64/
-	cp tsc/tsc-aarch64 bin-aarch64/tsc
-	-cd bin-aarch64 && aarch64-linux-gnu-strip --strip-unneeded * || true
+	mkdir -p bin/aarch64
+	cp -R async-profiler-aarch64 bin/aarch64/async-profiler
+	cp dmidecode-aarch64/dmidecode bin/aarch64/
+	cp ethtool-aarch64/ethtool bin/aarch64/
+	cp fio-aarch64/fio bin/aarch64/	
+	cp stackcollapse-perf/stackcollapse-perf-aarch64 bin/aarch64/stackcollapse-perf
+	cp ipmitool-aarch64/src/ipmitool.static bin/aarch64/ipmitool
+	cp lshw-aarch64/src/lshw-static bin/aarch64/lshw
+	cp lspci-aarch64/lspci bin/aarch64/
+	cp lspci-aarch64/pci.ids.gz bin/aarch64/
+	cp perf-archive/perf-archive.sh bin/aarch64/perf-archive && chmod +rx bin/aarch64/perf-archive
+	cp spectre-meltdown-checker/spectre-meltdown-checker.sh bin/aarch64/
+	cp sshpass-aarch64/sshpass bin/aarch64/
+	cp stress-ng-aarch64/stress-ng bin/aarch64/
+	cp sysstat-aarch64/mpstat bin/aarch64/
+	cp sysstat-aarch64/iostat bin/aarch64/
+	cp sysstat-aarch64/sar bin/aarch64/
+	cp sysstat-aarch64/sadc bin/aarch64/
+	cp tsc/tsc-aarch64 bin/aarch64/tsc
+	-cd bin/aarch64 && aarch64-linux-gnu-strip --strip-unneeded * || true
 
+tools: tools-x86_64 tools-aarch64
+	@echo "Tools built successfully in bin/x86_64 and bin/aarch64 directories."
 
 ASYNC_PROFILER_VERSION := "4.0"
 async-profiler:
@@ -289,13 +293,13 @@ endif
 	cd pcm/build && cmake --build .
 
 PERF_VERSION := "6.8.12"
-perf:
+perf-x86_64:
 	wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-$(PERF_VERSION).tar.xz
 	tar -xf linux-$(PERF_VERSION).tar.xz && mv linux-$(PERF_VERSION)/ linux_perf/
 	cd linux_perf/tools/perf && make LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1 -j$(NPROC)
-	mkdir -p bin
-	cp linux_perf/tools/perf/perf bin/
-	strip --strip-unneeded bin/perf
+	mkdir -p bin/x86_64
+	cp linux_perf/tools/perf/perf bin/x86_64/
+	strip --strip-unneeded bin/x86_64/perf
 
 perf-aarch64: PERF_VERSION := "6.15.3"
 perf-aarch64: zlib-aarch64 elfutils-aarch64 libpfm4-aarch64
@@ -304,14 +308,12 @@ ifeq ("$(wildcard perf-aarch64)","")
 	tar -xf linux-$(PERF_VERSION).tar.xz && mv linux-$(PERF_VERSION)/ linux_perf-aarch64/
 endif
 	cd linux_perf-aarch64/tools/perf && make LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1 ARCH=arm64 NO_LIBTRACEEVENT=1 CROSS_COMPILE=aarch64-linux-gnu- -j$(NPROC)
-	mkdir -p bin-aarch64
-	cp linux_perf-aarch64/tools/perf/perf bin-aarch64/
-	aarch64-linux-gnu-strip --strip-unneeded bin-aarch64/perf
+	mkdir -p bin/aarch64
+	cp linux_perf-aarch64/tools/perf/perf bin/aarch64/
+	aarch64-linux-gnu-strip --strip-unneeded bin/aarch64/perf
 
-perf-archive:
-	mkdir -p bin
-	cp perf-archive/perf-archive.sh bin/perf-archive
-	chmod +rx bin/perf-archive
+perf: perf-x86_64 perf-aarch64
+	@echo "Perf tools built successfully in bin/x86_64 and bin/aarch64 directories."
 
 PROCESSWATCH_VERSION := "c394065"	
 processwatch:
@@ -323,8 +325,8 @@ endif
 	cd processwatch && git checkout $(PROCESSWATCH_VERSION)
 	cd processwatch && ./build.sh
 	mkdir -p bin
-	cp processwatch/processwatch bin/
-	strip --strip-unneeded bin/processwatch
+	cp processwatch/processwatch bin/x86_64/
+	strip --strip-unneeded bin/x86_64/processwatch
 
 SPECTRE_MELTDOWN_CHECKER_VERSION := "master"
 spectre-meltdown-checker:

--- a/tools/build.Dockerfile
+++ b/tools/build.Dockerfile
@@ -42,7 +42,6 @@ RUN mkdir workdir
 ADD . /workdir
 WORKDIR /workdir
 RUN make tools
-RUN make tools-aarch64
 RUN make oss-source
 
 FROM ubuntu:22.04 AS perf-builder
@@ -79,12 +78,9 @@ RUN mkdir workdir
 ADD . /workdir
 WORKDIR /workdir
 RUN make perf
-RUN make perf-aarch64
 RUN make processwatch
 
 FROM scratch AS output
 COPY --from=builder workdir/bin /bin
-COPY --from=builder workdir/bin-aarch64 /bin-aarch64
 COPY --from=builder workdir/oss_source* /
 COPY --from=perf-builder workdir/bin/ /bin
-COPY --from=perf-builder workdir/bin-aarch64/ /bin-aarch64


### PR DESCRIPTION
This pull request refactors the build system to unify resource directories and streamline the handling of x86_64 and aarch64 architectures. It removes redundant logic, simplifies the `Makefile` structure, and consolidates resources into architecture-specific subdirectories under a single `bin` directory. Additionally, it updates the Docker build process to reflect these changes.

### Build system unification and simplification:
* Consolidated resource directories for x86_64 and aarch64 architectures into `internal/script/resources` and removed architecture-specific subdirectories (`x86_64` and `aarch64`) in the `Makefile`. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L31-L51) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R162-R164)
* Simplified the `tools/Makefile` by creating separate targets for `tools-x86_64` and `tools-aarch64`, with resources now stored in `bin/x86_64` and `bin/aarch64` directories. A unified `tools` target builds both architectures. [[1]](diffhunk://#diff-e327741dae7d1efd73c66ab134d50ac2c56187d814c443bb55464272b8b44113L9-R64) [[2]](diffhunk://#diff-e327741dae7d1efd73c66ab134d50ac2c56187d814c443bb55464272b8b44113L292-R302) [[3]](diffhunk://#diff-e327741dae7d1efd73c66ab134d50ac2c56187d814c443bb55464272b8b44113L307-R316) [[4]](diffhunk://#diff-e327741dae7d1efd73c66ab134d50ac2c56187d814c443bb55464272b8b44113L326-R329)

### Docker build process updates:
* Removed the creation and usage of separate directories (`bin-aarch64`) in the Docker build process. All architecture-specific tools are now handled under the unified `bin` directory. [[1]](diffhunk://#diff-7a79ceb0a7c431c3b02c1c07a0068b79db9183d3bfa1c40b766013322860fa0bL45) [[2]](diffhunk://#diff-7a79ceb0a7c431c3b02c1c07a0068b79db9183d3bfa1c40b766013322860fa0bL82-L90)

### Cleanup of unused logic:
* Removed unused logic for copying tools from temporary Docker containers in `builder/build.sh`, as it is no longer part of the build process.