### PR TITLE
fix regression where power and c6 residency not reported

### DIFF
--- a/cmd/metrics/event_frame.go
+++ b/cmd/metrics/event_frame.go
@@ -137,8 +137,10 @@ func parseEvents(rawEvents [][]byte) ([]Event, error) {
 		}
 		// sometimes perf will prepend "cpu/" to the topdown event names, e.g., cpu/topdown-retiring/ to x86 events, and
 		// sometimes perf will prepend armv8_pmuv*/ to the arm events, we clean them up here to match metric formulas
+		// We don't want to change power/energy-pkg, power/energy-ram, cstate_core/c6-residency, cstate_pkg/c6-residency
+		// because those are the actual event names used in the metric formulas
 		eventNameParts := strings.SplitN(event.Event, "/", 3)
-		if len(eventNameParts) == 3 {
+		if len(eventNameParts) == 3 && eventNameParts[0] != "power" && eventNameParts[0] != "cstate_core" && eventNameParts[0] != "cstate_pkg" {
 			event.Event = eventNameParts[1]
 		}
 		switch event.CounterValue {


### PR DESCRIPTION
This pull request updates the event name normalization logic in the `parseEvents` function to avoid altering certain event names that are required to match metric formulas. Specifically, it ensures that event names starting with `power`, `cstate_core`, or `cstate_pkg` are preserved as-is.

Event name normalization improvements:

* Updated the logic in `parseEvents` to skip normalization for event names prefixed with `power`, `cstate_core`, or `cstate_pkg`, ensuring these event names remain unchanged for metric formula compatibility.