### PR TITLE
refactor metrics event processing

### DIFF
--- a/cmd/metrics/event_frame.go
+++ b/cmd/metrics/event_frame.go
@@ -401,7 +401,7 @@ func collapseUncoreGroups(inGroups []EventGroup, firstIdx int, count int) (outGr
 func parseEventJSON(rawEvent []byte) (Event, error) {
 	var event Event
 	if err := json.Unmarshal(rawEvent, &event); err != nil {
-		err = fmt.Errorf("unrecognized event format: \"%s\"", rawEvent)
+		err = fmt.Errorf("unrecognized event format")
 		return event, err
 	}
 	if !strings.Contains(event.CounterValue, "not counted") && !strings.Contains(event.CounterValue, "not supported") {

--- a/cmd/metrics/event_frame.go
+++ b/cmd/metrics/event_frame.go
@@ -233,9 +233,6 @@ func coalesceEvents(allEvents []Event, scope string, granularity string, metadat
 				}
 			} else {
 				numCPUs = metadata.SocketCount * metadata.CoresPerSocket * metadata.ThreadsPerCore
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse cpu range: %w", err)
-				}
 				cpuMap = make(map[int]int, numCPUs)
 				for i := 0; i < numCPUs; i++ {
 					cpuMap[i] = i

--- a/cmd/metrics/event_frame_test.go
+++ b/cmd/metrics/event_frame_test.go
@@ -1,0 +1,59 @@
+package metrics
+
+// Copyright (C) 2021-2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "testing"
+
+func TestExtractInterval(t *testing.T) {
+	tests := []struct {
+		name string
+		line []byte
+		want float64
+	}{
+		{
+			name: "ValidJSON",
+			line: []byte(`{"interval" : 5.005073756, "cpu": "0"}`),
+			want: 5.005073756,
+		},
+		{
+			name: "ValidJSONWithSpaces",
+			line: []byte(`{ "interval" : 42.12345 }`),
+			want: 42.12345,
+		},
+		{
+			name: "MissingInterval",
+			line: []byte(`{"cpu": "0"}`),
+			want: -1,
+		},
+		{
+			name: "EmptyLine",
+			line: []byte(``),
+			want: -1,
+		},
+		{
+			name: "InvalidNumber",
+			line: []byte(`{"interval" : not_a_number, "cpu": "0"}`),
+			want: -1,
+		},
+		{
+			name: "IntervalAtEnd",
+			line: []byte(`{"interval" : 123.456}`),
+			want: 123.456,
+		},
+		{
+			name: "IntervalWithTrailingSpace",
+			line: []byte(`{"interval" : 77.88 , "cpu": "0"}`),
+			want: 77.88,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractInterval(tt.line)
+			if got != tt.want {
+				t.Errorf("extractInterval() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -1443,7 +1443,8 @@ func runPerf(myTarget target.Target, noRoot bool, processes []Process, cmd *exec
 	// receive perf output and batch by interval
 	var currentInterval float64 = -1
 	var currentBatch [][]byte
-	var previousBatchSize int = 1000 // initial size of the batch
+	const initialBatchSize = 1000 // initial size of the batch
+	var previousBatchSize int = initialBatchSize
 	done := false
 	for !done {
 		select {

--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -71,6 +71,77 @@ var (
 	gSignalReceived bool
 )
 
+// SafeLineBuffer provides thread-safe access to a slice of byte slices
+// Used to synchronize access to outputLines between runPerf and processPerfOutput goroutines
+type SafeLineBuffer struct {
+	mu    sync.Mutex
+	lines [][]byte
+}
+
+// Append adds a line to the buffer in a thread-safe manner
+func (s *SafeLineBuffer) Append(line []byte) {
+	s.mu.Lock()
+	s.lines = append(s.lines, line)
+	s.mu.Unlock()
+}
+
+// DrainAndClear returns all lines and clears the buffer atomically
+// Returns nil if buffer is empty
+func (s *SafeLineBuffer) DrainAndClear() [][]byte {
+	s.mu.Lock()
+	if len(s.lines) == 0 {
+		s.mu.Unlock()
+		return nil
+	}
+	// Transfer ownership instead of copying for better performance with large batches
+	result := s.lines
+	s.lines = make([][]byte, 0, cap(result)) // Preallocate capacity to reduce future allocations
+	s.mu.Unlock()
+	return result
+}
+
+// Len returns the current number of lines in the buffer
+func (s *SafeLineBuffer) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.lines)
+}
+
+// extractInterval parses the interval value from a JSON perf event line
+// Returns the interval as a float64, or -1 if parsing fails
+func extractInterval(line []byte) float64 {
+	// Look for the interval field in the JSON: "interval" : 5.005073756
+	intervalStart := strings.Index(string(line), `"interval" : `)
+	if intervalStart == -1 {
+		return -1
+	}
+
+	// Move to the start of the number
+	intervalStart += len(`"interval" : `)
+	lineStr := string(line[intervalStart:])
+
+	// Find the end of the number (comma or space)
+	var intervalEnd int
+	for i, ch := range lineStr {
+		if ch == ',' || ch == ' ' || ch == '}' {
+			intervalEnd = i
+			break
+		}
+	}
+	if intervalEnd == 0 {
+		return -1
+	}
+
+	// Parse the number
+	intervalStr := lineStr[:intervalEnd]
+	interval, err := strconv.ParseFloat(intervalStr, 64)
+	if err != nil {
+		return -1
+	}
+
+	return interval
+}
+
 func setSignalReceived() {
 	gSignalMutex.Lock()
 	defer gSignalMutex.Unlock()
@@ -1421,14 +1492,9 @@ func runPerf(myTarget target.Target, noRoot bool, processes []Process, cmd *exec
 		}
 	}
 	// Start a goroutine to wait for and then process perf output
-	// Use a timer to determine when we received an entire frame of events from perf
-	// The timer will expire when no lines (events) have been received from perf for more than 100ms. This
-	// works because perf writes the events to stderr in a burst every collection interval, e.g., 5 seconds.
-	// When the timer expires, this code assumes that perf is done writing events to stderr.
-	const perfEventWaitTime = time.Duration(100 * time.Millisecond)                   // 100ms is somewhat arbitrary, but is long enough for perf to print a frame of events
-	perfOutputTimer := time.NewTimer(time.Duration(2 * flagPerfPrintInterval * 1000)) // #nosec G115
+	const perfEventWaitTime = time.Duration(100 * time.Millisecond) // fallback timer for final interval
 	perfProcessingContext, cancelPerfProcessing := context.WithCancel(context.Background())
-	outputLines := make([][]byte, 0)
+	intervalBatchChannel := make(chan [][]byte, 10)  // channel to send interval batches (all events for a particular interval) for processing
 	donePerfProcessingChannel := make(chan struct{}) // channel to wait for processPerfOutput to finish
 	go processPerfOutput(
 		perfProcessingContext,
@@ -1440,24 +1506,56 @@ func runPerf(myTarget target.Target, noRoot bool, processes []Process, cmd *exec
 		processes,
 		cgroupTimeout,
 		startPerfTimestamp,
-		perfOutputTimer,
-		&outputLines,
+		intervalBatchChannel,
 		frameChannel,
 		donePerfProcessingChannel,
 	)
-	// receive perf output
+
+	// receive perf output and batch by interval
+	var currentInterval float64 = -1
+	var currentBatch [][]byte
 	done := false
 	for !done {
 		select {
 		case line := <-stderrChannel: // perf output comes in on this channel, one line at a time
-			perfOutputTimer.Stop()
-			perfOutputTimer.Reset(perfEventWaitTime)
-			// accumulate the lines, they will be processed in the goroutine when the timer expires
-			outputLines = append(outputLines, []byte(line))
+			lineBytes := []byte(line)
+			interval := extractInterval(lineBytes)
+
+			// Handle interval change or first line
+			if interval != currentInterval {
+				// If we have accumulated lines from a previous interval, send them for processing
+				if len(currentBatch) > 0 {
+					// Send a copy of the batch to avoid race conditions
+					batchCopy := make([][]byte, len(currentBatch))
+					copy(batchCopy, currentBatch)
+					select {
+					case intervalBatchChannel <- batchCopy:
+					case <-perfProcessingContext.Done():
+						done = true
+						continue
+					}
+				}
+				// Start a new batch for the new interval
+				currentInterval = interval
+				currentBatch = make([][]byte, 0, 1000)
+			}
+
+			// Add the line to the current batch
+			if interval >= 0 { // only add valid lines (with parseable interval)
+				currentBatch = append(currentBatch, lineBytes)
+			}
 		case exitCode := <-exitcodeChannel: // when perf exits, the exit code comes to this channel
 			slog.Debug("perf exited", slog.Int("exit code", exitCode))
-			time.Sleep(perfEventWaitTime) // wait for timer to expire so that last events can be processed
-			done = true                   // exit the loop
+			// Send the final batch if we have accumulated lines
+			if len(currentBatch) > 0 {
+				batchCopy := make([][]byte, len(currentBatch))
+				copy(batchCopy, currentBatch)
+				select {
+				case intervalBatchChannel <- batchCopy:
+				case <-time.After(perfEventWaitTime): // timeout to avoid blocking
+				}
+			}
+			done = true // exit the loop
 		case err := <-scriptErrorChannel: // if there is an error running perf, it comes here
 			if err != nil {
 				slog.Error("error from perf", slog.String("error", err.Error()))
@@ -1465,7 +1563,8 @@ func runPerf(myTarget target.Target, noRoot bool, processes []Process, cmd *exec
 			done = true // exit the loop
 		}
 	}
-	perfOutputTimer.Stop()
+	// Close the interval batch channel to signal no more batches
+	close(intervalBatchChannel)
 	// cancel the context to stop processPerfOutput
 	cancelPerfProcessing()
 	// wait for processPerfOutput to finish
@@ -1489,8 +1588,7 @@ func processPerfOutput(
 	processes []Process,
 	cgroupTimeout int,
 	startPerfTimestamp time.Time,
-	perfOutputTimer *time.Timer,
-	outputLines *[][]byte,
+	intervalBatchChannel chan [][]byte,
 	frameChannel chan []MetricFrame,
 	doneChannel chan struct{},
 ) {
@@ -1501,44 +1599,47 @@ func processPerfOutput(
 	const maxConsecutiveProcessEventErrors = 2
 	for !contextCancelled {
 		select {
-		case <-perfOutputTimer.C: // waits for timer to expire the process the events in outputLines
+		case batchLines, ok := <-intervalBatchChannel:
+			if !ok {
+				// Channel closed, no more batches
+				contextCancelled = true
+				break
+			}
+			// Process the interval batch
+			if len(batchLines) > 0 {
+				// write the events to a file
+				if flagWriteEventsToFile {
+					if err := writeEventsToFile(outputDir+"/"+myTarget.GetName()+"_"+"events.jsonl", batchLines); err != nil {
+						slog.Error("failed to write events to file", slog.String("error", err.Error()))
+					}
+				}
+				// process the events
+				var metricFrames []MetricFrame
+				var err error
+				metricFrames, frameTimestamp, err = ProcessEvents(batchLines, eventGroupDefinitions, metricDefinitions, processes, frameTimestamp, metadata)
+				if err != nil {
+					slog.Error(err.Error())
+					numConsecutiveProcessEventErrors++
+					if numConsecutiveProcessEventErrors > maxConsecutiveProcessEventErrors {
+						slog.Error("too many consecutive errors processing events, killing perf", slog.Int("max errors", maxConsecutiveProcessEventErrors))
+						// signaling self with SIGUSR1 will signal child processes to exit, which will cancel the context and let this function exit
+						err := util.SignalSelf(syscall.SIGUSR1)
+						if err != nil {
+							slog.Error("failed to signal self", slog.String("error", err.Error()))
+						}
+					}
+				} else {
+					// send the metrics frames out to be printed
+					frameChannel <- metricFrames
+					// reset the error count
+					numConsecutiveProcessEventErrors = 0
+				}
+			}
 		case <-ctx.Done(): // context cancellation
-			contextCancelled = true // exit the loop after one more pass
+			contextCancelled = true
 		}
 		if contextCancelled {
 			break
-		}
-		if len(*outputLines) != 0 {
-			// write the events to a file
-			if flagWriteEventsToFile {
-				if err := writeEventsToFile(outputDir+"/"+myTarget.GetName()+"_"+"events.jsonl", *outputLines); err != nil {
-					slog.Error("failed to write events to file", slog.String("error", err.Error()))
-				}
-			}
-			// process the events
-			var metricFrames []MetricFrame
-			var err error
-			metricFrames, frameTimestamp, err = ProcessEvents(*outputLines, eventGroupDefinitions, metricDefinitions, processes, frameTimestamp, metadata)
-			if err != nil {
-				slog.Error(err.Error())
-				numConsecutiveProcessEventErrors++
-				if numConsecutiveProcessEventErrors > maxConsecutiveProcessEventErrors {
-					slog.Error("too many consecutive errors processing events, killing perf", slog.Int("max errors", maxConsecutiveProcessEventErrors))
-					// signaling self with SIGUSR1 will signal child processes to exit, which will cancel the context and let this function exit
-					err := util.SignalSelf(syscall.SIGUSR1)
-					if err != nil {
-						slog.Error("failed to signal self", slog.String("error", err.Error()))
-					}
-				}
-				*outputLines = [][]byte{} // empty it
-			} else {
-				// send the metrics frames out to be printed
-				frameChannel <- metricFrames
-				// empty the outputLines
-				*outputLines = [][]byte{}
-				// reset the error count
-				numConsecutiveProcessEventErrors = 0
-			}
 		}
 		// for cgroup scope, terminate perf if refresh timeout is reached
 		if flagScope == scopeCgroup && cgroupTimeout != 0 {
@@ -1550,6 +1651,26 @@ func processPerfOutput(
 					slog.Error("failed to signal self", slog.String("error", err.Error()))
 				}
 			}
+		}
+	}
+	// Drain any remaining batches from the channel
+	for {
+		select {
+		case batchLines, ok := <-intervalBatchChannel:
+			if !ok {
+				return // Channel closed and drained
+			}
+			// Process final batches if they exist
+			if len(batchLines) > 0 {
+				if metricFrames, _, err := ProcessEvents(batchLines, eventGroupDefinitions, metricDefinitions, processes, frameTimestamp, metadata); err == nil {
+					select {
+					case frameChannel <- metricFrames:
+					default: // Don't block if frameChannel is full
+					}
+				}
+			}
+		default:
+			return // No more batches
 		}
 	}
 }

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -164,7 +164,7 @@ func RunScripts(myTarget target.Target, scripts []ScriptDefinition, ignoreScript
 }
 
 // RunScriptStream runs a script on the specified target and streams the output to the specified channels.
-func RunScriptStream(myTarget target.Target, script ScriptDefinition, localTempDir string, stdoutChannel chan string, stderrChannel chan string, exitcodeChannel chan int, errorChannel chan error, cmdChannel chan *exec.Cmd) {
+func RunScriptStream(myTarget target.Target, script ScriptDefinition, localTempDir string, stdoutChannel chan []byte, stderrChannel chan []byte, exitcodeChannel chan int, errorChannel chan error, cmdChannel chan *exec.Cmd) {
 	targetArchitecture, err := myTarget.GetArchitecture()
 	if err != nil {
 		err = fmt.Errorf("error getting target architecture: %v", err)

--- a/internal/target/helpers.go
+++ b/internal/target/helpers.go
@@ -163,7 +163,7 @@ func runLocalCommandWithInputWithTimeoutAsync(cmd *exec.Cmd, stdoutChannel chan 
 	}
 	go func() {
 		for stdoutScanner.Scan() {
-			internalBuf := stderrScanner.Bytes()
+			internalBuf := stdoutScanner.Bytes()
 			sendBuf := make([]byte, len(internalBuf))
 			copy(sendBuf, internalBuf)
 			stdoutChannel <- sendBuf

--- a/internal/target/helpers.go
+++ b/internal/target/helpers.go
@@ -128,7 +128,7 @@ func runLocalCommandWithInputWithTimeout(cmd *exec.Cmd, input string, timeout in
 //
 // Returns:
 //   - err: An error if the command fails to start or if there are issues with pipes.
-func runLocalCommandWithInputWithTimeoutAsync(cmd *exec.Cmd, stdoutChannel chan string, stderrChannel chan string, exitcodeChannel chan int, input string, timeout int) (err error) {
+func runLocalCommandWithInputWithTimeoutAsync(cmd *exec.Cmd, stdoutChannel chan []byte, stderrChannel chan []byte, exitcodeChannel chan int, input string, timeout int) (err error) {
 	logInput := ""
 	if input != "" {
 		logInput = "******"
@@ -163,14 +163,18 @@ func runLocalCommandWithInputWithTimeoutAsync(cmd *exec.Cmd, stdoutChannel chan 
 	}
 	go func() {
 		for stdoutScanner.Scan() {
-			text := stdoutScanner.Text()
-			stdoutChannel <- text
+			internalBuf := stderrScanner.Bytes()
+			sendBuf := make([]byte, len(internalBuf))
+			copy(sendBuf, internalBuf)
+			stdoutChannel <- sendBuf
 		}
 	}()
 	go func() {
 		for stderrScanner.Scan() {
-			text := stderrScanner.Text()
-			stderrChannel <- text
+			internalBuf := stderrScanner.Bytes()
+			sendBuf := make([]byte, len(internalBuf))
+			copy(sendBuf, internalBuf)
+			stderrChannel <- sendBuf
 		}
 	}()
 	err = cmd.Wait()

--- a/internal/target/local_target.go
+++ b/internal/target/local_target.go
@@ -36,7 +36,7 @@ func (t *LocalTarget) RunCommand(cmd *exec.Cmd, timeout int, argNotUsed bool) (s
 // and the exit code is sent to the exitcodeChannel.
 // The timeout parameter specifies the maximum time allowed for the command to run.
 // Returns an error if there was a problem running the command.
-func (t *LocalTarget) RunCommandStream(cmd *exec.Cmd, timeout int, argNotUsed bool, stdoutChannel chan string, stderrChannel chan string, exitcodeChannel chan int, cmdChannel chan *exec.Cmd) (err error) {
+func (t *LocalTarget) RunCommandStream(cmd *exec.Cmd, timeout int, argNotUsed bool, stdoutChannel chan []byte, stderrChannel chan []byte, exitcodeChannel chan int, cmdChannel chan *exec.Cmd) (err error) {
 	localCommand := cmd
 	cmdChannel <- localCommand
 	err = runLocalCommandWithInputWithTimeoutAsync(localCommand, stdoutChannel, stderrChannel, exitcodeChannel, "", timeout)

--- a/internal/target/remote_target.go
+++ b/internal/target/remote_target.go
@@ -57,7 +57,7 @@ func (t *RemoteTarget) RunCommand(cmd *exec.Cmd, timeout int, reuseSSHConnection
 //
 // Returns:
 //   - err: An error object if the command fails to execute or times out.
-func (t *RemoteTarget) RunCommandStream(cmd *exec.Cmd, timeout int, reuseSSHConnection bool, stdoutChannel chan string, stderrChannel chan string, exitcodeChannel chan int, cmdChannel chan *exec.Cmd) (err error) {
+func (t *RemoteTarget) RunCommandStream(cmd *exec.Cmd, timeout int, reuseSSHConnection bool, stdoutChannel chan []byte, stderrChannel chan []byte, exitcodeChannel chan int, cmdChannel chan *exec.Cmd) (err error) {
 	localCommand := t.prepareLocalCommand(cmd, reuseSSHConnection)
 	cmdChannel <- localCommand
 	err = runLocalCommandWithInputWithTimeoutAsync(localCommand, stdoutChannel, stderrChannel, exitcodeChannel, "", timeout)

--- a/internal/target/target.go
+++ b/internal/target/target.go
@@ -74,7 +74,7 @@ type Target interface {
 	// - exitcodeChannel: a channel to send the exit code of the command
 	// - cmdChannel: a channel to send the command that was run
 	// It returns any error that occurred.
-	RunCommandStream(cmd *exec.Cmd, timeout int, reuseSSHConnection bool, stdoutChannel chan string, stderrChannel chan string, exitcodeChannel chan int, cmdChannel chan *exec.Cmd) error
+	RunCommandStream(cmd *exec.Cmd, timeout int, reuseSSHConnection bool, stdoutChannel chan []byte, stderrChannel chan []byte, exitcodeChannel chan int, cmdChannel chan *exec.Cmd) error
 
 	// PushFile transfers a file from the local system to the target.
 	// It returns any error that occurred.


### PR DESCRIPTION
eliminate race condition in perf event processing

This pull request refactors how perf event output is collected and processed in the metrics package, shifting from line-by-line string handling to batching by interval using byte slices. The changes improve the accuracy and efficiency of event grouping, simplify channel usage, and add robust parsing and testing for interval extraction. Most changes are in `cmd/metrics/metrics.go`, with supporting updates to target and script streaming interfaces.

**Perf event batching and processing improvements:**

* Refactored perf event output handling to batch events by interval using byte slices (`[][]byte`), replacing previous timer-based grouping and string channels. This ensures each batch corresponds to a specific perf interval, improving accuracy and reducing race conditions. (`cmd/metrics/metrics.go`, `internal/target/target.go`, `internal/target/local_target.go`, `internal/target/remote_target.go`, `internal/target/helpers.go`, `internal/script/script.go`) [[1]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1386-R1387) [[2]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1424-R1426) [[3]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1443-R1486) [[4]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1468-R1496) [[5]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1492-R1520) [[6]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1504-R1548) [[7]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1533-R1572) [[8]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286R1585-R1604) [[9]](diffhunk://#diff-45380bac771754faf451a4665a11803ad420c0db8cfb1c00b08606c31baf4337L167-R167) [[10]](diffhunk://#diff-548ddc95d07bb3b1c2f316509930da7b677469c35999d210eba5479501b844a7L131-R131) [[11]](diffhunk://#diff-548ddc95d07bb3b1c2f316509930da7b677469c35999d210eba5479501b844a7L166-R177) [[12]](diffhunk://#diff-116d14a84e9c9966e8a7a3e15d62578ecd64a567e6940988d8f6337a6ce8d8b5L39-R39) [[13]](diffhunk://#diff-6da95ba12c456c2ef85ba6e20eef586a00efb2b171d1d9ef8531bbd1fb288b21L60-R60) [[14]](diffhunk://#diff-cfcf389b375d41f5b5d515d41a6a015e9308b02d47a7bae88d2deb7af94ddab8L77-R77)

* Added the `extractInterval` function to parse the interval value from perf event JSON lines, with robust error handling for missing or malformed data. (`cmd/metrics/event_frame.go`)

* Updated the perf output processing pipeline (`processPerfOutput`) to consume batches from a channel, process each batch per interval, and drain remaining batches after context cancellation, ensuring no events are lost. (`cmd/metrics/metrics.go`) [[1]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1492-R1520) [[2]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1504-R1548) [[3]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1533-R1572) [[4]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286R1585-R1604)

**Testing and error handling enhancements:**

* Added comprehensive unit tests for the new `extractInterval` function, covering valid, missing, and malformed interval cases. (`cmd/metrics/event_frame_test.go`)

* Improved error messages and parsing robustness for event JSON, and removed unnecessary error checks for CPU range parsing. (`cmd/metrics/event_frame.go`) [[1]](diffhunk://#diff-abb2211279e6700bcf1ae596b24469488e62b55aabb850268cb0de32f2ffa1f7L236-L238) [[2]](diffhunk://#diff-abb2211279e6700bcf1ae596b24469488e62b55aabb850268cb0de32f2ffa1f7L407-R405)

**Supporting interface and signature changes:**

* Updated all relevant interfaces and method signatures to use `chan []byte` instead of `chan string` for stdout and stderr streaming, ensuring consistency across local and remote target command execution and script streaming. (`internal/target/target.go`, `internal/target/local_target.go`, `internal/target/remote_target.go`, `internal/target/helpers.go`, `internal/script/script.go`) [[1]](diffhunk://#diff-cfcf389b375d41f5b5d515d41a6a015e9308b02d47a7bae88d2deb7af94ddab8L77-R77) [[2]](diffhunk://#diff-116d14a84e9c9966e8a7a3e15d62578ecd64a567e6940988d8f6337a6ce8d8b5L39-R39) [[3]](diffhunk://#diff-6da95ba12c456c2ef85ba6e20eef586a00efb2b171d1d9ef8531bbd1fb288b21L60-R60) [[4]](diffhunk://#diff-548ddc95d07bb3b1c2f316509930da7b677469c35999d210eba5479501b844a7L131-R131) [[5]](diffhunk://#diff-548ddc95d07bb3b1c2f316509930da7b677469c35999d210eba5479501b844a7L166-R177) [[6]](diffhunk://#diff-45380bac771754faf451a4665a11803ad420c0db8cfb1c00b08606c31baf4337L167-R167)