### PR TITLE
cache sizes reported by type

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -145,7 +145,7 @@ func setLlcSize(desiredLlcSize float64, myTarget target.Target, localTempDir str
 		completeChannel <- setOutput{goRoutineID: goRoutineId, err: fmt.Errorf("failed to get maximum LLC size: %w", err)}
 		return
 	}
-	currentLlcSize, err := report.GetL3MSRMB(outputs)
+	currentLlcSize, _, err := report.GetL3MSRMB(outputs)
 	if err != nil {
 		completeChannel <- setOutput{goRoutineID: goRoutineId, err: fmt.Errorf("failed to get current LLC size: %w", err)}
 		return

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -121,6 +121,7 @@ func setLlcSize(desiredLlcSize float64, myTarget target.Target, localTempDir str
 	// get the data we need to set the LLC size
 	scripts := []script.ScriptDefinition{}
 	scripts = append(scripts, script.GetScriptByName(script.LscpuScriptName))
+	scripts = append(scripts, script.GetScriptByName(script.LscpuCacheScriptName))
 	scripts = append(scripts, script.GetScriptByName(script.LspciBitsScriptName))
 	scripts = append(scripts, script.GetScriptByName(script.LspciDevicesScriptName))
 	scripts = append(scripts, script.GetScriptByName(script.L3CacheWayEnabledName))
@@ -140,7 +141,7 @@ func setLlcSize(desiredLlcSize float64, myTarget target.Target, localTempDir str
 		completeChannel <- setOutput{goRoutineID: goRoutineId, err: fmt.Errorf("cache way count is zero")}
 		return
 	}
-	maximumLlcSize, err := report.GetL3LscpuMB(outputs)
+	maximumLlcSize, _, err := report.GetL3LscpuMB(outputs)
 	if err != nil {
 		completeChannel <- setOutput{goRoutineID: goRoutineId, err: fmt.Errorf("failed to get maximum LLC size: %w", err)}
 		return

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -2072,7 +2072,7 @@ func configurationTableValues(outputs map[string]script.ScriptOutput) []Field {
 
 	fields := []Field{
 		{Name: "Cores per Socket", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Core\(s\) per socket:\s*(.+)$`)}},
-		{Name: "L3 Cache", Values: []string{l3FromOutput(outputs)}},
+		{Name: "L3 Cache", Values: []string{l3InstanceFromOutput(outputs)}},
 		{Name: "Package Power / TDP", Values: []string{tdpFromOutput(outputs)}},
 		{Name: "All-Core Max Frequency", Values: []string{allCoreMaxFrequencyFromOutput(outputs)}},
 	}

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -222,6 +222,7 @@ var tableDefinitions = map[string]TableDefinition{
 		MenuLabel: CPUMenuLabel,
 		ScriptNames: []string{
 			script.LscpuScriptName,
+			script.LscpuCacheScriptName,
 			script.LspciBitsScriptName,
 			script.LspciDevicesScriptName,
 			script.CpuidScriptName,
@@ -502,6 +503,7 @@ var tableDefinitions = map[string]TableDefinition{
 			script.DateScriptName,
 			script.DmidecodeScriptName,
 			script.LscpuScriptName,
+			script.LscpuCacheScriptName,
 			script.LspciBitsScriptName,
 			script.LspciDevicesScriptName,
 			script.L3CacheWayEnabledName,
@@ -537,6 +539,7 @@ var tableDefinitions = map[string]TableDefinition{
 			script.HostnameScriptName,
 			script.DateScriptName,
 			script.LscpuScriptName,
+			script.LscpuCacheScriptName,
 			script.LspciBitsScriptName,
 			script.LspciDevicesScriptName,
 			script.MaximumFrequencyScriptName,
@@ -563,6 +566,7 @@ var tableDefinitions = map[string]TableDefinition{
 		HasRows: false,
 		ScriptNames: []string{
 			script.LscpuScriptName,
+			script.LscpuCacheScriptName,
 			script.LspciBitsScriptName,
 			script.LspciDevicesScriptName,
 			script.L3CacheWayEnabledName,
@@ -997,6 +1001,7 @@ func softwareVersionTableValues(outputs map[string]script.ScriptOutput) []Field 
 }
 
 func cpuTableValues(outputs map[string]script.ScriptOutput) []Field {
+	lscpuCache := parseLscpuCacheOutput(outputs[script.LscpuCacheScriptName].Stdout)
 	return []Field{
 		{Name: "CPU Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^[Mm]odel name:\s*(.+)$`)}},
 		{Name: "Architecture", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Architecture:\s*(.+)$`)}},
@@ -1014,11 +1019,11 @@ func cpuTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "Sockets", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(s\):\s*(.+)$`)}},
 		{Name: "NUMA Nodes", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^NUMA node\(s\):\s*(.+)$`)}},
 		{Name: "NUMA CPU List", Values: []string{numaCPUListFromOutput(outputs)}},
-		{Name: "L1d Cache", Values: []string{l1dFromOutput(outputs)}, Description: "The sum of all L1 data cache sizes for one CPU socket."},
-		{Name: "L1i Cache", Values: []string{l1iFromOutput(outputs)}, Description: "The sum of all L1 instruction cache sizes for one CPU socket."},
-		{Name: "L2 Cache", Values: []string{l2FromOutput(outputs)}, Description: "The sum of all L2 cache sizes for one CPU socket."},
-		{Name: "L3 Cache", Values: []string{l3FromOutput(outputs)}, Description: "The total L3 cache size for one CPU socket."},
-		{Name: "L3 per Core", Values: []string{l3PerCoreFromOutput(outputs)}, Description: "The L3 cache size per CPU core."},
+		{Name: "L1d Cache", Values: []string{l1l2CacheSizeFromLscpuCache(lscpuCache["L1d"])}, Description: "The size of the L1 data cache for one core."},
+		{Name: "L1i Cache", Values: []string{l1l2CacheSizeFromLscpuCache(lscpuCache["L1i"])}, Description: "The size of the L1 instruction cache for one core."},
+		{Name: "L2 Cache", Values: []string{l1l2CacheSizeFromLscpuCache(lscpuCache["L2"])}, Description: "The size of the L2 cache for one core."},
+		{Name: "L3 Cache (instance/total)", Values: []string{l3FromOutput(outputs)}, Description: "The size of one L3 cache instance and the total L3 cache size for the system."},
+		{Name: "L3 per Core", Values: []string{l3PerCoreFromOutput(outputs)}, Description: "The L3 cache size per core."},
 		{Name: "Memory Channels", Values: []string{channelsFromOutput(outputs)}},
 		{Name: "Intel Turbo Boost", Values: []string{turboEnabledFromOutput(outputs)}},
 		{Name: "Virtualization", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Virtualization:\s*(.+)$`)}},

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -1001,7 +1001,7 @@ func softwareVersionTableValues(outputs map[string]script.ScriptOutput) []Field 
 }
 
 func cpuTableValues(outputs map[string]script.ScriptOutput) []Field {
-	lscpuCache := parseLscpuCacheOutput(outputs[script.LscpuCacheScriptName].Stdout)
+	lscpuCache, _ := parseLscpuCacheOutput(outputs[script.LscpuCacheScriptName].Stdout)
 	return []Field{
 		{Name: "CPU Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^[Mm]odel name:\s*(.+)$`)}},
 		{Name: "Architecture", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Architecture:\s*(.+)$`)}},

--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -2002,7 +2002,7 @@ func systemSummaryTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "CPU Model", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^[Mm]odel name:\s*(.+)$`)}},
 		{Name: "Architecture", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Architecture:\s*(.+)$`)}},
 		{Name: "Microarchitecture", Values: []string{UarchFromOutput(outputs)}},
-		{Name: "L3 Cache", Values: []string{l3FromOutput(outputs)}, Description: "The total L3 cache size for one CPU socket."},
+		{Name: "L3 Cache (instance/total)", Values: []string{l3FromOutput(outputs)}, Description: "The size of one L3 cache instance and the total L3 cache size for the system."},
 		{Name: "Cores per Socket", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Core\(s\) per socket:\s*(.+)$`)}},
 		{Name: "Sockets", Values: []string{valFromRegexSubmatch(outputs[script.LscpuScriptName].Stdout, `^Socket\(s\):\s*(.+)$`)}},
 		{Name: "Hyperthreading", Values: []string{hyperthreadingFromOutput(outputs)}},

