### PR TITLE
clean up tools' build dockerfile

### DIFF
--- a/tools/build.Dockerfile
+++ b/tools/build.Dockerfile
@@ -53,17 +53,6 @@ RUN success=false; \
     done; \
     $success || (echo "Failed to install build tools after 5 attempts" && exit 1)
 
-# install java
-# RUN success=false; \
-#     for i in {1..5}; do \
-#         apt-get install -y \
-#         default-jre default-jdk \
-#         && success=true && break; \
-#         echo "Retrying in 5 seconds... ($i/5)" && sleep 5; \
-#     done; \
-#     $success || (echo "Failed to install java after 5 attempts" && exit
-# ENV JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64
-
 # need golang to build go tools like ethtool
 RUN rm -rf /usr/local/go && wget -qO- https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH="${PATH}:/usr/local/go/bin"


### PR DESCRIPTION
This pull request refactors and improves the `tools/build.Dockerfile` to make the build process more robust and reliable, particularly by adding retry logic to package installations and repository additions. It also reorganizes some steps for clarity and maintainability, and comments out Java installation for now.

Key improvements and changes:

**Robustness and Reliability:**
* Added retry logic (up to 5 attempts) for all critical `apt-get install` and `add-apt-repository` commands to handle transient network or package server issues, with clear error messages if failures persist. [[1]](diffhunk://#diff-7a79ceb0a7c431c3b02c1c07a0068b79db9183d3bfa1c40b766013322860fa0bL19-R85) [[2]](diffhunk://#diff-7a79ceb0a7c431c3b02c1c07a0068b79db9183d3bfa1c40b766013322860fa0bL66-R130) [[3]](diffhunk://#diff-7a79ceb0a7c431c3b02c1c07a0068b79db9183d3bfa1c40b766013322860fa0bL85-R142)

**Build Process Organization:**
* Separated installation of minimum packages (for adding repositories), build tools, and perf/processwatch dependencies into distinct, clearly commented sections. [[1]](diffhunk://#diff-7a79ceb0a7c431c3b02c1c07a0068b79db9183d3bfa1c40b766013322860fa0bL19-R85) [[2]](diffhunk://#diff-7a79ceb0a7c431c3b02c1c07a0068b79db9183d3bfa1c40b766013322860fa0bL66-R130)
* Moved and clarified the addition of the Git PPA and subsequent update to ensure the latest Git version is used. [[1]](diffhunk://#diff-7a79ceb0a7c431c3b02c1c07a0068b79db9183d3bfa1c40b766013322860fa0bL19-R85) [[2]](diffhunk://#diff-7a79ceb0a7c431c3b02c1c07a0068b79db9183d3bfa1c40b766013322860fa0bL66-R130)

**Other Notable Changes:**
* Commented out Java installation steps, likely to avoid unnecessary dependencies or issues in the current build context.
* Ensured static zlib build is correctly copied to the expected directory for both x86_64 and aarch64 targets.
* Added explicit section for building perf and processwatch tools, improving clarity for future maintainers.