### PR TITLE
add description to report table field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,13 @@ update-deps:
 .PHONY: check_format
 check_format:
 	@echo "Running gofmt to check for code formatting issues..."
-	@test -z "$(shell gofmt -l -s ./)" || { echo "[WARN] Formatting issues detected. Resolve with 'make format'"; exit 1; }
+	@files=$$(gofmt -l -s ./); \
+	if [ -n "$$files" ]; then \
+		echo "[WARN] Formatting issues detected in the following files:"; \
+		echo "$$files"; \
+		echo "Resolve with 'make format'"; \
+		exit 1; \
+	fi
 	@echo "gofmt detected no issues"
 
 # Format code

--- a/internal/report/render_excel.go
+++ b/internal/report/render_excel.go
@@ -89,6 +89,8 @@ func renderXlsxTableMultiTarget(targetTableValues []TableValues, targetNames []s
 			col = 2
 			_ = f.SetCellValue(sheetName, cellName(col, *row), field.Name)
 			_ = f.SetCellStyle(sheetName, cellName(col, *row), cellName(col, *row), fieldNameStyle)
+			// Add cell comment if field has a description
+			addCellCommentIfNeeded(f, sheetName, cellName(col, *row), field.Description)
 			col++
 			for targetIdx := range targetNames {
 				var fieldValue string
@@ -161,6 +163,8 @@ func DefaultXlsxTableRendererFunc(tableValues TableValues, f *excelize.File, she
 		for _, field := range tableValues.Fields {
 			_ = f.SetCellValue(sheetName, cellName(col, *row), field.Name)
 			_ = f.SetCellStyle(sheetName, cellName(col, *row), cellName(col, *row), headerStyle)
+			// Add cell comment if field has a description
+			addCellCommentIfNeeded(f, sheetName, cellName(col, *row), field.Description)
 			col++
 		}
 		col = 2
@@ -186,6 +190,8 @@ func DefaultXlsxTableRendererFunc(tableValues TableValues, f *excelize.File, she
 				fieldValue = field.Values[0]
 			}
 			_ = f.SetCellValue(sheetName, cellName(col, *row), field.Name)
+			// Add cell comment if field has a description
+			addCellCommentIfNeeded(f, sheetName, cellName(col, *row), field.Description)
 			col++
 			value := getValueForCell(fieldValue)
 			_ = f.SetCellValue(sheetName, cellName(col, *row), value)
@@ -287,4 +293,22 @@ func getValueForCell(value string) (val any) {
 	}
 	val = value
 	return
+}
+
+const (
+	CommentWidth  = 300
+	CommentHeight = 200
+)
+
+// addCellCommentIfNeeded adds a cell comment if the description is not empty.
+func addCellCommentIfNeeded(f *excelize.File, sheetName, cell, description string) {
+	if description != "" {
+		_ = f.AddComment(sheetName, excelize.Comment{
+			Cell:   cell,
+			Author: "PerfSpect",
+			Text:   description,
+			Width:  CommentWidth,
+			Height: CommentHeight,
+		})
+	}
 }

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -1004,9 +1004,9 @@ func cpuTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "Family", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU family:\s*(.+)$`)}},
 		{Name: "Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Model:\s*(.+)$`)}},
 		{Name: "Stepping", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Stepping:\s*(.+)$`)}},
-		{Name: "Base Frequency", Values: []string{baseFrequencyFromOutput(outputs)}, Description: "The guaranteed minimum frequency one core can run at."},
-		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}, Description: "The maximum frequency one core can reach."},
-		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The maximum frequency all cores can reach simultaneously."},
+		{Name: "Base Frequency", Values: []string{baseFrequencyFromOutput(outputs)}, Description: "The minimum guaranteed speed of a single core under standard conditions."},
+		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}, Description: "The highest speed a single core can reach with Turbo Boost."},
+		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The highest speed all cores can reach simultaneously with Turbo Boost."},
 		{Name: "CPUs", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU\(s\):\s*(.+)$`)}},
 		{Name: "On-line CPU List", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^On-line CPU\(s\) list:\s*(.+)$`)}},
 		{Name: "Hyperthreading", Values: []string{hyperthreadingFromOutput(outputs)}},
@@ -1989,9 +1989,9 @@ func systemSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "Hyperthreading", Values: []string{hyperthreadingFromOutput(outputs)}},
 		{Name: "CPUs", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU\(s\):\s*(.+)$`)}},
 		{Name: "Intel Turbo Boost", Values: []string{turboEnabledFromOutput(outputs)}},
