### PR TITLE
core temperature and frequency telemetry when no uncore

### DIFF
--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -2428,12 +2428,8 @@ func temperatureTelemetryTableValues(outputs map[string]script.ScriptOutput) []F
 	}
 	packageRows, err := turbostatPackageRows(outputs[script.TurbostatTelemetryScriptName].Stdout, []string{"PkgTmp"})
 	if err != nil {
-		slog.Error(err.Error())
-		return []Field{}
-	}
-	if len(platformRows) == 0 || len(packageRows) == 0 {
-		slog.Warn("no platform or package rows found in turbostat telemetry output")
-		return []Field{}
+		// not an error, just means no package rows (package temperature)
+		slog.Warn(err.Error())
 	}
 	// add the package rows to the fields
 	for i := range packageRows {
@@ -2469,12 +2465,8 @@ func frequencyTelemetryTableValues(outputs map[string]script.ScriptOutput) []Fie
 	}
 	packageRows, err := turbostatPackageRows(outputs[script.TurbostatTelemetryScriptName].Stdout, []string{"UncMHz"})
 	if err != nil {
-		slog.Error(err.Error())
-		return []Field{}
-	}
-	if len(platformRows) == 0 || len(packageRows) == 0 {
-		slog.Warn("no platform or package rows found in turbostat telemetry output")
-		return []Field{}
+		// not an error, just means no package rows (uncore frequency)
+		slog.Warn(err.Error())
 	}
 	// add the package rows to the fields
 	for i := range packageRows {


### PR DESCRIPTION
This pull request refines error handling in telemetry table generation functions by adjusting the logging behavior when no package rows are found. Instead of treating these cases as errors, they are now logged as warnings to better reflect their non-critical nature.

### Changes to error handling:

* [`internal/report/table_defs.go`](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL2431-R2432): Updated `temperatureTelemetryTableValues` to log a warning instead of an error when no package rows are found, clarifying that this is not a critical issue but expected behavior in some cases.
* [`internal/report/table_defs.go`](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL2472-R2469): Updated `frequencyTelemetryTableValues` with similar changes, logging a warning instead of an error when no package rows are present, aligning the behavior with the temperature telemetry function.