### PR TITLE
add profiling capabilities

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,8 +3,50 @@ package main
 // Copyright (C) 2021-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "perfspect/cmd"
+import (
+	"fmt"
+	"os"
+	"perfspect/cmd"
+	"runtime/pprof"
+)
 
 func main() {
+	// profile only if the environment variable is set
+	if os.Getenv("PERFSPECT_PROFILE") != "" {
+		// CPU profiling
+		cpuFile, err := os.Create("cpu.prof")
+		if err != nil {
+			panic(err)
+		}
+		defer cpuFile.Close()
+
+		if err := pprof.StartCPUProfile(cpuFile); err != nil {
+			panic(err)
+		}
+		defer pprof.StopCPUProfile()
+
+		// Memory profiling
+		memFile, err := os.Create("mem.prof")
+		if err != nil {
+			panic(err)
+		}
+		defer memFile.Close()
+		defer func() {
+			if err := pprof.WriteHeapProfile(memFile); err != nil {
+				panic(err)
+			}
+		}()
+		defer func() {
+			fmt.Printf("Profiling data written to cpu.prof and mem.prof\n")
+			fmt.Printf("To analyze, use:\n")
+			fmt.Printf("  go tool pprof cpu.prof\n")
+			fmt.Printf("  go tool pprof mem.prof\n")
+			fmt.Printf("For web visualization, use:\n")
+			fmt.Printf("  go tool pprof -http=:8080 cpu.prof\n")
+			fmt.Printf("  go tool pprof -inuse_space -http=:8081 mem.prof\n")
+			fmt.Printf("  go tool pprof -alloc_space -http=:8081 mem.prof\n")
+			fmt.Printf("  go tool pprof -alloc_objects -http=:8081 mem.prof\n")
+		}()
+	}
 	cmd.Execute()
 }


### PR DESCRIPTION
This pull request adds optional runtime profiling to the application, allowing developers to collect CPU and memory profiling data when needed. Profiling is activated by setting the `PERFSPECT_PROFILE` environment variable, and the collected data is saved for analysis using Go's profiling tools.

Profiling enhancements:

* Added conditional profiling logic in `main.go` to generate `cpu.prof` and `mem.prof` files if the `PERFSPECT_PROFILE` environment variable is set. This includes starting and stopping CPU profiling and writing a heap profile for memory usage.
* Included helpful instructions printed to the console on how to analyze and visualize the generated profiling data using `go tool pprof`.