### PR TITLE
Added support for cri-containerd for cgroup scope

### DIFF
--- a/cmd/metrics/process.go
+++ b/cmd/metrics/process.go
@@ -131,7 +131,7 @@ func GetHotCgroups(myTarget target.Target, maxCgroups int, filter string, localT
 search_dir="/sys/fs/cgroup"
 
 # Find matching cgroups
-matching_cgroups=$(find "$search_dir" -type d \( -name "docker*scope" -o -name "containerd*scope" \))
+matching_cgroups=$(find "$search_dir" -type d \( -name "docker*scope" -o -name "containerd*scope" -o -name "cri-containerd*scope" \))
 
 # Filter matching cgroups based on regex if provided
 regex=%s


### PR DESCRIPTION
Tested in containerd environment run by kubectl. REquires the extra path to be scanned for cgroups under cri-containerd.