### PR TITLE
fix CXL device reporting

### DIFF
--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -190,8 +190,8 @@ var scriptDefinitions = map[string]ScriptDefinition{
 	},
 	LspciVmmScriptName: {
 		Name:           LspciVmmScriptName,
-		ScriptTemplate: "lspci -vmm",
-		Depends:        []string{"lspci"},
+		ScriptTemplate: "lspci -i pci.ids.gz -vmm",
+		Depends:        []string{"lspci", "pci.ids.gz"},
 	},
 	UnameScriptName: {
 		Name:           UnameScriptName,


### PR DESCRIPTION
This pull request updates the script definitions in `internal/script/script_defs.go` to improve functionality by modifying the `LspciVmmScriptName` script template and its dependencies.

### Updates to script definitions:

* [`internal/script/script_defs.go`](diffhunk://#diff-eb14347ecb8d0457d616ea7458b375fa88206bb53ac21fa59c48106c1c975536L193-R194): Updated the `LspciVmmScriptName` script template to use the `pci.ids.gz` file for enhanced functionality and added `pci.ids.gz` as a dependency.