### PR TITLE
add timeout for intel network check

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"perfspect/internal/common"
 	"perfspect/internal/util"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -311,7 +312,7 @@ func onIntelNetwork() bool {
 	// perform the lookup
 	_, err := resolver.LookupHost(ctx, host)
 	if err != nil {
-		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		if errors.Is(err, context.DeadlineExceeded) {
 			slog.Debug("DNS lookup timed out", "host", host)
 		} else {
 			slog.Debug("DNS lookup failed", "host", host, "error", err.Error())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,10 +118,8 @@ Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
 	rootCmd.AddCommand(flame.Cmd)
 	rootCmd.AddCommand(lock.Cmd)
 	rootCmd.AddCommand(config.Cmd)
-	if onIntelNetwork() {
-		rootCmd.AddGroup([]*cobra.Group{{ID: "other", Title: "Other Commands:"}}...)
-		rootCmd.AddCommand(updateCmd)
-	}
+	rootCmd.AddGroup([]*cobra.Group{{ID: "other", Title: "Other Commands:"}}...)
+	rootCmd.AddCommand(updateCmd)
 	// Global (persistent) flags
 	rootCmd.PersistentFlags().BoolVar(&flagDebug, flagDebugName, false, "enable debug logging and retain temporary directories")
 	rootCmd.PersistentFlags().BoolVar(&flagSyslog, flagSyslogName, false, "write logs to syslog instead of a file")
@@ -344,8 +342,11 @@ const (
 var updateCmd = &cobra.Command{
 	GroupID: "other",
 	Use:     updateCommandName,
-	Short:   "Update the application",
+	Short:   "Update the application (Intel network only)",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !onIntelNetwork() {
+			return fmt.Errorf("update command is only available on the Intel network")
+		}
 		appContext := cmd.Parent().Context().Value(common.AppContext{}).(common.AppContext)
 		localTempDir := appContext.LocalTempDir
 		updateAvailable, latestManifest, err := checkForUpdates(gVersion)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ replace (
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/deckarep/golang-set/v2 v2.8.0
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
@@ -44,7 +46,6 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
-github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
 github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=


### PR DESCRIPTION
This pull request refines the `onIntelNetwork` function to improve its DNS lookup mechanism by introducing a timeout and enhanced error handling. The changes ensure that network checks are more robust and provide better debugging information.

### Improvements to DNS lookup mechanism:

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL306-R323): Updated the `onIntelNetwork` function to use a `context.WithTimeout` for a 1-second timeout during DNS resolution, ensuring quicker failure in case of network issues. Introduced a custom resolver (`net.Resolver`) and added detailed logging for timeout and other DNS errors using `slog.Debug`.