### PR TITLE
Update memory benchmarks for larger L3 cache systems

### DIFF
--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -949,7 +949,7 @@ needed_num_huge_pages=$((numa_nodes * min_kb / size_huge_pages_kb))
 if [ $needed_num_huge_pages -gt $orig_num_huge_pages ]; then
   echo $needed_num_huge_pages > /proc/sys/vm/nr_hugepages
 fi
-mlc --loaded_latency
+mlc --loaded_latency -b500m -X
 echo $orig_num_huge_pages > /proc/sys/vm/nr_hugepages
 `,
 		Architectures: []string{x86_64},
@@ -970,7 +970,7 @@ needed_num_huge_pages=$((numa_nodes * min_kb / size_huge_pages_kb))
 if [ $needed_num_huge_pages -gt $orig_num_huge_pages ]; then
   echo $needed_num_huge_pages > /proc/sys/vm/nr_hugepages
 fi
-mlc --bandwidth_matrix
+mlc --bandwidth_matrix -b500m -X
 echo $orig_num_huge_pages > /proc/sys/vm/nr_hugepages
 `,
 		Architectures: []string{x86_64},


### PR DESCRIPTION
This pull request updates the way the `mlc` (Memory Latency Checker) tool is invoked within the `internal/script/script_defs.go` script definitions. The changes add specific options to the `mlc` command to control buffer size and output format for both latency and bandwidth measurements.

Updates to `mlc` command usage:

* The `mlc --loaded_latency` command now includes the `-b500m` option to set the buffer size to 500MB and the `-X` option to use one thread per core.
* The `mlc --bandwidth_matrix` command also adds the `-b500m` and `-X` options for the same purposes.