### PR TITLE
fix error in kernel utilization percentage metric formula

### DIFF
--- a/cmd/metrics/resources/perfmon/emr/emr_perfspect_metrics.json
+++ b/cmd/metrics/resources/perfmon/emr/emr_perfspect_metrics.json
@@ -9,7 +9,7 @@
       "BriefDescription": "CPU utilization percentage in kernel mode",
       "Events": [
         {
-          "Name": "CPU_CLK_UNHALTED.THREAD_P:SUP",
+          "Name": "CPU_CLK_UNHALTED.REF_TSC_P:SUP",
           "Alias": "a"
         },
         {

--- a/cmd/metrics/resources/perfmon/gnr/gnr_perfspect_metrics.json
+++ b/cmd/metrics/resources/perfmon/gnr/gnr_perfspect_metrics.json
@@ -9,7 +9,7 @@
       "BriefDescription": "CPU utilization percentage in kernel mode",
       "Events": [
         {
-          "Name": "CPU_CLK_UNHALTED.THREAD_P:SUP",
+          "Name": "CPU_CLK_UNHALTED.REF_TSC_P:SUP",
           "Alias": "a"
         },
         {

--- a/cmd/metrics/resources/perfmon/icx/icx_perfspect_metrics.json
+++ b/cmd/metrics/resources/perfmon/icx/icx_perfspect_metrics.json
@@ -9,7 +9,7 @@
       "BriefDescription": "CPU utilization percentage in kernel mode",
       "Events": [
         {
-          "Name": "CPU_CLK_UNHALTED.THREAD_P:SUP",
+          "Name": "CPU_CLK_UNHALTED.REF_TSC_P:SUP",
           "Alias": "a"
         },
         {

--- a/cmd/metrics/resources/perfmon/spr/spr_perfspect_metrics.json
+++ b/cmd/metrics/resources/perfmon/spr/spr_perfspect_metrics.json
@@ -9,7 +9,7 @@
       "BriefDescription": "CPU utilization percentage in kernel mode",
       "Events": [
         {
-          "Name": "CPU_CLK_UNHALTED.THREAD_P:SUP",
+          "Name": "CPU_CLK_UNHALTED.REF_TSC_P:SUP",
           "Alias": "a"
         },
         {

--- a/cmd/metrics/resources/perfmon/srf/srf_perfspect_metrics.json
+++ b/cmd/metrics/resources/perfmon/srf/srf_perfspect_metrics.json
@@ -9,7 +9,7 @@
       "BriefDescription": "CPU utilization percentage in kernel mode",
       "Events": [
         {
-          "Name": "CPU_CLK_UNHALTED.THREAD_P:SUP",
+          "Name": "CPU_CLK_UNHALTED.REF_TSC_P:SUP",
           "Alias": "a"
         },
         {


### PR DESCRIPTION
"CPU utilization % in kernel mode" metric using wrong event in formula resulting in a percentage much higher than actual.