-		{Name: "Base Frequency", Values: []string{baseFrequencyFromOutput(outputs)}, Description: "The guaranteed minimum frequency one core can run at."},
-		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The maximum frequency all cores can reach simultaneously."},
-		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}, Description: "The maximum frequency one core can reach."},
+		{Name: "Base Frequency", Values: []string{baseFrequencyFromOutput(outputs)}, Description: "The minimum guaranteed speed of a single core under standard conditions."},
+		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}, Description: "The highest speed a single core can reach with Turbo Boost."},
+		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The highest speed all cores can reach simultaneously with Turbo Boost."},
 		{Name: "NUMA Nodes", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^NUMA node\(s\):\s*(.+)$`)}},
 		{Name: "Prefetchers", Values: []string{prefetchersSummaryFromOutput(outputs)}},
 		{Name: "PPINs", Values: []string{ppinsFromOutput(outputs)}},
@@ -2019,28 +2019,28 @@ func systemSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 
 func briefSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 	return []Field{
-		{Name: "Host Name", Values: []string{strings.TrimSpace(outputs[script.HostnameScriptName].Stdout)}},                                                      // Hostname
-		{Name: "Time", Values: []string{strings.TrimSpace(outputs[script.DateScriptName].Stdout)}},                                                               // Date
-		{Name: "CPU Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^[Mm]odel name:\s*(.+)$`)}},                           // Lscpu
-		{Name: "Microarchitecture", Values: []string{UarchFromOutput(outputs)}},                                                                                  // Lscpu, LspciBits, LspciDevices
-		{Name: "TDP", Values: []string{tdpFromOutput(outputs)}},                                                                                                  // PackagePowerLimit
-		{Name: "Sockets", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(s\):\s*(.+)$`)}},                               // Lscpu
-		{Name: "Cores per Socket", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Core\(s\) per socket:\s*(.+)$`)}},             // Lscpu
-		{Name: "Hyperthreading", Values: []string{hyperthreadingFromOutput(outputs)}},                                                                            // Lscpu, LspciBits, LspciDevices
-		{Name: "CPUs", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU\(s\):\s*(.+)$`)}},                                     // Lscpu
-		{Name: "NUMA Nodes", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^NUMA node\(s\):\s*(.+)$`)}},                         // Lscpu
-		{Name: "Scaling Driver", Values: []string{strings.TrimSpace(outputs[script.ScalingDriverScriptName].Stdout)}},                                            // ScalingDriver
-		{Name: "Scaling Governor", Values: []string{strings.TrimSpace(outputs[script.ScalingGovernorScriptName].Stdout)}},                                        // ScalingGovernor
-		{Name: "C-states", Values: []string{cstatesSummaryFromOutput(outputs)}},                                                                                  // Cstates
-		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}, Description: "The maximum frequency one core can reach."},                 // MaximumFrequency, SpecCoreFrequencies,
-		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The maximum frequency that all cores can reach simultaneously."}, // Lscpu, LspciBits, LspciDevices, SpecCoreFrequencies
-		{Name: "Energy Performance Bias", Values: []string{epbFromOutput(outputs)}},                                                                              // EpbSource, EpbBIOS, EpbOS
-		{Name: "Efficiency Latency Control", Values: []string{elcSummaryFromOutput(outputs)}},                                                                    // Elc
-		{Name: "MemTotal", Values: []string{valFromRegexSubmatch(outputs[script.MeminfoScriptName].Stdout, `^MemTotal:\s*(.+?)$`)}},                              // Meminfo
-		{Name: "NIC", Values: []string{nicSummaryFromOutput(outputs)}},                                                                                           // Lshw, NicInfo
-		{Name: "Disk", Values: []string{diskSummaryFromOutput(outputs)}},                                                                                         // DiskInfo, Hdparm
-		{Name: "OS", Values: []string{operatingSystemFromOutput(outputs)}},                                                                                       // EtcRelease
-		{Name: "Kernel", Values: []string{valFromRegexSubmatch(outputs[script.UnameScriptName].Stdout, `^Linux \S+ (\S+)`)}},                                     // Uname
+		{Name: "Host Name", Values: []string{strings.TrimSpace(outputs[script.HostnameScriptName].Stdout)}},                                                                                   // Hostname
+		{Name: "Time", Values: []string{strings.TrimSpace(outputs[script.DateScriptName].Stdout)}},                                                                                            // Date
+		{Name: "CPU Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^[Mm]odel name:\s*(.+)$`)}},                                                        // Lscpu
+		{Name: "Microarchitecture", Values: []string{UarchFromOutput(outputs)}},                                                                                                               // Lscpu, LspciBits, LspciDevices
+		{Name: "TDP", Values: []string{tdpFromOutput(outputs)}},                                                                                                                               // PackagePowerLimit
+		{Name: "Sockets", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(s\):\s*(.+)$`)}},                                                            // Lscpu
+		{Name: "Cores per Socket", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Core\(s\) per socket:\s*(.+)$`)}},                                          // Lscpu
+		{Name: "Hyperthreading", Values: []string{hyperthreadingFromOutput(outputs)}},                                                                                                         // Lscpu, LspciBits, LspciDevices
+		{Name: "CPUs", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU\(s\):\s*(.+)$`)}},                                                                  // Lscpu
+		{Name: "NUMA Nodes", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^NUMA node\(s\):\s*(.+)$`)}},                                                      // Lscpu
+		{Name: "Scaling Driver", Values: []string{strings.TrimSpace(outputs[script.ScalingDriverScriptName].Stdout)}},                                                                         // ScalingDriver
+		{Name: "Scaling Governor", Values: []string{strings.TrimSpace(outputs[script.ScalingGovernorScriptName].Stdout)}},                                                                     // ScalingGovernor
+		{Name: "C-states", Values: []string{cstatesSummaryFromOutput(outputs)}},                                                                                                               // Cstates
+		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}, Description: "The highest speed a single core can reach with Turbo Boost."},                            // MaximumFrequency, SpecCoreFrequencies,
+		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The highest speed all cores can reach simultaneously with Turbo Boost."}, // Lscpu, LspciBits, LspciDevices, SpecCoreFrequencies
+		{Name: "Energy Performance Bias", Values: []string{epbFromOutput(outputs)}},                                                                                                           // EpbSource, EpbBIOS, EpbOS
+		{Name: "Efficiency Latency Control", Values: []string{elcSummaryFromOutput(outputs)}},                                                                                                 // Elc
+		{Name: "MemTotal", Values: []string{valFromRegexSubmatch(outputs[script.MeminfoScriptName].Stdout, `^MemTotal:\s*(.+?)$`)}},                                                           // Meminfo
+		{Name: "NIC", Values: []string{nicSummaryFromOutput(outputs)}},                                                                                                                        // Lshw, NicInfo
+		{Name: "Disk", Values: []string{diskSummaryFromOutput(outputs)}},                                                                                                                      // DiskInfo, Hdparm
+		{Name: "OS", Values: []string{operatingSystemFromOutput(outputs)}},                                                                                                                    // EtcRelease
+		{Name: "Kernel", Values: []string{valFromRegexSubmatch(outputs[script.UnameScriptName].Stdout, `^Linux \S+ (\S+)`)}},                                                                  // Uname
 	}
 }
 

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -2033,7 +2033,7 @@ func briefSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "Scaling Governor", Values: []string{strings.TrimSpace(outputs[script.ScalingGovernorScriptName].Stdout)}},                                        // ScalingGovernor
 		{Name: "C-states", Values: []string{cstatesSummaryFromOutput(outputs)}},                                                                                  // Cstates
 		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}, Description: "The maximum frequency one core can reach."},                 // MaximumFrequency, SpecCoreFrequencies,
