### PR TITLE
Single source for maximum frequency

### DIFF
--- a/cmd/report/report_tables.go
+++ b/cmd/report/report_tables.go
@@ -143,7 +143,6 @@ var tableDefinitions = map[string]table.TableDefinition{
 			script.LspciDevicesScriptName,
 			script.CpuidScriptName,
 			script.BaseFrequencyScriptName,
-			script.MaximumFrequencyScriptName,
 			script.SpecCoreFrequenciesScriptName,
 			script.PPINName,
 			script.L3CacheWayEnabledName,

--- a/internal/common/frequency.go
+++ b/internal/common/frequency.go
@@ -271,21 +271,8 @@ func ExpandTurboFrequencies(specFrequencyBuckets [][]string, isa string) ([]stri
 	return freqs, nil
 }
 
-// MaxFrequencyFromOutput gets max core frequency
-//
-//	1st option) /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq
-//	2nd option) from MSR/tpmi
-//	3rd option) from dmidecode "Max Speed"
+// MaxFrequencyFromOutput gets max core frequency from MSR/TPMI
 func MaxFrequencyFromOutput(outputs map[string]script.ScriptOutput) string {
-	cmdout := strings.TrimSpace(outputs[script.MaximumFrequencyScriptName].Stdout)
-	if cmdout != "" {
-		freqf, err := strconv.ParseFloat(cmdout, 64)
-		if err == nil {
-			freqf = freqf / 1000000
-			return fmt.Sprintf("%.1fGHz", freqf)
-		}
-	}
-	// get the max frequency from the MSR/tpmi
 	specCoreFrequencies, err := GetSpecFrequencyBuckets(outputs)
 	if err == nil {
 		sseFreqs := GetSSEFreqsFromBuckets(specCoreFrequencies)
@@ -294,7 +281,7 @@ func MaxFrequencyFromOutput(outputs map[string]script.ScriptOutput) string {
 			return sseFreqs[0] + "GHz"
 		}
 	}
-	return ValFromDmiDecodeRegexSubmatch(outputs[script.DmidecodeScriptName].Stdout, "4", `Max Speed:\s(.*)`)
+	return ""
 }
 
 func GetSSEFreqsFromBuckets(buckets [][]string) []string {

--- a/internal/common/table_defs.go
+++ b/internal/common/table_defs.go
@@ -23,7 +23,6 @@ var TableDefinitions = map[string]table.TableDefinition{
 			script.LscpuCacheScriptName,
 			script.LspciBitsScriptName,
 			script.LspciDevicesScriptName,
-			script.MaximumFrequencyScriptName,
 			script.SpecCoreFrequenciesScriptName,
 			script.MeminfoScriptName,
 			script.NicInfoScriptName,

--- a/internal/script/script_defs.go
+++ b/internal/script/script_defs.go
@@ -49,7 +49,6 @@ const (
 	OpensslVersionScriptName         = "openssl version"
 	CpuidScriptName                  = "cpuid"
 	BaseFrequencyScriptName          = "base frequency"
-	MaximumFrequencyScriptName       = "maximum frequency"
 	ScalingDriverScriptName          = "scaling driver"
 	ScalingGovernorScriptName        = "scaling governor"
 	CstatesScriptName                = "c-states"
@@ -256,10 +255,6 @@ var scriptDefinitions = map[string]ScriptDefinition{
 	BaseFrequencyScriptName: {
 		Name:           BaseFrequencyScriptName,
 		ScriptTemplate: "cat /sys/devices/system/cpu/cpu0/cpufreq/base_frequency",
-	},
-	MaximumFrequencyScriptName: {
-		Name:           MaximumFrequencyScriptName,
-		ScriptTemplate: "cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq",
 	},
 	ScalingDriverScriptName: {
 		Name:           ScalingDriverScriptName,


### PR DESCRIPTION
This pull request removes all references to the `maximum frequency` script from the codebase, simplifying the way maximum core frequency is determined and reported. The logic for retrieving the maximum frequency now relies solely on MSR/TPMI data, and the fallback to other sources such as `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq` or dmidecode has been eliminated.

Key changes include:

**Removal of `maximum frequency` script:**

* Deleted the `MaximumFrequencyScriptName` constant and its associated script definition from `internal/script/script_defs.go`. [[1]](diffhunk://#diff-eb14347ecb8d0457d616ea7458b375fa88206bb53ac21fa59c48106c1c975536L52) [[2]](diffhunk://#diff-eb14347ecb8d0457d616ea7458b375fa88206bb53ac21fa59c48106c1c975536L260-L263)
* Removed `script.MaximumFrequencyScriptName` from the list of scripts in `cmd/report/report_tables.go` and `internal/common/table_defs.go`. [[1]](diffhunk://#diff-f062097d9bc5deea35469f97e738fd4f7842285c74bdef2685288ffe3b6ddbc8L146) [[2]](diffhunk://#diff-23f73eef7330924c62da67ac6da38ab46df56bd2cb814f0c61ba423776a87b5bL26)

**Refactoring of maximum frequency retrieval logic:**

* Updated the `MaxFrequencyFromOutput` function in `internal/common/frequency.go` to remove logic that used `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq` and dmidecode as sources for the maximum frequency, now relying only on MSR/TPMI data. [[1]](diffhunk://#diff-66d1618813005c4e5f54109ecc8a3291d198988828a895624ca0026946053b9dL274-L288) [[2]](diffhunk://#diff-66d1618813005c4e5f54109ecc8a3291d198988828a895624ca0026946053b9dL297-R284)