### PR TITLE
fix lscpu parsing for older versions of lscpu

### DIFF
--- a/internal/report/table_helpers_cache_test.go
+++ b/internal/report/table_helpers_cache_test.go
@@ -5,6 +5,9 @@ package report
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseCacheSizeToMB(t *testing.T) {
@@ -40,5 +43,198 @@ func TestParseCacheSizeToMB(t *testing.T) {
 		if !tt.wantErr && got != tt.want {
 			t.Errorf("parseCacheSizeToMB(%q, %q) = %v, want %v", tt.input, tt.fieldName, got, tt.want)
 		}
+	}
+}
+
+func TestParseLscpuCacheOutput(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedError  bool
+		expectedLength int
+		expectedL3     lscpuCacheEntry
+	}{
+		{
+			name: "Modern format with integer fields",
+			input: `{
+   "caches": [
+      {
+         "name": "L1d",
+         "one-size": "48K",
+         "all-size": "6M",
+         "ways": 12,
+         "type": "Data",
+         "level": 1,
+         "sets": 64,
+         "phy-line": 1,
+         "coherency-size": 64
+      },
+      {
+         "name": "L3",
+         "one-size": "320M",
+         "all-size": "640M",
+         "ways": 20,
+         "type": "Unified",
+         "level": 3,
+         "sets": 262144,
+         "phy-line": 1,
+         "coherency-size": 64
+      }
+   ]
+}`,
+			expectedError:  false,
+			expectedLength: 2,
+			expectedL3: lscpuCacheEntry{
+				Name:          "L3",
+				OneSize:       "320M",
+				AllSize:       "640M",
+				Ways:          20,
+				Type:          "Unified",
+				Level:         3,
+				Sets:          262144,
+				PhyLine:       1,
+				CoherencySize: 64,
+			},
+		},
+		{
+			name: "Legacy format with string fields",
+			input: `{
+   "caches": [
+      {
+         "name": "L1d",
+         "one-size": "48K",
+         "all-size": "6M",
+         "ways": "12",
+         "type": "Data",
+         "level": "1",
+         "sets": "64",
+         "phy-line": "1",
+         "coherency-size": "64"
+      },
+      {
+         "name": "L3",
+         "one-size": "320M",
+         "all-size": "640M",
+         "ways": "20",
+         "type": "Unified",
+         "level": "3",
+         "sets": "262144",
+         "phy-line": "1",
+         "coherency-size": "64"
+      }
+   ]
+}`,
+			expectedError:  false,
+			expectedLength: 2,
+			expectedL3: lscpuCacheEntry{
+				Name:          "L3",
+				OneSize:       "320M",
+				AllSize:       "640M",
+				Ways:          20,
+				Type:          "Unified",
+				Level:         3,
+				Sets:          262144,
+				PhyLine:       1,
+				CoherencySize: 64,
+			},
+		},
+		{
+			name: "Legacy format with some empty string fields",
+			input: `{
+   "caches": [
+      {
+         "name": "L3",
+         "one-size": "320M",
+         "all-size": "640M",
+         "ways": "20",
+         "type": "Unified",
+         "level": "3",
+         "sets": "",
+         "phy-line": "",
+         "coherency-size": "64"
+      }
+   ]
+}`,
+			expectedError:  false,
+			expectedLength: 1,
+			expectedL3: lscpuCacheEntry{
+				Name:          "L3",
+				OneSize:       "320M",
+				AllSize:       "640M",
+				Ways:          20,
+				Type:          "Unified",
+				Level:         3,
+				Sets:          0, // empty string converts to 0
+				PhyLine:       0, // empty string converts to 0
+				CoherencySize: 64,
+			},
+		},
+		{
+			name: "Legacy format with invalid number strings",
+			input: `{
+   "caches": [
+      {
+         "name": "L3",
+         "one-size": "320M",
+         "all-size": "640M",
+         "ways": "invalid",
+         "type": "Unified",
+         "level": "3",
+         "sets": "not_a_number",
+         "phy-line": "1",
+         "coherency-size": "64"
+      }
+   ]
+}`,
+			expectedError:  false,
+			expectedLength: 1,
+			expectedL3: lscpuCacheEntry{
+				Name:          "L3",
+				OneSize:       "320M",
+				AllSize:       "640M",
+				Ways:          0, // invalid string converts to 0
+				Type:          "Unified",
+				Level:         3,
+				Sets:          0, // invalid string converts to 0
+				PhyLine:       1,
+				CoherencySize: 64,
+			},
+		},
+		{
+			name:          "Empty input",
+			input:         "",
+			expectedError: true,
+		},
+		{
+			name:          "Invalid JSON",
+			input:         `{"caches": [invalid json}`,
+			expectedError: true,
+		},
+		{
+			name:           "Empty caches array",
+			input:          `{"caches": []}`,
+			expectedError:  false,
+			expectedLength: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := parseLscpuCacheOutput(tt.input)
+
+			if tt.expectedError {
+				require.Error(t, err)
+				assert.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				assert.Len(t, result, tt.expectedLength)
+
+				if tt.expectedLength > 0 && tt.expectedL3.Name != "" {
+					l3Cache, exists := result["L3"]
+					require.True(t, exists, "L3 cache should exist in result")
+					assert.Equal(t, tt.expectedL3, l3Cache)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This pull request improves the robustness of the cache parsing logic for `lscpu` output, ensuring compatibility with both modern and legacy formats where numeric fields may be represented as strings. It also adds comprehensive tests to validate correct parsing across various scenarios.

### Parsing improvements for `lscpu` cache output

* Added support for legacy `lscpu` output formats by introducing a new `lscpuCacheEntryLegacy` struct in `table_helpers_cache.go`, allowing the parser to handle cases where numeric fields are returned as strings.
* Updated the `parseLscpuCacheOutput` function to first attempt parsing with the modern format, and if that fails, to fall back to the legacy format. Legacy string fields are converted to integers, with invalid or empty strings defaulting to zero.

### Testing enhancements

* Added `testify` assertions and requirements to `table_helpers_cache_test.go` for more expressive and reliable test checks.
* Introduced a new `TestParseLscpuCacheOutput` function in `table_helpers_cache_test.go`, covering a wide range of input scenarios including modern and legacy formats, empty fields, invalid number strings, empty input, invalid JSON, and empty caches arrays.