### PR TITLE
fix: exclude final metric sample when running with workload

### DIFF
--- a/cmd/metrics/metadata.go
+++ b/cmd/metrics/metadata.go
@@ -72,6 +72,7 @@ type Metadata struct {
 	// below are not loaded by LoadMetadata, but are set by the caller (should these be here at all?)
 	CollectionStartTime time.Time
 	PerfSpectVersion    string
+	WithWorkload        bool // true if metrics were collected with a user-provided workload application
 }
 
 // LoadMetadata - populates and returns a Metadata structure containing state of the

--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -1320,6 +1320,7 @@ func collectOnTarget(targetContext *targetContext, localTempDir string, localOut
 	printCompleteChannel := make(chan []string)
 	// get current time for use in setting timestamps on output
 	targetContext.metadata.CollectionStartTime = time.Now() // save the start time in the metadata for use when using the --input option to process raw data
+	targetContext.metadata.WithWorkload = len(argsApplication) > 0
 	go printMetricsAsync(targetContext, localOutputDir, frameChannel, printCompleteChannel)
 	var err error
 	for !signalMgr.shouldStop() {

--- a/cmd/metrics/summary_test.go
+++ b/cmd/metrics/summary_test.go
@@ -1,0 +1,143 @@
+package metrics
+
+// Copyright (C) 2021-2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExcludeFinalSample(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputRows     []row
+		expectedCount int
+		expectedMaxTS float64
+	}{
+		{
+			name: "exclude single final timestamp",
+			inputRows: []row{
+				{timestamp: 5.0, metrics: map[string]float64{"metric1": 100.0}},
+				{timestamp: 10.0, metrics: map[string]float64{"metric1": 200.0}},
+				{timestamp: 15.0, metrics: map[string]float64{"metric1": 150.0}},
+				{timestamp: 20.0, metrics: map[string]float64{"metric1": 50.0}}, // this should be excluded
+			},
+			expectedCount: 3,
+			expectedMaxTS: 15.0,
+		},
+		{
+			name: "exclude multiple rows with same final timestamp",
+			inputRows: []row{
+				{timestamp: 5.0, socket: "0", metrics: map[string]float64{"metric1": 100.0}},
+				{timestamp: 10.0, socket: "0", metrics: map[string]float64{"metric1": 200.0}},
+				{timestamp: 15.0, socket: "0", metrics: map[string]float64{"metric1": 150.0}},
+				{timestamp: 15.0, socket: "1", metrics: map[string]float64{"metric1": 160.0}}, // same timestamp, different socket
+			},
+			expectedCount: 2,
+			expectedMaxTS: 10.0,
+		},
+		{
+			name: "single sample - should not exclude",
+			inputRows: []row{
+				{timestamp: 5.0, metrics: map[string]float64{"metric1": 100.0}},
+			},
+			expectedCount: 1,
+			expectedMaxTS: 5.0,
+		},
+		{
+			name: "two samples - exclude last one",
+			inputRows: []row{
+				{timestamp: 5.0, metrics: map[string]float64{"metric1": 100.0}},
+				{timestamp: 10.0, metrics: map[string]float64{"metric1": 50.0}},
+			},
+			expectedCount: 1,
+			expectedMaxTS: 5.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a MetricCollection with a single MetricGroup
+			mc := MetricCollection{
+				MetricGroup{
+					names:        []string{"metric1"},
+					rows:         tt.inputRows,
+					groupByField: "",
+					groupByValue: "",
+				},
+			}
+
+			// Call excludeFinalSample
+			mc.excludeFinalSample()
+
+			// Verify the number of remaining rows
+			assert.Equal(t, tt.expectedCount, len(mc[0].rows), "unexpected number of rows after exclusion")
+
+			// Verify that no row has a timestamp greater than expectedMaxTS
+			if len(mc[0].rows) > 0 {
+				for _, row := range mc[0].rows {
+					assert.LessOrEqual(t, row.timestamp, tt.expectedMaxTS, "found row with timestamp greater than expected maximum")
+				}
+			}
+		})
+	}
+}
+
+func TestExcludeFinalSampleMultipleGroups(t *testing.T) {
+	// Test with multiple metric groups (e.g., multiple sockets)
+	mc := MetricCollection{
+		MetricGroup{
+			names:        []string{"metric1"},
+			groupByField: "SKT",
+			groupByValue: "0",
+			rows: []row{
+				{timestamp: 5.0, socket: "0", metrics: map[string]float64{"metric1": 100.0}},
+				{timestamp: 10.0, socket: "0", metrics: map[string]float64{"metric1": 200.0}},
+				{timestamp: 15.0, socket: "0", metrics: map[string]float64{"metric1": 50.0}}, // should be excluded
+			},
+		},
+		MetricGroup{
+			names:        []string{"metric1"},
+			groupByField: "SKT",
+			groupByValue: "1",
+			rows: []row{
+				{timestamp: 5.0, socket: "1", metrics: map[string]float64{"metric1": 110.0}},
+				{timestamp: 10.0, socket: "1", metrics: map[string]float64{"metric1": 210.0}},
+				{timestamp: 15.0, socket: "1", metrics: map[string]float64{"metric1": 60.0}}, // should be excluded
+			},
+		},
+	}
+
+	mc.excludeFinalSample()
+
+	// Both groups should have 2 rows remaining
+	assert.Equal(t, 2, len(mc[0].rows), "socket 0 should have 2 rows")
+	assert.Equal(t, 2, len(mc[1].rows), "socket 1 should have 2 rows")
+
+	// Verify max timestamps
+	assert.Equal(t, 10.0, mc[0].rows[1].timestamp, "socket 0 max timestamp should be 10.0")
+	assert.Equal(t, 10.0, mc[1].rows[1].timestamp, "socket 1 max timestamp should be 10.0")
+}
+
+func TestExcludeFinalSampleEmptyCollection(t *testing.T) {
+	// Test with empty MetricCollection
+	mc := MetricCollection{}
+	mc.excludeFinalSample() // should not panic
+	assert.Equal(t, 0, len(mc), "empty collection should remain empty")
+}
+
+func TestExcludeFinalSampleEmptyRows(t *testing.T) {
+	// Test with MetricGroup that has no rows
+	mc := MetricCollection{
+		MetricGroup{
+			names:        []string{"metric1"},
+			groupByField: "",
+			groupByValue: "",
+			rows:         []row{},
+		},
+	}
+	mc.excludeFinalSample() // should not panic
+	assert.Equal(t, 0, len(mc[0].rows), "empty rows should remain empty")
+}


