### PR TITLE
Add support for Altra microarchitecture in loader and metadata functions

### DIFF
--- a/cmd/metrics/loader.go
+++ b/cmd/metrics/loader.go
@@ -88,7 +88,7 @@ func NewLoader(uarch string) (Loader, error) {
 	case cpus.UarchGNR, cpus.UarchGNR_X1, cpus.UarchGNR_X2, cpus.UarchGNR_X3, cpus.UarchGNR_D, cpus.UarchSRF, cpus.UarchSRF_SP, cpus.UarchSRF_AP, cpus.UarchEMR, cpus.UarchEMR_MCC, cpus.UarchEMR_XCC, cpus.UarchSPR, cpus.UarchSPR_MCC, cpus.UarchSPR_XCC, cpus.UarchICX:
 		slog.Debug("Using perfmon loader for microarchitecture", slog.String("uarch", uarch))
 		return newPerfmonLoader(), nil
-	case cpus.UarchGraviton2, cpus.UarchGraviton3, cpus.UarchGraviton4, cpus.UarchAxion, cpus.UarchAmpereOneAC03, cpus.UarchAmpereOneAC04, cpus.UarchAmpereOneAC04_1:
+	case cpus.UarchGraviton2, cpus.UarchGraviton3, cpus.UarchGraviton4, cpus.UarchAxion, cpus.UarchAltraFamily, cpus.UarchAmpereOneAC03, cpus.UarchAmpereOneAC04, cpus.UarchAmpereOneAC04_1:
 		slog.Debug("Using component loader for microarchitecture", slog.String("uarch", uarch))
 		return newComponentLoader(), nil
 	default:

--- a/cmd/metrics/loader_component.go
+++ b/cmd/metrics/loader_component.go
@@ -505,6 +505,8 @@ func getUarchDir(uarch string) (string, error) {
 		return "ampereone", nil
 	case cpus.UarchAmpereOneAC04, cpus.UarchAmpereOneAC04_1:
 		return "ampereonex", nil
+	case cpus.UarchAltraFamily:
+		return "neoverse-n1", nil
 	}
 	return "", fmt.Errorf("unsupported component loader architecture: %s", uarch)
 }

--- a/cmd/metrics/metadata.go
+++ b/cmd/metrics/metadata.go
@@ -906,6 +906,8 @@ func getARMSlotsByArchitecture(uarch string) (slots int, err error) {
 		slots = 6
 	case cpus.UarchAmpereOneAC04, cpus.UarchAmpereOneAC04_1:
 		slots = 10
+	case cpus.UarchAltraFamily:
+		slots = 6
 	default:
 		err = fmt.Errorf("unsupported ARM uarch: %s", uarch)
 		return

--- a/internal/cpus/cpus.go
+++ b/internal/cpus/cpus.go
@@ -206,14 +206,14 @@ var cpuIdentifiersARM = []struct {
 	Identifier        CPUIdentifierARM
 	MicroArchitecture string
 }{
-	{CPUIdentifierARM{Implementer: "0x41", Part: "0xd0c", DmidecodePart: "AWS Graviton2"}, UarchGraviton2}, // AWS Graviton 2 ([m|c|r]6g) Neoverse-N1
-	{CPUIdentifierARM{Implementer: "0x41", Part: "0xd40", DmidecodePart: "AWS Graviton3"}, UarchGraviton3}, // AWS Graviton 3 ([m|c|r]7g) Neoverse-V1
-	{CPUIdentifierARM{Implementer: "0x41", Part: "0xd4f", DmidecodePart: "AWS Graviton4"}, UarchGraviton4}, // AWS Graviton 4 ([m|c|r]8g) Neoverse-V2
-	{CPUIdentifierARM{Implementer: "0x41", Part: "0xd4f", DmidecodePart: "Not Specified"}, UarchAxion},     // GCP Axion (c4a) Neoverse-V2
-	{CPUIdentifierARM{Implementer: "0x41", Part: "0xd0c", DmidecodePart: ""}, UarchAltraFamily},            // Ampere Altra
-	{CPUIdentifierARM{Implementer: "0xc0", Part: "0xac3", DmidecodePart: ""}, UarchAmpereOneAC03},          // AmpereOne AC03
-	{CPUIdentifierARM{Implementer: "0xc0", Part: "0xac4", DmidecodePart: "X"}, UarchAmpereOneAC04},         // AmpereOne AC04
-	{CPUIdentifierARM{Implementer: "0xc0", Part: "0xac4", DmidecodePart: "M"}, UarchAmpereOneAC04_1},       // AmpereOne AC04_1
+	{CPUIdentifierARM{Implementer: "0x41", Part: "0xd0c", DmidecodePart: "AWS Graviton2"}, UarchGraviton2},   // AWS Graviton 2 ([m|c|r]6g) Neoverse-N1
+	{CPUIdentifierARM{Implementer: "0x41", Part: "0xd40", DmidecodePart: "AWS Graviton3"}, UarchGraviton3},   // AWS Graviton 3 ([m|c|r]7g) Neoverse-V1
+	{CPUIdentifierARM{Implementer: "0x41", Part: "0xd4f", DmidecodePart: "AWS Graviton4"}, UarchGraviton4},   // AWS Graviton 4 ([m|c|r]8g) Neoverse-V2
+	{CPUIdentifierARM{Implementer: "0x41", Part: "0xd4f", DmidecodePart: "Not Specified"}, UarchAxion},       // GCP Axion (c4a) Neoverse-V2
+	{CPUIdentifierARM{Implementer: "0x41", Part: "0xd0c", DmidecodePart: "Not Specified"}, UarchAltraFamily}, // Ampere Altra
+	{CPUIdentifierARM{Implementer: "0xc0", Part: "0xac3", DmidecodePart: ""}, UarchAmpereOneAC03},            // AmpereOne AC03
+	{CPUIdentifierARM{Implementer: "0xc0", Part: "0xac4", DmidecodePart: "X"}, UarchAmpereOneAC04},           // AmpereOne AC04
+	{CPUIdentifierARM{Implementer: "0xc0", Part: "0xac4", DmidecodePart: "M"}, UarchAmpereOneAC04_1},         // AmpereOne AC04_1
 }
 
 // NewCPUIdentifier creates a CPUIdentifier with all data elements

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -1013,6 +1013,7 @@ echo $__DEFAULT_HL_DEVICE
 		ScriptTemplate: "dmidecode -t processor | grep -m 1 \"Part Number\" | awk -F': ' '{print $2}'",
 		Architectures:  []string{cpus.ARMArchitecture},
 		Superuser:      true,
+		Depends:        []string{"dmidecode"},
 	},
 	MemoryBenchmarkScriptName: {
 		Name: MemoryBenchmarkScriptName,


### PR DESCRIPTION
This pull request extends support for the Ampere Altra family of ARM CPUs across the codebase, ensuring correct identification and handling of this architecture in loader selection, directory mapping, slot calculation, and script dependencies.

**Ampere Altra family support:**

* Updated the loader selection logic in `loader.go` to include `UarchAltraFamily` in the component loader case, enabling proper loader assignment for Ampere Altra CPUs.
* Mapped `UarchAltraFamily` to the `neoverse-n1` directory in `loader_component.go` for correct component directory resolution.
* Set the slot count for `UarchAltraFamily` CPUs to 6 in `metadata.go`, ensuring accurate resource calculation.
* Refined the CPU identifier for Ampere Altra in `cpus.go` to match `DmidecodePart: "Not Specified"` for more precise detection.

**Script improvements:**

* Added `dmidecode` as an explicit dependency for the CPU part number script in `script_defs.go`, ensuring required tools are present for script execution.