### PR TITLE
fix: pad core frequencies to length of frequency buckets

### DIFF
--- a/internal/report/table_helpers.go
+++ b/internal/report/table_helpers.go
@@ -357,6 +357,9 @@ func getSpecFrequencyBuckets(outputs map[string]script.ScriptOutput) ([][]string
 			if isaFreqs[0] == "0.0" {
 				continue
 			} else {
+				if i >= len(isaFreqs) {
+					return nil, fmt.Errorf("index out of range for isa frequencies")
+				}
 				row = append(row, isaFreqs[i])
 			}
 		}


### PR DESCRIPTION
Address issue where number of frequencies read from MSR does not match the number of frequency buckets read from MSR.