### PR DESCRIPTION
## Summary

Fixes #569 - Prevents skewed mean metric values when collecting metrics for workloads.

When collecting metrics with a workload (e.g., `perfspect metrics -- stress-ng --cpu 0 --cpu-load 60 --timeout 30`), the final sample may be collected after or during workload completion. This captures the system transitioning from loaded to idle state. With short collections (e.g., 30 seconds = 6 samples), this single anomalous sample can significantly skew summary statistics.

## Changes

- **Added `WithWorkload` field to `Metadata` struct** - Tracks whether metrics were collected with a user-provided workload application
- **Set workload context** - `WithWorkload = true` when workload arguments are provided via `--`
- **Implemented `excludeFinalSample()` method** - Removes final timestamp's rows from all metric groups before computing summary statistics
- **Optimized logging** - Checks first group only and logs once per collection to avoid log spam with many sockets/CPUs
- **Added comprehensive tests** - Unit tests cover various scenarios including single samples, multiple groups, and edge cases

## Solution Approach

The implementation excludes the final timestamp's samples from summary statistics when `metadata.WithWorkload` is true. The full CSV with all samples is still preserved for users who want to perform advanced analysis.

## Testing

- ✅ All new unit tests pass
- ✅ All existing tests pass
- ✅ `make check` passes (format, vet, staticcheck, lint, vulnerabilities, tests)

## Test plan

1. Run `perfspect metrics -- stress-ng --cpu 0 --cpu-load 60 --timeout 30`
2. Verify summary statistics exclude final sample and are not skewed by post-workload data
3. Verify full CSV still contains all samples
4. Test with various workloads and collection durations