### PR TITLE
Modify fio benchmark to output JSON and extract IOPs and latency as well

### DIFF
--- a/internal/report/table_defs.go
+++ b/internal/report/table_defs.go
@@ -2363,13 +2363,15 @@ func numaBenchmarkTableValues(outputs map[string]script.ScriptOutput) []Field {
 }
 
 func storageBenchmarkTableValues(outputs map[string]script.ScriptOutput) []Field {
-	readBW, writeBW := storagePerfFromOutput(outputs)
-	if readBW == "" && writeBW == "" {
+	readLat, readBw, writeLat, writeBw := storagePerfFromOutput(outputs)
+	if readLat == "" && readBw == "" && writeLat == "" && writeBw == "" {
 		return []Field{}
 	}
 	return []Field{
-		{Name: "Single-Thread Read Bandwidth", Values: []string{readBW}},
-		{Name: "Single-Thread Write Bandwidth", Values: []string{writeBW}},
+		{Name: "Single-Thread Read Latency (ns)", Values: []string{readLat}},
+		{Name: "Single-Thread Read Bandwidth (MiB/s)", Values: []string{readBw}},
+		{Name: "Single-Thread Write Latency (ns)", Values: []string{writeLat}},
+		{Name: "Single-Thread Write Bandwidth (MiB/s)", Values: []string{writeBw}},
 	}
 }
 

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -1176,7 +1176,8 @@ fio --name=bandwidth --directory=$test_dir --numjobs=$numjobs \
 --size="$file_size_g"G --time_based --runtime=$runtime --ramp_time=$ramp_time --ioengine=$ioengine \
 --direct=1 --verify=0 --bs=1M --iodepth=1 --rw=rw \
 --group_reporting=1 --iodepth_batch_submit=64 \
---iodepth_batch_complete_max=64
+--iodepth_batch_complete_max=64 \
+--output-format=json
 rm -rf $test_dir
 `,
 		Superuser:  true,


### PR DESCRIPTION
Modify fio benchmark to output JSON and extract IOPs and latency as well
Modifies fio benchmark to use iodepth=1 to supresss warnings since a synchronous engine is used

Forward looking would want to look into using libaio and benchmark at a few queue depths