--- a/internal/report/table_helpers_cache.go
+++ b/internal/report/table_helpers_cache.go
@@ -153,7 +153,7 @@ func l3PerCoreFromOutput(outputs map[string]script.ScriptOutput) string {
 // formatCacheSizeMB formats a floating-point cache size value (in MB) as a string
 // with the "M" unit suffix.
 func formatCacheSizeMB(size float64) string {
-	val := strconv.FormatFloat(size, 'f', 1, 64)
+	val := strconv.FormatFloat(size, 'f', 3, 64)
 	val = strings.TrimRight(val, "0") // trim trailing zeros
 	val = strings.TrimRight(val, ".") // trim decimal point if trailing
 	return fmt.Sprintf("%sM", val)

--- a/internal/report/table_helpers_cache.go
+++ b/internal/report/table_helpers_cache.go
@@ -105,6 +105,20 @@ func l3FromOutput(outputs map[string]script.ScriptOutput) string {
 	return fmt.Sprintf("%s/%s", formatCacheSizeMB(l3InstanceMB), formatCacheSizeMB(l3TotalMB))
 }
 
+// l3InstanceFromOutput retrieves the L3 cache size per instance (per socket on Intel) in megabytes
+func l3InstanceFromOutput(outputs map[string]script.ScriptOutput) string {
+	l3InstanceMB, _, err := GetL3MSRMB(outputs)
+	if err != nil {
+		slog.Info("Could not get L3 size from MSR, falling back to lscpu", slog.String("error", err.Error()))
+		l3InstanceMB, _, err = GetL3LscpuMB(outputs)
+		if err != nil {
+			slog.Error("Could not get L3 size from lscpu", slog.String("error", err.Error()))
+			return ""
+		}
+	}
+	return formatCacheSizeMB(l3InstanceMB)
+}
+
 // l3PerCoreFromOutput calculates the amount of L3 cache (in MiB) available per core
 // based on the provided script outputs. It first checks if the host is virtualized,
 // in which case it returns an empty string since the calculation is not applicable.

--- a/internal/report/table_helpers_cache_test.go
+++ b/internal/report/table_helpers_cache_test.go
@@ -7,209 +7,38 @@ import (
 	"testing"
 )
 
-func TestGetCacheLscpuParts(t *testing.T) {
+func TestParseCacheSizeToMB(t *testing.T) {
 	tests := []struct {
-		input         string
-		wantSize      float64
-		wantUnits     string
-		wantInstances int
-		wantErr       bool
+		input     string
+		fieldName string
+		want      float64
+		wantErr   bool
 	}{
-		{
-			input:         "32 MiB (1 instance)",
-			wantSize:      32,
-			wantUnits:     "MiB",
-			wantInstances: 1,
-			wantErr:       false,
-		},
-		{
-			input:         "1.5 GiB (2 instances)",
-			wantSize:      1.5,
-			wantUnits:     "GiB",
-			wantInstances: 2,
-			wantErr:       false,
-		},
-		{
-			input:         "512 KiB (4 instances)",
-			wantSize:      512,
-			wantUnits:     "KiB",
-			wantInstances: 4,
-			wantErr:       false,
-		},
-		{
-			input:         "256 KiB",
-			wantSize:      256,
-			wantUnits:     "KiB",
-			wantInstances: 1,
-			wantErr:       false,
-		},
-		{
-			input:         "2 MiB",
-			wantSize:      2,
-			wantUnits:     "MiB",
-			wantInstances: 1,
-			wantErr:       false,
-		},
-		{
-			input:         "bad format string",
-			wantSize:      0,
-			wantUnits:     "",
-			wantInstances: 0,
-			wantErr:       true,
-		},
-		{
-			input:         "12.5 MiB (notanumber instances)",
-			wantSize:      0,
-			wantUnits:     "",
-			wantInstances: 0,
-			wantErr:       true,
-		},
-		{
-			input:         "",
-			wantSize:      0,
-			wantUnits:     "",
-			wantInstances: 0,
-			wantErr:       true,
-		},
+		{"32K", "test", 32.0 / 1024.0, false},
+		{"1024K", "test", 1.0, false},
+		{"2M", "test", 2.0, false},
+		{"2MB", "test", 2.0, false},
+		{"1G", "test", 1024.0, false},
+		{"1GB", "test", 1024.0, false},
+		{"0K", "test", 0.0, false},
+		{"", "empty", 0.0, true},
+		{"100", "no_suffix", 0.0, true},
+		{"abcK", "invalid_number", 0.0, true},
+		{"5T", "unknown_suffix", 0.0, true},
+		{"  4M  ", "spaces", 4.0, false},
+		{"8kB", "case", 8.0 / 1024.0, false},
+		{"3m", "case", 3.0, false},
+		{"2g", "case", 2048.0, false},
 	}
 
 	for _, tt := range tests {
-		size, units, instances, err := getCacheLscpuParts(tt.input)
-		if tt.wantErr {
-			if err == nil {
-				t.Errorf("getCacheLscpuParts(%q) expected error, got none", tt.input)
-			}
+		got, err := parseCacheSizeToMB(tt.input, tt.fieldName)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("parseCacheSizeToMB(%q, %q) error = %v, wantErr %v", tt.input, tt.fieldName, err, tt.wantErr)
 			continue
 		}
-		if err != nil {
-			t.Errorf("getCacheLscpuParts(%q) unexpected error: %v", tt.input, err)
-			continue
+		if !tt.wantErr && got != tt.want {
+			t.Errorf("parseCacheSizeToMB(%q, %q) = %v, want %v", tt.input, tt.fieldName, got, tt.want)
 		}
-		if size != tt.wantSize {
-			t.Errorf("getCacheLscpuParts(%q) size = %v, want %v", tt.input, size, tt.wantSize)
-		}
-		if units != tt.wantUnits {
-			t.Errorf("getCacheLscpuParts(%q) units = %v, want %v", tt.input, units, tt.wantUnits)
-		}
-		if instances != tt.wantInstances {
-			t.Errorf("getCacheLscpuParts(%q) instances = %v, want %v", tt.input, instances, tt.wantInstances)
-		}
-	}
-}
-func TestGetCacheMBLscpu(t *testing.T) {
-	tests := []struct {
-		name        string
-		lscpuOutput string
-		cacheRegex  string
-		wantMB      float64
-		wantErr     bool
-	}{
-		{
-			name: "L3 cache in MiB, 1 socket",
-			lscpuOutput: `
-Socket(s):             1
-L3 cache:              32 MiB (1 instance)
-`,
-			cacheRegex: `^L3 cache:\s*(.+)$`,
-			wantMB:     32,
-			wantErr:    false,
-		},
-		{
-			name: "L3 cache in MiB, 2 sockets",
-			lscpuOutput: `
-Socket(s):             2
-L3 cache:              64 MiB (2 instances)
-`,
-			cacheRegex: `^L3 cache:\s*(.+)$`,
-			wantMB:     32,
-			wantErr:    false,
-		},
-		{
-			name: "L3 cache in GiB, 2 sockets",
-			lscpuOutput: `
-Socket(s):             2
-L3 cache:              2 GiB (2 instances)
-`,
-			cacheRegex: `^L3 cache:\s*(.+)$`,
-			wantMB:     1024,
-			wantErr:    false,
-		},
-		{
-			name: "L2 cache in KiB, 4 sockets",
-			lscpuOutput: `
-Socket(s):             4
-L2 cache:              1024 KiB (4 instances)
-`,
-			cacheRegex: `^L2 cache:\s*(.+)$`,
-			wantMB:     0.25,
-			wantErr:    false,
-		},
-		{
-			name: "Cache size not found",
-			lscpuOutput: `
-Socket(s):             1
-`,
-			cacheRegex: `^L3 cache:\s*(.+)$`,
-			wantMB:     0,
-			wantErr:    true,
-		},
-		{
-			name: "Socket line missing",
-			lscpuOutput: `
-L3 cache:              32 MiB (1 instance)
-`,
-			cacheRegex: `^L3 cache:\s*(.+)$`,
-			wantMB:     0,
-			wantErr:    true,
-		},
-		{
-			name: "Socket value not a number",
-			lscpuOutput: `
-Socket(s):             notanumber
-L3 cache:              32 MiB (1 instance)
-`,
-			cacheRegex: `^L3 cache:\s*(.+)$`,
-			wantMB:     0,
-			wantErr:    true,
-		},
-		{
-			name: "Unknown units",
-			lscpuOutput: `
-Socket(s):             1
-L3 cache:              32 XYB (1 instance)
-`,
-			cacheRegex: `^L3 cache:\s*(.+)$`,
-			wantMB:     0,
-			wantErr:    true,
-		},
-		{
-			name: "Cache size parse error",
-			lscpuOutput: `
-Socket(s):             1
-L3 cache:              bad format string
-`,
-			cacheRegex: `^L3 cache:\s*(.+)$`,
-			wantMB:     0,
-			wantErr:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotMB, err := getCacheMBLscpu(tt.lscpuOutput, tt.cacheRegex)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("getCacheMBLscpu() expected error, got none")
-				}
-				return
-			}
-			if err != nil {
-				t.Errorf("getCacheMBLscpu() unexpected error: %v", err)
-				return
-			}
-			if gotMB != tt.wantMB {
-				t.Errorf("getCacheMBLscpu() = %v, want %v", gotMB, tt.wantMB)
-			}
-		})
 	}
 }

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -31,6 +31,7 @@ const (
 	DateScriptName                   = "date"
 	DmidecodeScriptName              = "dmidecode"
 	LscpuScriptName                  = "lscpu"
+	LscpuCacheScriptName             = "lscpu cache"
 	LspciBitsScriptName              = "lspci bits"
 	LspciDevicesScriptName           = "lspci devices"
 	LspciVmmScriptName               = "lspci vmm"
@@ -173,6 +174,10 @@ var scriptDefinitions = map[string]ScriptDefinition{
 	LscpuScriptName: {
 		Name:           LscpuScriptName,
 		ScriptTemplate: "lscpu",
+	},
+	LscpuCacheScriptName: {
+		Name:           LscpuCacheScriptName,
+		ScriptTemplate: `lscpu -C -J`,
 	},
 	LspciBitsScriptName: {
 		Name:           LspciBitsScriptName,


### PR DESCRIPTION
This pull request refactors how CPU cache sizes are parsed and reported, improving accuracy and consistency by leveraging the JSON output from the `lscpu -C -J` command. The changes affect both the cache reporting logic and the tables that display cache sizes, ensuring that values are correctly split between per-instance and total sizes, and that L1/L2 cache sizes are extracted more reliably.

**Cache reporting and parsing improvements:**

* Refactored cache size extraction to use the new `lscpuCacheScriptName` output, parsing its JSON to obtain L1d, L1i, L2, and L3 cache sizes, replacing previous regex-based extraction from plain text. [[1]](diffhunk://#diff-45d7f52943fc0d315b8375596890c4d6a6fc8bbcab61ff618a5aaf2cf18e9a6aR7-R105) [[2]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cR1004-R1018) [[3]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL1017-R1040)
* Updated `GetL3LscpuMB` and `GetL3MSRMB` to return both per-instance and total L3 cache sizes, and adjusted functions to format output as "instance/total" for clarity in tables and summaries. [[1]](diffhunk://#diff-45d7f52943fc0d315b8375596890c4d6a6fc8bbcab61ff618a5aaf2cf18e9a6aR7-R105) [[2]](diffhunk://#diff-45d7f52943fc0d315b8375596890c4d6a6fc8bbcab61ff618a5aaf2cf18e9a6aL108-R284) [[3]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL1986-R2005)

**Table and script integration:**

* Added `lscpuCacheScriptName` to the list of required scripts for all relevant table definitions, ensuring cache data is available for reporting. [[1]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cR225) [[2]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cR506) [[3]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cR542) [[4]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cR569)
* Modified the display of cache sizes in tables to use the new parsed values, updating descriptions and field formatting to reflect per-core and instance/total cache sizes. [[1]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cR1004-R1018) [[2]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL1017-R1040) [[3]](diffhunk://#diff-40020381fb8631bc46477e98732857d1990925cdefdd181ce398cfdab4bfff2cL1986-R2005)

**Set LLC size workflow:**

* Updated the LLC size setting logic to use the new cache parsing methods and to require `lscpuCacheScriptName` output, improving robustness when setting cache sizes. [[1]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30R124) [[2]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L143-R149)

These changes make cache size reporting more robust and future-proof by relying on structured data rather than fragile regex parsing, and improve the clarity of cache size presentation in all tables.