### PR TITLE
fix: CHAs per socket value for metric formulas

### DIFF
--- a/cmd/metrics/loader_util.go
+++ b/cmd/metrics/loader_util.go
@@ -166,7 +166,7 @@ func replaceConstants(metrics []MetricDefinition, metadata Metadata) ([]MetricDe
 		return nil, fmt.Errorf("unknown granularity: %s", flagGranularity)
 	}
 	coresPerSocket := fmt.Sprintf("%f", float64(metadata.CoresPerSocket))
-	chasPerSocket := fmt.Sprintf("%f", float64(len(metadata.UncoreDeviceIDs["cha"])))
+	chasPerSocket := fmt.Sprintf("%f", float64(len(metadata.UncoreDeviceIDs["cha"]))/float64(metadata.SocketCount))
 	socketCount := fmt.Sprintf("%f", float64(metadata.SocketCount))
 	hyperThreadingOn := fmt.Sprintf("%t", metadata.ThreadsPerCore > 1)
 	threadsPerCore := fmt.Sprintf("%f", float64(metadata.ThreadsPerCore))


### PR DESCRIPTION
This pull request makes a small but important correction to how the number of CHAs per socket is calculated in the `replaceConstants` function. Instead of using the total number of CHAs, it now divides by the socket count to get an accurate per-socket value.

- Corrected the calculation of `chasPerSocket` in `replaceConstants` to divide the total number of CHAs by the number of sockets, ensuring the value represents CHAs per socket rather than the total.