### PR TITLE
fix: handle empty model names in NIC summary output

### DIFF
--- a/internal/report/table_helpers.go
+++ b/internal/report/table_helpers.go
@@ -1754,6 +1754,9 @@ func nicSummaryFromOutput(outputs map[string]script.ScriptOutput) string {
 	}
 	var summary []string
 	for model, count := range modelCount {
+		if model == "" {
+			model = "Unknown NIC"
+		}
 		summary = append(summary, fmt.Sprintf("%dx %s", count, model))
 	}
 	return strings.Join(summary, ", ")


### PR DESCRIPTION
This pull request introduces a small improvement to the NIC summary generation logic in `internal/report/table_helpers.go`. The change ensures that NICs with missing model information are labeled as "Unknown NIC" in the summary output, making the results more readable and informative.

* When generating the NIC summary, empty model names are replaced with "Unknown NIC" to improve clarity in the output.