-		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The maximum frequency one core can reach."}, // Lscpu, LspciBits, LspciDevices, SpecCoreFrequencies
+		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The maximum frequency that all cores can reach simultaneously."}, // Lscpu, LspciBits, LspciDevices, SpecCoreFrequencies
 		{Name: "Energy Performance Bias", Values: []string{epbFromOutput(outputs)}},                                                                              // EpbSource, EpbBIOS, EpbOS
 		{Name: "Efficiency Latency Control", Values: []string{elcSummaryFromOutput(outputs)}},                                                                    // Elc
 		{Name: "MemTotal", Values: []string{valFromRegexSubmatch(outputs[script.MeminfoScriptName].Stdout, `^MemTotal:\s*(.+?)$`)}},                              // Meminfo

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -22,8 +22,9 @@ import (
 
 // Field represents the values for a field in a table
 type Field struct {
-	Name   string
-	Values []string
+	Name        string
+	Description string // optional description of the field
+	Values      []string
 }
 
 // TableValues combines the table definition with the resulting fields and their values
@@ -1003,9 +1004,9 @@ func cpuTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "Family", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU family:\s*(.+)$`)}},
 		{Name: "Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Model:\s*(.+)$`)}},
 		{Name: "Stepping", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Stepping:\s*(.+)$`)}},
-		{Name: "Base Frequency", Values: []string{baseFrequencyFromOutput(outputs)}},
-		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}},
-		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}},
+		{Name: "Base Frequency", Values: []string{baseFrequencyFromOutput(outputs)}, Description: "The guaranteed minimum frequency one core can run at."},
+		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}, Description: "The maximum frequency one core can reach."},
+		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The maximum frequency all cores can reach simultaneously."},
 		{Name: "CPUs", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU\(s\):\s*(.+)$`)}},
 		{Name: "On-line CPU List", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^On-line CPU\(s\) list:\s*(.+)$`)}},
 		{Name: "Hyperthreading", Values: []string{hyperthreadingFromOutput(outputs)}},
@@ -1013,11 +1014,11 @@ func cpuTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "Sockets", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(s\):\s*(.+)$`)}},
 		{Name: "NUMA Nodes", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^NUMA node\(s\):\s*(.+)$`)}},
 		{Name: "NUMA CPU List", Values: []string{numaCPUListFromOutput(outputs)}},
-		{Name: "L1d Cache", Values: []string{l1dFromOutput(outputs)}},
-		{Name: "L1i Cache", Values: []string{l1iFromOutput(outputs)}},
-		{Name: "L2 Cache", Values: []string{l2FromOutput(outputs)}},
-		{Name: "L3 Cache", Values: []string{l3FromOutput(outputs)}},
-		{Name: "L3 per Core", Values: []string{l3PerCoreFromOutput(outputs)}},
+		{Name: "L1d Cache", Values: []string{l1dFromOutput(outputs)}, Description: "The sum of all L1 data cache sizes for one CPU socket."},
+		{Name: "L1i Cache", Values: []string{l1iFromOutput(outputs)}, Description: "The sum of all L1 instruction cache sizes for one CPU socket."},
+		{Name: "L2 Cache", Values: []string{l2FromOutput(outputs)}, Description: "The sum of all L2 cache sizes for one CPU socket."},
+		{Name: "L3 Cache", Values: []string{l3FromOutput(outputs)}, Description: "The total L3 cache size for one CPU socket."},
+		{Name: "L3 per Core", Values: []string{l3PerCoreFromOutput(outputs)}, Description: "The L3 cache size per CPU core."},
 		{Name: "Memory Channels", Values: []string{channelsFromOutput(outputs)}},
 		{Name: "Intel Turbo Boost", Values: []string{turboEnabledFromOutput(outputs)}},
 		{Name: "Virtualization", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Virtualization:\s*(.+)$`)}},
