### PR TITLE
Minor cleanup and adjustments to metrics HTML report

### DIFF
--- a/cmd/metrics/resources/base.html
+++ b/cmd/metrics/resources/base.html
@@ -168,6 +168,81 @@
       const description = <<.DESCRIPTION>>
       const metadata = <<.METADATA>>
       const system_info = <<.SYSTEMINFO>>
+      let tmasunburst = {
+          tooltip: {},
+          series: {
+            nodeClick: false,
+            type: "sunburst",
+            radius: [60, "90%"],
+            itemStyle: {
+              borderRadius: 7,
+              borderWidth: 2,
+            },
+            data: [
+              {
+                name: "<<.FRONTEND_LABEL>>",
+                value: Math.round(<<.FRONTEND >> * 10) / 10,
+                children: [
+                  {
+                    name: "<<.FETCHBANDWIDTH_LABEL>>",
+                    value: Math.round(<<.FETCHBANDWIDTH >> * 10) / 10,
+                  },
+                  {
+                    name: "<<.FETCHLATENCY_LABEL>>",
+                    value: Math.round(<<.FETCHLATENCY >> * 10) / 10,
+                  },
+                ]
+              },
+              {
+                name: "<<.BADSPECULATION_LABEL>>",
+                value: Math.round(<<.BADSPECULATION >> * 10) / 10,
+                children: [
+                  {
+                    name: "<<.BRANCHMISPREDICTS_LABEL>>",
+                    value: Math.round(<<.BRANCHMISPREDICTS >> * 10) / 10,
+                  },
+                  {
+                    name: "<<.MACHINECLEARS_LABEL>>",
+                    value: Math.round(<<.MACHINECLEARS >> * 10) / 10,
+                  },
+                ]
+              },
+              {
+                name: "<<.BACKEND_LABEL>>",
+                value: Math.round(<<.BACKEND >> * 10) / 10,
+                children: [
+                  {
+                    name: "<<.CORE_LABEL>>",
+                    value: Math.round(<<.COREDATA >> * 10) / 10,
+                  },
+                  {
+                    name: "<<.MEMORY_LABEL>>",
+                    value: Math.round(<<.MEMORY >> * 10) / 10,
+                  },
+                ],
+              },
+              {
+                name: "<<.RETIRING_LABEL>>",
+                value: Math.round(<<.RETIRING >> * 10) / 10,
+                children: [
+                  {
+                    name: "<<.LIGHTOPS_LABEL>>",
+                    value: Math.round(<<.LIGHTOPS >> * 10) / 10,
+                  },
+                  {
+                    name: "<<.HEAVYOPS_LABEL>>",
+                    value: Math.round(<<.HEAVYOPS >> * 10) / 10,
+                  },
+                ]
+              },
+            ],
+            radius: [20, "100%"],
+            label: {
+              rotate: "radial",
+            },
+          },
+        }
+      // the common config for all line charts
       const base_line = {
         xAxis: {
           type: "category",
@@ -185,7 +260,13 @@
           trigger: 'axis',
           valueFormatter: (value) => value.toFixed(2),
         },
-        legend: {},
+        legend: {
+          orient: 'horizontal',
+          bottom: 0,
+          left: 'center',
+          show: true,
+          selectedMode: false, // Prevents toggling series visibility by clicking on legend
+        },
       }
 
       let level1tma = {
@@ -218,6 +299,7 @@
         ...base_line,
         series: [
           {
+            name: "CPU Utilization",
             type: 'line',
             data: <<.CPUUTIL>>,
           }
@@ -228,6 +310,7 @@
         ...base_line,
         series: [
           {
+            name: "CPI",
             type: 'line',
             data: <<.CPIDATA>>,
           }
@@ -238,6 +321,7 @@
         ...base_line,
         series: [
           {
+            name: "CPU Frequency",
             type: 'line',
             data: <<.CPUFREQ>>,
           }
@@ -248,6 +332,7 @@
         ...base_line,
         series: [
           {
+            name: "Remote NUMA Access",
             type: 'line',
             data: <<.REMOTENUMA>>,
           }
@@ -300,6 +385,7 @@
         ...base_line,
         series: [
           {
+            name: "Package Power",
             type: 'line',
             data: <<.PKGPOWER>>,
           }
@@ -310,6 +396,7 @@
         ...base_line,
         series: [
           {
+            name: "DRAM Power",
             type: 'line',
             data: <<.DRAMPOWER>>,
           }
@@ -418,80 +505,7 @@
                   </ul>
                 </Grid>
                 <Grid item xs={7}>
-                  <ReactECharts style={{ minHeight: "400px" }} option={{
-                    tooltip: {},
-                    series: {
-                      nodeClick: false,
-                      type: "sunburst",
-                      radius: [60, "90%"],
-                      itemStyle: {
-                        borderRadius: 7,
-                        borderWidth: 2,
-                      },
-                      data: [
-                      {
-			  name: "<<.FRONTEND_LABEL>>",
-			  value: Math.round(<<.FRONTEND>> * 10) / 10,
-                          children:[
-                            {
-			      name: "<<.FETCHBANDWIDTH_LABEL>>",
-			      value: Math.round(<<.FETCHBANDWIDTH>> * 10) / 10,
-                            },
-                            {
-			      name: "<<.FETCHLATENCY_LABEL>>",
-			      value: Math.round(<<.FETCHLATENCY>> * 10) / 10,
-                            },
-                          ]
-                        },
-                        {
-			  name: "<<.BADSPECULATION_LABEL>>",
-			  value: Math.round(<<.BADSPECULATION>> * 10) / 10,
-                          children: [
-                            {
-			      name: "<<.BRANCHMISPREDICTS_LABEL>>",
-			      value: Math.round(<<.BRANCHMISPREDICTS>> * 10) / 10,
-                            },
-                            {
-			      name: "<<.MACHINECLEARS_LABEL>>",
-			      value: Math.round(<<.MACHINECLEARS>> * 10) / 10,
-                            },
-                          ]
-                        },
-                        {
-			  name: "<<.BACKEND_LABEL>>",
-			  value: Math.round(<<.BACKEND>> * 10) / 10,
-                          children: [
-                            {
-			      name: "<<.CORE_LABEL>>",
-			      value: Math.round(<<.COREDATA>> * 10) / 10,
-                            },
-                            {
-			      name: "<<.MEMORY_LABEL>>",
-			      value: Math.round(<<.MEMORY>> * 10) / 10,
-                            },
-                          ],
-                        },
-                        {
-			  name: "<<.RETIRING_LABEL>>",
-			  value: Math.round(<<.RETIRING>> * 10) / 10,
-                          children: [
-                            {
-			      name: "<<.LIGHTOPS_LABEL>>",
-			      value: Math.round(<<.LIGHTOPS>> * 10) / 10,
-                            },
-                            {
-			      name: "<<.HEAVYOPS_LABEL>>",
-			      value: Math.round(<<.HEAVYOPS>> * 10) / 10,
-                            },
-                          ]
-                        },
-                      ],
-                      radius: [20, "100%"],
-                      label: {
-                        rotate: "radial",
-                      },
-                    },
-                  }} />
+                  <ReactECharts style={{ minHeight: "400px" }} option={tmasunburst} />
                 </Grid>
               </Grid>
               <Grid container>

--- a/cmd/metrics/resources/base.html
+++ b/cmd/metrics/resources/base.html
@@ -168,8 +168,28 @@
       const description = <<.DESCRIPTION>>
       const metadata = <<.METADATA>>
       const system_info = <<.SYSTEMINFO>>
+      // Define consistent colors for TMA categories with child variations
+      const tmaColors = {
+        // Blue family for Frontend
+        'Frontend': '#5470c6',
+        'FrontendChild': '#7a90d3',  // Lighter blue for all Frontend children
+        
+        // Green family for Backend
+        'Backend': '#91cc75',
+        'BackendChild': '#b3e0a0',   // Lighter green for all Backend children
+        
+        // Yellow/Orange family for BadSpeculation
+        'BadSpeculation': '#fac858',
+        'BadSpeculationChild': '#ffda8a', // Lighter yellow for all BadSpeculation children
+        
+        // Red family for Retiring
+        'Retiring': '#ee6666',
+        'RetiringChild': '#f38989'    // Lighter red for all Retiring children
+      };
+      
       let tmasunburst = {
           tooltip: {},
+          color: [tmaColors.Frontend, tmaColors.BadSpeculation, tmaColors.Backend, tmaColors.Retiring],
           series: {
             nodeClick: false,
             type: "sunburst",
@@ -182,56 +202,68 @@
               {
                 name: "<<.FRONTEND_LABEL>>",
                 value: Math.round(<<.FRONTEND >> * 10) / 10,
+                itemStyle: { color: tmaColors.Frontend },
                 children: [
                   {
                     name: "<<.FETCHBANDWIDTH_LABEL>>",
                     value: Math.round(<<.FETCHBANDWIDTH >> * 10) / 10,
+                    itemStyle: { color: tmaColors.FrontendChild }
                   },
                   {
                     name: "<<.FETCHLATENCY_LABEL>>",
                     value: Math.round(<<.FETCHLATENCY >> * 10) / 10,
+                    itemStyle: { color: tmaColors.FrontendChild }
                   },
                 ]
               },
               {
                 name: "<<.BADSPECULATION_LABEL>>",
                 value: Math.round(<<.BADSPECULATION >> * 10) / 10,
+                itemStyle: { color: tmaColors.BadSpeculation },
                 children: [
                   {
                     name: "<<.BRANCHMISPREDICTS_LABEL>>",
                     value: Math.round(<<.BRANCHMISPREDICTS >> * 10) / 10,
+                    itemStyle: { color: tmaColors.BadSpeculationChild }
                   },
                   {
                     name: "<<.MACHINECLEARS_LABEL>>",
                     value: Math.round(<<.MACHINECLEARS >> * 10) / 10,
+                    itemStyle: { color: tmaColors.BadSpeculationChild }
                   },
                 ]
               },
               {
                 name: "<<.BACKEND_LABEL>>",
                 value: Math.round(<<.BACKEND >> * 10) / 10,
+                itemStyle: { color: tmaColors.Backend },
                 children: [
                   {
                     name: "<<.CORE_LABEL>>",
                     value: Math.round(<<.COREDATA >> * 10) / 10,
+                    itemStyle: { color: tmaColors.BackendChild }
                   },
                   {
                     name: "<<.MEMORY_LABEL>>",
                     value: Math.round(<<.MEMORY >> * 10) / 10,
+                    itemStyle: { color: tmaColors.BackendChild }
                   },
                 ],
               },
               {
                 name: "<<.RETIRING_LABEL>>",
                 value: Math.round(<<.RETIRING >> * 10) / 10,
+                itemStyle: { color: tmaColors.Retiring },
                 children: [
                   {
                     name: "<<.LIGHTOPS_LABEL>>",
                     value: Math.round(<<.LIGHTOPS >> * 10) / 10,
+                    itemStyle: { color: tmaColors.RetiringChild }
                   },
                   {
                     name: "<<.HEAVYOPS_LABEL>>",
                     value: Math.round(<<.HEAVYOPS >> * 10) / 10,
+                    itemStyle: { color: tmaColors.RetiringChild }
                   },
                 ]
               },
@@ -271,6 +303,7 @@
 
       let level1tma = {
         ...base_line,
+        color: [tmaColors.Frontend, tmaColors.Backend, tmaColors.Retiring, tmaColors.BadSpeculation],
         series: [
           {
             name: "Front-end",

--- a/cmd/metrics/resources/base.html
+++ b/cmd/metrics/resources/base.html
@@ -332,7 +332,7 @@
         ...base_line,
         series: [
           {
-            name: "CPU Utilization",
+            name: "CPU Utilization %",
             type: 'line',
             data: <<.CPUUTIL>>,
           }
@@ -354,7 +354,7 @@
         ...base_line,
         series: [
           {
-            name: "CPU Frequency",
+            name: "CPU Frequency (GHz)",
             type: 'line',
             data: <<.CPUFREQ>>,
           }
@@ -365,7 +365,7 @@
         ...base_line,
         series: [
           {
-            name: "Remote NUMA Access",
+            name: "Remote DRAM Reads %",
             type: 'line',
             data: <<.REMOTENUMA>>,
           }
@@ -418,7 +418,7 @@
         ...base_line,
         series: [
           {
-            name: "Package Power",
+            name: "Package Power (Watts)",
             type: 'line',
             data: <<.PKGPOWER>>,
           }
@@ -429,7 +429,7 @@
         ...base_line,
         series: [
           {
-            name: "DRAM Power",
+            name: "DRAM Power (Watts)",
             type: 'line',
             data: <<.DRAMPOWER>>,
           }
@@ -622,7 +622,7 @@
                     Remote DRAM reads %
                   </Typography>
                   <Typography variant="body1">
-                    The memory reads that miss the last level cache (LLC) and are addressed to another socket's DRAM (remote DRAM) as a percentage of total memory read accesses. This does not include LLC prefetches.
+                    The memory reads that miss the last level cache (LLC) and are addressed to remote DRAM as a percentage of total memory read accesses. This does not include LLC prefetches.
                   </Typography>
                 </Grid>
                 <Grid item xs={7}>
@@ -635,7 +635,7 @@
                     Cache MPI (misses per instruction)
                   </Typography>
                   <Typography variant="body1">
-                    The ratio of the number of requests missing cache to the total number of completed instructions, at each level of cache (L1, L2 and LLC)
+                    The ratio of the number of requests missing cache to the total number of completed instructions, at each level of cache (L1d, L2 and LLC)
                   </Typography>
                 </Grid>
                 <Grid item xs={7}>


### PR DESCRIPTION
This pull request enhances the `cmd/metrics/resources/base.html` file by improving the visualization and clarity of the TMA (Top-down Microarchitecture Analysis) sunburst chart and related line charts. The main changes include introducing a consistent color scheme for TMA categories and their children, refactoring the sunburst chart configuration for maintainability, adding explicit series names to line charts, and making minor improvements to metric descriptions.

**Visualization and Theming Improvements:**

* Introduced a `tmaColors` object to define consistent color families for TMA categories and their children, and updated the sunburst chart to use these colors for better visual distinction and clarity.
* Refactored the sunburst chart configuration into a `tmasunburst` variable, improving maintainability and making it easier to update chart properties or data in the future. The chart rendering now uses this variable.

**Chart Configuration Enhancements:**

* Updated the legend configuration for charts to improve readability: legends are now centered at the bottom, oriented horizontally, and series toggling is disabled for clarity.
* Added explicit `name` properties to all line chart series (e.g., "CPU Utilization %", "CPI", "CPU Frequency (GHz)", "Remote DRAM Reads %", "Package Power (Watts)", "DRAM Power (Watts)") for clearer chart legends and tooltips. [[1]](diffhunk://#diff-d0a760112a20f90104b656f00964a925d304401bbed2608a6e5532931efdab0eR335) [[2]](diffhunk://#diff-d0a760112a20f90104b656f00964a925d304401bbed2608a6e5532931efdab0eR346) [[3]](diffhunk://#diff-d0a760112a20f90104b656f00964a925d304401bbed2608a6e5532931efdab0eR357) [[4]](diffhunk://#diff-d0a760112a20f90104b656f00964a925d304401bbed2608a6e5532931efdab0eR368) [[5]](diffhunk://#diff-d0a760112a20f90104b656f00964a925d304401bbed2608a6e5532931efdab0eR421) [[6]](diffhunk://#diff-d0a760112a20f90104b656f00964a925d304401bbed2608a6e5532931efdab0eR432)
* Applied the new TMA color scheme to the TMA level-1 line chart for consistency across visualizations.

**Documentation and Description Updates:**

* Clarified the description of "Remote DRAM reads %" to specify "remote DRAM" instead of "another socket's DRAM."
* Updated the description of "Cache MPI" to specify "L1d" instead of just "L1," making the metric explanation more precise.