### PR TITLE
add flag for instruction mix frequency in telemetry command

### DIFF
--- a/cmd/telemetry/telemetry.go
+++ b/cmd/telemetry/telemetry.go
@@ -65,8 +65,9 @@ var (
 
 	flagNoSystemSummary bool
 
-	flagInstrMixPid    int
-	flagInstrMixFilter []string
+	flagInstrMixPid       int
+	flagInstrMixFilter    []string
+	flagInstrMixFrequency int
 )
 
 const (
@@ -90,8 +91,9 @@ const (
 
 	flagNoSystemSummaryName = "no-summary"
 
-	flagInstrMixPidName    = "instrmix-pid"
-	flagInstrMixFilterName = "instrmix-filter"
+	flagInstrMixPidName       = "instrmix-pid"
+	flagInstrMixFilterName    = "instrmix-filter"
+	flagInstrMixFrequencyName = "instrmix-frequency"
 )
 
 var telemetrySummaryTableName = "Telemetry Summary"
@@ -117,12 +119,13 @@ func init() {
 		Cmd.Flags().BoolVar(cat.FlagVar, cat.FlagName, cat.DefaultValue, cat.Help)
 	}
 	Cmd.Flags().StringVar(&common.FlagInput, common.FlagInputName, "", "")
-	Cmd.Flags().BoolVar(&flagAll, flagAllName, false, "")
+	Cmd.Flags().BoolVar(&flagAll, flagAllName, true, "")
 	Cmd.Flags().StringSliceVar(&common.FlagFormat, common.FlagFormatName, []string{report.FormatAll}, "")
 	Cmd.Flags().IntVar(&flagDuration, flagDurationName, 30, "")
 	Cmd.Flags().IntVar(&flagInterval, flagIntervalName, 2, "")
 	Cmd.Flags().IntVar(&flagInstrMixPid, flagInstrMixPidName, 0, "")
 	Cmd.Flags().StringSliceVar(&flagInstrMixFilter, flagInstrMixFilterName, []string{"SSE", "AVX", "AVX2", "AVX512", "AMX_TILE"}, "")
+	Cmd.Flags().IntVar(&flagInstrMixFrequency, flagInstrMixFrequencyName, 10000000, "") // 10 million
 	Cmd.Flags().BoolVar(&flagNoSystemSummary, flagNoSystemSummaryName, false, "")
 
 	common.AddTargetFlags(Cmd)
@@ -188,11 +191,15 @@ func getFlagGroups() []common.FlagGroup {
 		},
 		{
 			Name: flagInstrMixPidName,
-			Help: "pid to monitor for instruction mix, no pid means all processes",
+			Help: "PID to monitor for instruction mix, no PID means all processes",
 		},
 		{
 			Name: flagInstrMixFilterName,
 			Help: "filter to apply to instruction mix",
+		},
+		{
+			Name: flagInstrMixFrequencyName,
+			Help: "number of instructions between samples when no PID specified",
 		},
 		{
 			Name: flagNoSystemSummaryName,
@@ -218,17 +225,13 @@ func getFlagGroups() []common.FlagGroup {
 }
 
 func validateFlags(cmd *cobra.Command, args []string) error {
-	// set flagAll if all categories are selected or if none are selected
-	if !flagAll {
-		numCategoriesTrue := 0
+	// clear flagAll if any categories are selected
+	if flagAll {
 		for _, cat := range categories {
-			if *cat.FlagVar {
-				numCategoriesTrue++
+			if cat.FlagVar != nil && *cat.FlagVar {
+				flagAll = false
 				break
 			}
-		}
-		if numCategoriesTrue == len(categories) || numCategoriesTrue == 0 {
-			flagAll = true
 		}
 	}
 	// validate format options
@@ -264,6 +267,9 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
+	if flagInstrMixFrequency < 100000 { // 100,000 instructions is the minimum frequency
+		return common.FlagValidationError(cmd, "instruction mix frequency must be 100,000 or greater")
+	}
 	// common target flags
 	if err := common.ValidateTargetFlags(cmd); err != nil {
 		return common.FlagValidationError(cmd, err.Error())
@@ -295,10 +301,11 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		Cmd:            cmd,
 		ReportNamePost: "telem",
 		ScriptParams: map[string]string{
-			"Interval": strconv.Itoa(flagInterval),
-			"Duration": strconv.Itoa(flagDuration),
-			"PID":      strconv.Itoa(flagInstrMixPid),
-			"Filter":   strings.Join(flagInstrMixFilter, " "),
+			"Interval":          strconv.Itoa(flagInterval),
+			"Duration":          strconv.Itoa(flagDuration),
+			"InstrMixPID":       strconv.Itoa(flagInstrMixPid),
+			"InstrMixFilter":    strings.Join(flagInstrMixFilter, " "),
+			"InstrMixFrequency": strconv.Itoa(flagInstrMixFrequency),
 		},
 		TableNames:             tableNames,
 		SummaryFunc:            summaryFunc,

--- a/cmd/telemetry/telemetry.go
+++ b/cmd/telemetry/telemetry.go
@@ -119,7 +119,7 @@ func init() {
 		Cmd.Flags().BoolVar(cat.FlagVar, cat.FlagName, cat.DefaultValue, cat.Help)
 	}
 	Cmd.Flags().StringVar(&common.FlagInput, common.FlagInputName, "", "")
-	Cmd.Flags().BoolVar(&flagAll, flagAllName, true, "")
+	Cmd.Flags().BoolVar(&flagAll, flagAllName, false, "")
 	Cmd.Flags().StringSliceVar(&common.FlagFormat, common.FlagFormatName, []string{report.FormatAll}, "")
 	Cmd.Flags().IntVar(&flagDuration, flagDurationName, 30, "")
 	Cmd.Flags().IntVar(&flagInterval, flagIntervalName, 2, "")
@@ -225,13 +225,17 @@ func getFlagGroups() []common.FlagGroup {
 }
 
 func validateFlags(cmd *cobra.Command, args []string) error {
-	// clear flagAll if any categories are selected
-	if flagAll {
+	// set flagAll if all categories are selected or if none are selected
+	if !flagAll {
+		numCategoriesTrue := 0
 		for _, cat := range categories {
-			if cat.FlagVar != nil && *cat.FlagVar {
-				flagAll = false
+			if *cat.FlagVar {
+				numCategoriesTrue++
 				break
 			}
+		}
+		if numCategoriesTrue == len(categories) || numCategoriesTrue == 0 {
+			flagAll = true
 		}
 	}
 	// validate format options

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -1229,23 +1229,23 @@ wait
 		ScriptTemplate: `interval={{.Interval}}
 duration={{.Duration}}
 if [ $duration -ne 0 ] && [ $interval -ne 0 ]; then
-	count=$((duration / interval))
-	arg_count="-n $count"
+    count=$((duration / interval))
+    arg_count="-n $count"
 fi
 if [ $interval -ne 0 ]; then
-	arg_interval="-i $interval"
+    arg_interval="-i $interval"
 fi
 echo TIME: $(date +"%H:%M:%S")
 echo INTERVAL: $interval
 # if no PID specified, increase the sampling interval (defaults to 100,000) to reduce overhead
-if [ {{.PID}} -eq 0 ]; then
-	arg_sampling_rate="-s 1000000"
+if [ {{.InstrMixPID}} -eq 0 ]; then
+    arg_sampling_rate="-s {{.InstrMixFrequency}}"
 else
-	arg_pid="-p {{.PID}}"
+    arg_pid="-p {{.InstrMixPID}}"
 fi
-# .Filter is a space separated list of ISA categories
+# .InstrMixFilter is a space separated list of ISA categories
 # for each category in the list, add -f <category> to the command line
-for category in {{.Filter}}; do
+for category in {{.InstrMixFilter}}; do
     arg_filter="$arg_filter -f $category"
 done
 


### PR DESCRIPTION
This pull request introduces a new flag, `flagInstrMixFrequency`, to enhance the telemetry functionality by allowing users to specify the number of instructions between samples when no PID is provided. It also includes updates to improve flag validation and script parameter handling.

Previous value for frequency was hard-coded to 1,000,000 when no PID is specified. We observed too much overhead in this configuration. The new --instrmix-frequency flag defaults to 10,000,000 to reduce overhead in the default configuration but allows the user to override this value if more frequent samples are required. Minimum is set to 100,000 to avoid catastrophic overhead.

### Enhancements to telemetry flags:

* Added `flagInstrMixFrequency` to `var` and `const` declarations in `cmd/telemetry/telemetry.go`, enabling users to configure the sampling frequency. [[1]](diffhunk://#diff-ab406ddee077acfed247baae550835aa10b65844b8833e1eaf1cdf13d0fd5c4eR70) [[2]](diffhunk://#diff-ab406ddee077acfed247baae550835aa10b65844b8833e1eaf1cdf13d0fd5c4eR96)
* Updated `getFlagGroups()` to include `flagInstrMixFrequency` with a description for its purpose.

### Updates to flag behavior and validation:

* Modified `validateFlags()` to ensure `flagInstrMixFrequency` is at least 100,000 instructions and adjusted logic for `flagAll` based on category selection. [[1]](diffhunk://#diff-ab406ddee077acfed247baae550835aa10b65844b8833e1eaf1cdf13d0fd5c4eL221-L232) [[2]](diffhunk://#diff-ab406ddee077acfed247baae550835aa10b65844b8833e1eaf1cdf13d0fd5c4eR270-R272)

### Script parameter adjustments:

* Renamed script parameters (`PID`, `Filter`) to `InstrMixPID`, `InstrMixFilter`, and added `InstrMixFrequency` for better clarity and alignment with the new flag. [[1]](diffhunk://#diff-ab406ddee077acfed247baae550835aa10b65844b8833e1eaf1cdf13d0fd5c4eL300-R308) [[2]](diffhunk://#diff-eb14347ecb8d0457d616ea7458b375fa88206bb53ac21fa59c48106c1c975536L1241-R1248)