@@ -1982,15 +1983,15 @@ func systemSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "CPU Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^[Mm]odel name:\s*(.+)$`)}},
 		{Name: "Architecture", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Architecture:\s*(.+)$`)}},
 		{Name: "Microarchitecture", Values: []string{UarchFromOutput(outputs)}},
-		{Name: "L3 Cache", Values: []string{l3FromOutput(outputs)}},
+		{Name: "L3 Cache", Values: []string{l3FromOutput(outputs)}, Description: "The total L3 cache size for one CPU socket."},
 		{Name: "Cores per Socket", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Core\(s\) per socket:\s*(.+)$`)}},
 		{Name: "Sockets", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(s\):\s*(.+)$`)}},
 		{Name: "Hyperthreading", Values: []string{hyperthreadingFromOutput(outputs)}},
 		{Name: "CPUs", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU\(s\):\s*(.+)$`)}},
 		{Name: "Intel Turbo Boost", Values: []string{turboEnabledFromOutput(outputs)}},
-		{Name: "Base Frequency", Values: []string{baseFrequencyFromOutput(outputs)}},
-		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}},
-		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}},
+		{Name: "Base Frequency", Values: []string{baseFrequencyFromOutput(outputs)}, Description: "The guaranteed minimum frequency one core can run at."},
+		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The maximum frequency all cores can reach simultaneously."},
+		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}, Description: "The maximum frequency one core can reach."},
 		{Name: "NUMA Nodes", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^NUMA node\(s\):\s*(.+)$`)}},
 		{Name: "Prefetchers", Values: []string{prefetchersSummaryFromOutput(outputs)}},
 		{Name: "PPINs", Values: []string{ppinsFromOutput(outputs)}},
@@ -2018,28 +2019,28 @@ func systemSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 
 func briefSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 	return []Field{
-		{Name: "Host Name", Values: []string{strings.TrimSpace(outputs[script.HostnameScriptName].Stdout)}},                                          // Hostname
-		{Name: "Time", Values: []string{strings.TrimSpace(outputs[script.DateScriptName].Stdout)}},                                                   // Date
-		{Name: "CPU Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^[Mm]odel name:\s*(.+)$`)}},               // Lscpu
-		{Name: "Microarchitecture", Values: []string{UarchFromOutput(outputs)}},                                                                      // Lscpu, LspciBits, LspciDevices
-		{Name: "TDP", Values: []string{tdpFromOutput(outputs)}},                                                                                      // PackagePowerLimit
-		{Name: "Sockets", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(s\):\s*(.+)$`)}},                   // Lscpu
-		{Name: "Cores per Socket", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Core\(s\) per socket:\s*(.+)$`)}}, // Lscpu
-		{Name: "Hyperthreading", Values: []string{hyperthreadingFromOutput(outputs)}},                                                                // Lscpu, LspciBits, LspciDevices
-		{Name: "CPUs", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU\(s\):\s*(.+)$`)}},                         // Lscpu
-		{Name: "NUMA Nodes", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^NUMA node\(s\):\s*(.+)$`)}},             // Lscpu
-		{Name: "Scaling Driver", Values: []string{strings.TrimSpace(outputs[script.ScalingDriverScriptName].Stdout)}},                                // ScalingDriver
-		{Name: "Scaling Governor", Values: []string{strings.TrimSpace(outputs[script.ScalingGovernorScriptName].Stdout)}},                            // ScalingGovernor
-		{Name: "C-states", Values: []string{cstatesSummaryFromOutput(outputs)}},                                                                      // Cstates
-		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}},                                                               // MaximumFrequency, SpecCoreFrequencies,
-		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}},                                               // Lscpu, LspciBits, LspciDevices, SpecCoreFrequencies
-		{Name: "Energy Performance Bias", Values: []string{epbFromOutput(outputs)}},                                                                  // EpbSource, EpbBIOS, EpbOS
-		{Name: "Efficiency Latency Control", Values: []string{elcSummaryFromOutput(outputs)}},                                                        // Elc
-		{Name: "MemTotal", Values: []string{valFromRegexSubmatch(outputs[script.MeminfoScriptName].Stdout, `^MemTotal:\s*(.+?)$`)}},                  // Meminfo
-		{Name: "NIC", Values: []string{nicSummaryFromOutput(outputs)}},                                                                               // Lshw, NicInfo
-		{Name: "Disk", Values: []string{diskSummaryFromOutput(outputs)}},                                                                             // DiskInfo, Hdparm
-		{Name: "OS", Values: []string{operatingSystemFromOutput(outputs)}},                                                                           // EtcRelease
-		{Name: "Kernel", Values: []string{valFromRegexSubmatch(outputs[script.UnameScriptName].Stdout, `^Linux \S+ (\S+)`)}},                         // Uname
+		{Name: "Host Name", Values: []string{strings.TrimSpace(outputs[script.HostnameScriptName].Stdout)}},                                                      // Hostname
+		{Name: "Time", Values: []string{strings.TrimSpace(outputs[script.DateScriptName].Stdout)}},                                                               // Date
+		{Name: "CPU Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^[Mm]odel name:\s*(.+)$`)}},                           // Lscpu
+		{Name: "Microarchitecture", Values: []string{UarchFromOutput(outputs)}},                                                                                  // Lscpu, LspciBits, LspciDevices
+		{Name: "TDP", Values: []string{tdpFromOutput(outputs)}},                                                                                                  // PackagePowerLimit
+		{Name: "Sockets", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(s\):\s*(.+)$`)}},                               // Lscpu
+		{Name: "Cores per Socket", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Core\(s\) per socket:\s*(.+)$`)}},             // Lscpu
+		{Name: "Hyperthreading", Values: []string{hyperthreadingFromOutput(outputs)}},                                                                            // Lscpu, LspciBits, LspciDevices
+		{Name: "CPUs", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^CPU\(s\):\s*(.+)$`)}},                                     // Lscpu
+		{Name: "NUMA Nodes", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^NUMA node\(s\):\s*(.+)$`)}},                         // Lscpu
+		{Name: "Scaling Driver", Values: []string{strings.TrimSpace(outputs[script.ScalingDriverScriptName].Stdout)}},                                            // ScalingDriver
+		{Name: "Scaling Governor", Values: []string{strings.TrimSpace(outputs[script.ScalingGovernorScriptName].Stdout)}},                                        // ScalingGovernor
+		{Name: "C-states", Values: []string{cstatesSummaryFromOutput(outputs)}},                                                                                  // Cstates
+		{Name: "Maximum Frequency", Values: []string{maxFrequencyFromOutput(outputs)}, Description: "The maximum frequency one core can reach."},                 // MaximumFrequency, SpecCoreFrequencies,
+		{Name: "All-core Maximum Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}, Description: "The maximum frequency one core can reach."}, // Lscpu, LspciBits, LspciDevices, SpecCoreFrequencies
+		{Name: "Energy Performance Bias", Values: []string{epbFromOutput(outputs)}},                                                                              // EpbSource, EpbBIOS, EpbOS
+		{Name: "Efficiency Latency Control", Values: []string{elcSummaryFromOutput(outputs)}},                                                                    // Elc
+		{Name: "MemTotal", Values: []string{valFromRegexSubmatch(outputs[script.MeminfoScriptName].Stdout, `^MemTotal:\s*(.+?)$`)}},                              // Meminfo
+		{Name: "NIC", Values: []string{nicSummaryFromOutput(outputs)}},                                                                                           // Lshw, NicInfo
+		{Name: "Disk", Values: []string{diskSummaryFromOutput(outputs)}},                                                                                         // DiskInfo, Hdparm
+		{Name: "OS", Values: []string{operatingSystemFromOutput(outputs)}},                                                                                       // EtcRelease
+		{Name: "Kernel", Values: []string{valFromRegexSubmatch(outputs[script.UnameScriptName].Stdout, `^Linux \S+ (\S+)`)}},                                     // Uname
 	}
 }
 
