### PR TITLE
Fix accelerator table insights

### DIFF
--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -1113,13 +1113,13 @@ func acceleratorTableInsights(outputs map[string]script.ScriptOutput, tableValue
 	for i, count := range tableValues.Fields[countFieldIndex].Values {
 		name := tableValues.Fields[nameFieldIndex].Values[i]
 		queues := tableValues.Fields[queuesFieldIndex].Values[i]
-		if name == "DSA" && count != "0" && queues != "None" {
+		if name == "DSA" && count != "0" && queues == "None" {
 			insights = append(insights, Insight{
 				Recommendation: "Consider configuring DSA to allow accelerated data copy and transformation in DSA-enabled software.",
 				Justification:  "No work queues are configured for DSA accelerator(s).",
 			})
 		}
-		if name == "IAA" && count != "0" && queues != "None" {
+		if name == "IAA" && count != "0" && queues == "None" {
 			insights = append(insights, Insight{
 				Recommendation: "Consider configuring IAA to allow accelerated compression and decompression in IAA-enabled software.",
 				Justification:  "No work queues are configured for IAA accelerator(s).",


### PR DESCRIPTION
This pull request includes a small but critical change to the logic in the `acceleratorTableInsights` function within the `internal/report/table_defs.go` file. The change ensures that insights are generated only when the `queues` value is explicitly `"None"` for DSA and IAA accelerators, rather than when it is not `"None"`.