### PR TITLE
enhancements for perf-x86_64 static build

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -292,16 +292,15 @@ endif
 	cd pcm/build &&	cmake -DNO_ASAN=1 ..
 	cd pcm/build && cmake --build .
 
-PERF_VERSION := "6.8.12"
+PERF_VERSION := "6.15.3"
 perf-x86_64:
 	wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-$(PERF_VERSION).tar.xz
 	tar -xf linux-$(PERF_VERSION).tar.xz && mv linux-$(PERF_VERSION)/ linux_perf/
-	cd linux_perf/tools/perf && make LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1 -j$(NPROC)
+	cd linux_perf/tools/perf && make LLVM_CONFIG="llvm-config --link-static" LDFLAGS="-static --static" BUILD_BPF_SKEL=1 NO_JVMTI=1 BUILD_NONDISTRO=1 LIBUNWIND=1 -j$(NPROC)
 	mkdir -p bin/x86_64
 	cp linux_perf/tools/perf/perf bin/x86_64/
 	strip --strip-unneeded bin/x86_64/perf
 
-perf-aarch64: PERF_VERSION := "6.15.3"
 perf-aarch64: zlib-aarch64 elfutils-aarch64 libpfm4-aarch64
 ifeq ("$(wildcard perf-aarch64)","")
 	wget -N https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-$(PERF_VERSION).tar.xz

--- a/tools/build.Dockerfile
+++ b/tools/build.Dockerfile
@@ -68,12 +68,16 @@ RUN ulimit -n 4096 && for i in {1..5}; do \
         libbabeltrace-dev libbpf-dev libc6 libcap-dev libdw-dev libdwarf-dev libelf-dev \
         libiberty-dev liblzma-dev libnuma-dev libperl-dev libpfm4-dev libreadline-dev \
         libslang2-dev libssl-dev libtool libtraceevent-dev libunwind-dev libzstd-dev \
-        libzstd1 llvm-13 pandoc pkgconf python-setuptools python2-dev python3 python3-dev \
+        libzstd1 llvm-14 pandoc pkgconf python-setuptools python2-dev python3 python3-dev \
         python3-pip systemtap-sdt-dev zlib1g-dev \
+        libbz2-dev libcapstone-dev libtracefs-dev \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu cpp-aarch64-linux-gnu && break; \
         echo "Retrying in 5 seconds... ($i/5)" && sleep 5; \
     done
-ENV PATH="${PATH}:/usr/lib/llvm-13/bin"
+
+# libdwfl will dlopen libdebuginfod at runtime, may cause segment fault in static build, disablt it. ref: https://github.com/vgteam/vg/pull/3600
+RUN wget https://sourceware.org/elfutils/ftp/0.190/elfutils-0.190.tar.bz2 && tar -xf elfutils-0.190.tar.bz2 && cd elfutils-0.190 && ./configure --disable-debuginfod --disable-libdebuginfod && make install -j
+ENV PATH="${PATH}:/usr/lib/llvm-14/bin"
 RUN mkdir workdir
 ADD . /workdir
 WORKDIR /workdir


### PR DESCRIPTION
1. use unified kernel version 6.15.3
2. enable llvm-perf support to speed up perf report
3. fix potential segment fault in new libdwfl
4. support more features like dwarf,unwind,tracefs,capsstone