### PR TITLE
refactor lscpu cache parsing to support table output format and update tests

### DIFF
--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -173,7 +173,7 @@ var scriptDefinitions = map[string]ScriptDefinition{
 	},
 	LscpuCacheScriptName: {
 		Name:           LscpuCacheScriptName,
-		ScriptTemplate: `lscpu -C -J`,
+		ScriptTemplate: `lscpu -C`,
 	},
 	LspciBitsScriptName: {
 		Name:               LspciBitsScriptName,


### PR DESCRIPTION
This pull request updates the cache parsing logic in the `internal/report/table_helpers_cache.go` and its associated tests to support the modern tabular output of the `lscpu -C` command, removing support for the older JSON formats. The main changes include refactoring the parser and its test cases, simplifying the cache entry type, and updating the script definition to use the new output format.

**Cache Parsing Refactor:**

* The `parseLscpuCacheOutput` function now parses the tabular/text output from `lscpu -C` instead of the previous JSON output, and all code paths for legacy and modern JSON formats have been removed. (`internal/report/table_helpers_cache.go`)
* The `lscpuCacheEntry` struct has been simplified: all fields are now strings, removing type conversions and legacy support. (`internal/report/table_helpers_cache.go`)

**Test Updates:**

* The test cases in `internal/report/table_helpers_cache_test.go` have been rewritten to use tabular input and to match the new parsing logic, with all legacy JSON-based tests removed. (`internal/report/table_helpers_cache_test.go`) [[1]](diffhunk://#diff-b19e05ab889472b5be44953c9941469e9a4f21e7ccdc6259c847190de0b42dd2L58-R85) [[2]](diffhunk://#diff-b19e05ab889472b5be44953c9941469e9a4f21e7ccdc6259c847190de0b42dd2L209-L231)

**Script Definition Update:**

* The `LscpuCacheScriptName` script definition has been updated to use `lscpu -C` instead of `lscpu -C -J`, aligning with the new parsing logic. (`internal/script/script_defs.go`)

**Minor Cleanup:**

* The unused `encoding/json` import has been removed from `internal/report/table_helpers_cache.go`.