### PR TITLE
fix: ignore metrics that use ref-cycles when ref-cycles not supported

### DIFF
--- a/cmd/metrics/loader_perfmon_event_core.go
+++ b/cmd/metrics/loader_perfmon_event_core.go
@@ -120,7 +120,7 @@ func (event CoreEvent) IsCollectable(metadata Metadata) bool {
 			return false // Off-core response events are not supported in process or cgroup scope
 		}
 	}
-	if !metadata.SupportsRefCycles && strings.Contains(event.EventName, "ref-cycles") {
+	if !metadata.SupportsRefCycles && strings.Contains(event.EventName, "CPU_CLK_UNHALTED.REF_TSC") { // AKA ref-cycles
 		slog.Debug("Ref-cycles events not supported", slog.String("event", event.EventName))
 		return false // ref-cycles events are not supported
 	}


### PR DESCRIPTION
This pull request updates the logic for detecting "ref-cycles" events in the `IsCollectable` function to improve accuracy and maintainability.

Event detection logic update:

* Changed the check for unsupported "ref-cycles" events to specifically look for `"CPU_CLK_UNHALTED.REF_TSC"` in the event name, rather than the more generic `"ref-cycles"`, making the detection more precise and aligned with actual event naming conventions.