### PR TITLE
fix benchmark summary by removing mismatched storage benchmark fields

### DIFF
--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -425,8 +425,6 @@ func benchmarkSummaryFromTableValues(allTableValues []table.TableValues, outputs
 			{Name: "Minimum Power", Values: []string{getValueFromTableValues(getTableValues(allTableValues, PowerBenchmarkTableName), "Minimum Power", 0)}},
 			{Name: "Memory Peak Bandwidth", Values: []string{maxMemBW}},
 			{Name: "Memory Minimum Latency", Values: []string{minLatency}},
-			{Name: "Disk Read Bandwidth", Values: []string{getValueFromTableValues(getTableValues(allTableValues, StorageBenchmarkTableName), "Single-Thread Read Bandwidth", 0)}},
-			{Name: "Disk Write Bandwidth", Values: []string{getValueFromTableValues(getTableValues(allTableValues, StorageBenchmarkTableName), "Single-Thread Write Bandwidth", 0)}},
 			{Name: "Microarchitecture", Values: []string{getValueFromTableValues(getTableValues(allTableValues, SystemSummaryTableName), "Microarchitecture", 0)}},
 			{Name: "Sockets", Values: []string{getValueFromTableValues(getTableValues(allTableValues, SystemSummaryTableName), "Sockets", 0)}},
 		},


### PR DESCRIPTION
This pull request makes a targeted change to the benchmark summary generation by removing disk read and write bandwidth metrics from the summary table.

Metrics update:

* Removed "Disk Read Bandwidth" and "Disk Write Bandwidth" from the summary values in the `benchmarkSummaryFromTableValues` function in `cmd/report/report.go`.