### PR TITLE
fix frequency bucket assembly

### DIFF
--- a/internal/report/table_helpers.go
+++ b/internal/report/table_helpers.go
@@ -272,6 +272,9 @@ func getSpecFrequencyBuckets(outputs map[string]script.ScriptOutput) ([][]string
 		archMultiplier = 1
 	}
 	for _, count := range bucketCoreCounts {
+		if startRange > count {
+			break
+		}
 		if archMultiplier > 1 {
 			totalCoreCount := count * archMultiplier
 			if totalCoreStartRange > int(totalCoreCount) {


### PR DESCRIPTION
This pull request introduces a small change to the `getSpecFrequencyBuckets` function in `internal/report/table_helpers.go`. The update adds an early exit condition to the loop, improving efficiency by breaking out of the loop when `startRange` exceeds the current bucket core count.