### PR TITLE
make component loader event group formation deterministic for post-processing

### DIFF
--- a/cmd/metrics/loader_component.go
+++ b/cmd/metrics/loader_component.go
@@ -277,7 +277,7 @@ func mergeSmallGroups(groups []GroupDefinition, numGPCounters int) []GroupDefini
 	// Important that this is a deterministic sort
 	slices.SortFunc(groups, func(a, b GroupDefinition) int {
 		if len(a) == 0 || len(b) == 0 {
-			panic("empty group encountered during event group sorting in formEventGroups")
+			panic("empty group encountered during sorting in mergeSmallGroups")
 		}
 		aGPCount := countGPEvents(a)
 		bGPCount := countGPEvents(b)


### PR DESCRIPTION
The event group ordering must be consistent for the metrics post-processing (--input) feature to work.

This pull request refactors the metrics loader component for improved determinism and maintainability. The main changes focus on removing unused filtering logic and ensuring deterministic processing and grouping of metric events.

**Refactoring and code cleanup:**

* Removed the `filterUncollectableMetrics` and `identifyUncollectableEvents` functions, as well as their usage, simplifying the metric loading process by assuming all events are collectable. [[1]](diffhunk://#diff-9deb35ab62b99662ef2f65dcd6157e1c8d2c31abb7294a0064fe413d7088a9d4L29-L32) [[2]](diffhunk://#diff-9deb35ab62b99662ef2f65dcd6157e1c8d2c31abb7294a0064fe413d7088a9d4L201-L224)

**Deterministic processing:**

* Sorted directory entries by name in `loadEventDefinitions` to ensure a consistent and deterministic order when processing event definition files.
* Sorted metric variable names before grouping to guarantee deterministic group formation.
* Updated group sorting logic in `mergeSmallGroups` to be deterministic, including a panic for empty groups and consistent tie-breaking.

**Dependency updates:**

* Added the `io/fs` import to support directory entry sorting.