### PR TITLE
add Gaudi microarchitecture to report

### DIFF
--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -420,6 +420,7 @@ var tableDefinitions = map[string]TableDefinition{
 			script.GaudiInfoScriptName,
 			script.GaudiFirmwareScriptName,
 			script.GaudiNumaScriptName,
+			script.GaudiArchitectureScriptName,
 		},
 		FieldsFunc: gaudiTableValues},
 	CXLTableName: {
@@ -1748,6 +1749,7 @@ func gaudiTableValues(outputs map[string]script.ScriptOutput) []Field {
 	}
 	fields := []Field{
 		{Name: "Module ID"},
+		{Name: "Microarchitecture"},
 		{Name: "Serial Number"},
 		{Name: "Bus ID"},
 		{Name: "Driver Version"},
@@ -1758,13 +1760,14 @@ func gaudiTableValues(outputs map[string]script.ScriptOutput) []Field {
 	}
 	for _, gaudiInfo := range gaudiInfos {
 		fields[0].Values = append(fields[0].Values, gaudiInfo.ModuleID)
-		fields[1].Values = append(fields[1].Values, gaudiInfo.SerialNumber)
-		fields[2].Values = append(fields[2].Values, gaudiInfo.BusID)
-		fields[3].Values = append(fields[3].Values, gaudiInfo.DriverVersion)
-		fields[4].Values = append(fields[4].Values, gaudiInfo.EROM)
-		fields[5].Values = append(fields[5].Values, gaudiInfo.CPLD)
-		fields[6].Values = append(fields[6].Values, gaudiInfo.SPI)
-		fields[7].Values = append(fields[7].Values, gaudiInfo.NUMA)
+		fields[1].Values = append(fields[1].Values, gaudiInfo.Microarchitecture)
+		fields[2].Values = append(fields[2].Values, gaudiInfo.SerialNumber)
+		fields[3].Values = append(fields[3].Values, gaudiInfo.BusID)
+		fields[4].Values = append(fields[4].Values, gaudiInfo.DriverVersion)
+		fields[5].Values = append(fields[5].Values, gaudiInfo.EROM)
+		fields[6].Values = append(fields[6].Values, gaudiInfo.CPLD)
+		fields[7].Values = append(fields[7].Values, gaudiInfo.SPI)
+		fields[8].Values = append(fields[8].Values, gaudiInfo.NUMA)
 	}
 	return fields
 }

--- a/internal/report/table_helpers.go
+++ b/internal/report/table_helpers.go
@@ -1417,14 +1417,15 @@ func gpuInfoFromOutput(outputs map[string]script.ScriptOutput) []GPU {
 }
 
 type Gaudi struct {
-	ModuleID      string
-	SerialNumber  string
-	BusID         string
-	DriverVersion string
-	EROM          string
-	CPLD          string
-	SPI           string
-	NUMA          string
+	ModuleID          string
+	Microarchitecture string
+	SerialNumber      string
+	BusID             string
+	DriverVersion     string
+	EROM              string
+	CPLD              string
+	SPI               string
+	NUMA              string
 }
 
 // output from the GaudiInfo script:
@@ -1504,6 +1505,10 @@ func gaudiInfoFromOutput(outputs map[string]script.ScriptOutput) []Gaudi {
 	sort.Slice(gaudis, func(i, j int) bool {
 		return gaudis[i].ModuleID < gaudis[j].ModuleID
 	})
+	// set microarchitecture (assumes same arch for all gaudi devices)
+	for i := range gaudis {
+		gaudis[i].Microarchitecture = strings.TrimSpace(outputs[script.GaudiArchitectureScriptName].Stdout)
+	}
 	// get NUMA affinity
 	numaAffinities := valsArrayFromRegexSubmatch(outputs[script.GaudiNumaScriptName].Stdout, `^(\d+)\s+(\d+)\s+$`)
 	if len(numaAffinities) != len(gaudis) {

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -98,6 +98,7 @@ const (
 	GaudiInfoScriptName              = "gaudi info"
 	GaudiFirmwareScriptName          = "gaudi firmware"
 	GaudiNumaScriptName              = "gaudi numa"
+	GaudiArchitectureScriptName      = "gaudi architecture"
 	// benchmark scripts
 	MemoryBenchmarkScriptName    = "memory benchmark"
 	NumaBenchmarkScriptName      = "numa benchmark"
@@ -936,6 +937,22 @@ done
 		Name:           GaudiNumaScriptName,
 		ScriptTemplate: `hl-smi topo -N`,
 		Vendors:        []string{"GenuineIntel"},
+	},
+	GaudiArchitectureScriptName: {
+		Name: GaudiArchitectureScriptName,
+		ScriptTemplate: `# Determine the default HL_DEVICE based on PCI ID
+__DEFAULT_HL_DEVICE=
+__pcidev=$(grep PCI_ID /sys/bus/pci/devices/*/uevent | grep -i 1da3: || echo "")
+if echo $__pcidev | grep -qE '1000|1001|1010|1011'; then
+	__DEFAULT_HL_DEVICE="gaudi"
+elif echo $__pcidev | grep -qE '1020|1030'; then
+	__DEFAULT_HL_DEVICE="gaudi2"
+elif echo $__pcidev | grep -qE '106[0-9]'; then
+	__DEFAULT_HL_DEVICE="gaudi3"
+fi
+echo $__DEFAULT_HL_DEVICE
+`,
+		Vendors: []string{"GenuineIntel"},
 	},
 	MemoryBenchmarkScriptName: {
 		Name: MemoryBenchmarkScriptName,


### PR DESCRIPTION
currently assumes that all Gaudi devices installed in a system are of the same microarchitecture