### PR TITLE
Enhance NIC table field descriptions for better clarity on IRQBalance…

### DIFF
--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -1615,11 +1615,11 @@ func nicTableValues(outputs map[string]script.ScriptOutput) []Field {
 		{Name: "Firmware Version"},
 		{Name: "MAC Address"},
 		{Name: "NUMA Node"},
-		{Name: "IRQBalance"},
-		{Name: "Adaptive RX"},
-		{Name: "Adaptive TX"},
-		{Name: "rx-usecs"},
-		{Name: "tx-usecs"},
+		{Name: "IRQBalance", Description: "System level setting. Dynamically monitors system activity and spreads IRQs across available cores, aiming to balance CPU load, improve throughput, and reduce latency for interrupt-heavy workloads."},
+		{Name: "Adaptive RX", Description: "Enables dynamic adjustment of receive interrupt coalescing based on traffic patterns."},
+		{Name: "Adaptive TX", Description: "Enables dynamic adjustment of transmit interrupt coalescing based on traffic patterns."},
+		{Name: "rx-usecs", Description: "Sets the delay, in microseconds, before an interrupt is generated after receiving a packet. Higher values reduce CPU usage (by batching packets), but increase latency. Lower values reduce latency, but increase interrupt rate and CPU load."},
+		{Name: "tx-usecs", Description: "Sets the delay, in microseconds, before an interrupt is generated after transmitting a packet. Higher values reduce CPU usage (by batching packets), but increase latency. Lower values reduce latency, but increase interrupt rate and CPU load."},
 	}
 	for _, nicInfo := range allNicsInfo {
 		fields[0].Values = append(fields[0].Values, nicInfo.Name)


### PR DESCRIPTION
This pull request enhances the clarity and usability of the NIC table in the report by adding detailed descriptions to several technical fields. These descriptions help users better understand the purpose and impact of each setting, particularly for interrupt handling and coalescing parameters.

**Improvements to NIC table field documentation:**

* Added descriptive `Description` fields to `IRQBalance`, `Adaptive RX`, `Adaptive TX`, `rx-usecs`, and `tx-usecs` in the `nicTableValues` function within `internal/report/table_defs.go`, explaining their roles and effects on system performance and network latency.… and coalescing settings