@@ -2192,19 +2193,19 @@ func frequencyBenchmarkTableValues(outputs map[string]script.ScriptOutput) []Fie
 	var avx2FieldIdx int
 	var avx512FieldIdx int
 	if len(specSSEFreqs) > 0 {
-		fields = append(fields, Field{Name: "SSE (expected)"})
+		fields = append(fields, Field{Name: "SSE (expected)", Description: "The expected frequency, when running SSE instructions, for the given number of active cores."})
 		specSSEFieldIdx = len(fields) - 1
 	}
 	if len(scalarIaddFreqs) > 0 {
-		fields = append(fields, Field{Name: "SSE"})
+		fields = append(fields, Field{Name: "SSE", Description: "The measured frequency, when running SSE instructions, for the given number of active cores."})
 		scalarIaddFieldIdx = len(fields) - 1
 	}
 	if len(avx256FmaFreqs) > 0 {
-		fields = append(fields, Field{Name: "AVX2"})
+		fields = append(fields, Field{Name: "AVX2", Description: "The measured frequency, when running AVX2 instructions, for the given number of active cores."})
 		avx2FieldIdx = len(fields) - 1
 	}
 	if len(avx512FmaFreqs) > 0 {
-		fields = append(fields, Field{Name: "AVX512"})
+		fields = append(fields, Field{Name: "AVX512", Description: "The measured frequency, when running AVX512 instructions, for the given number of active cores."})
 		avx512FieldIdx = len(fields) - 1
 	}
 	// add the data to the fields


### PR DESCRIPTION
This pull request enhances the reporting features by adding support for field descriptions in both HTML and Excel reports. Field descriptions are now included in the data model, and are displayed as tooltips in HTML tables and as cell comments in Excel exports. These improvements make the reports more informative and user-friendly, especially for fields whose meaning may not be immediately obvious.

**Field Description Support**

* Added a `Description` member to the `Field` struct, allowing each field to include an optional description.
* Updated table construction functions (e.g., `cpuTableValues`, `systemSummaryTableValues`, `briefSummaryTableValues`, `frequencyBenchmarkTableValues`) to populate the new `Description` field for relevant fields, providing informative context for key metrics. [[1]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL1006-R1021) [[2]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL1985-R1994) [[3]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL2034-R2036) [[4]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL2195-R2208)

**Excel Report Enhancements**

* Added the `addCellCommentIfNeeded` helper function in `render_excel.go`, which attaches cell comments containing field descriptions to header cells and field name cells in Excel tables.
* Integrated calls to `addCellCommentIfNeeded` at appropriate places in the Excel rendering logic to ensure field descriptions appear as comments in the exported files. [[1]](diffhunk://#diff-a1617c12979d7e6ed4762c58d11e037ac45caa46719edf90a40bb1c425c49eb6R92-R93) [[2]](diffhunk://#diff-a1617c12979d7e6ed4762c58d11e037ac45caa46719edf90a40bb1c425c49eb6R166-R167) [[3]](diffhunk://#diff-a1617c12979d7e6ed4762c58d11e037ac45caa46719edf90a40bb1c425c49eb6R193-R194)

**HTML Report Enhancements**

* Introduced new CSS styles for tooltip display, and a `CreateFieldNameWithDescription` helper to render field names with a tooltip icon and description in HTML tables. [[1]](diffhunk://#diff-8c105bccb413747f72f97605d821806fc2e44b041f3fa2aa1be2522ba16aa142R122-R175) [[2]](diffhunk://#diff-8c105bccb413747f72f97605d821806fc2e44b041f3fa2aa1be2522ba16aa142R505-R529)
* Updated all HTML table rendering functions to use the new helper, so field descriptions appear as tooltips in both header and value cells. [[1]](diffhunk://#diff-8c105bccb413747f72f97605d821806fc2e44b041f3fa2aa1be2522ba16aa142R554-R557) [[2]](diffhunk://#diff-8c105bccb413747f72f97605d821806fc2e44b041f3fa2aa1be2522ba16aa142L494-R573) [[3]](diffhunk://#diff-8c105bccb413747f72f97605d821806fc2e44b041f3fa2aa1be2522ba16aa142L516-R589) [[4]](diffhunk://#diff-8c105bccb413747f72f97605d821806fc2e44b041f3fa2aa1be2522ba16aa142L734-R807)