### PR TITLE
more descriptive representation of installed memory in summary table

### DIFF
--- a/cmd/report/system.go
+++ b/cmd/report/system.go
@@ -65,7 +65,7 @@ func systemSummaryFromOutput(outputs map[string]script.ScriptOutput) string {
 		turboOnOff = "?"
 	}
 	// memory
-	installedMem = installedMemoryFromOutput(outputs)
+	installedMem = common.InstalledMemoryFromOutput(outputs)
 	// BIOS
 	biosVersion = common.ValFromRegexSubmatch(outputs[script.DmidecodeScriptName].Stdout, `^Version:\s*(.+?)$`)
 	// microcode

--- a/internal/common/table_defs.go
+++ b/internal/common/table_defs.go
@@ -38,11 +38,16 @@ var TableDefinitions = map[string]table.TableDefinition{
 			script.ArmImplementerScriptName,
 			script.ArmPartScriptName,
 			script.ArmDmidecodePartScriptName,
+			script.DmidecodeScriptName,
 		},
 		FieldsFunc: briefSummaryTableValues},
 }
 
 func briefSummaryTableValues(outputs map[string]script.ScriptOutput) []table.Field {
+	memory := InstalledMemoryFromOutput(outputs) // Dmidecode, try this first
+	if memory == "" {
+		memory = ValFromRegexSubmatch(outputs[script.MeminfoScriptName].Stdout, `^MemTotal:\s*(.+?)$`) // Meminfo as fallback
+	}
 	return []table.Field{
 		{Name: "Host Name", Values: []string{strings.TrimSpace(outputs[script.HostnameScriptName].Stdout)}},                                                                                   // Hostname
 		{Name: "Time", Values: []string{strings.TrimSpace(outputs[script.DateScriptName].Stdout)}},                                                                                            // Date
@@ -61,7 +66,7 @@ func briefSummaryTableValues(outputs map[string]script.ScriptOutput) []table.Fie
 		{Name: "All-core Maximum Frequency", Values: []string{AllCoreMaxFrequencyFromOutput(outputs)}, Description: "The highest speed all cores can reach simultaneously with Turbo Boost."}, // Lscpu, LspciBits, LspciDevices, SpecCoreFrequencies
 		{Name: "Energy Performance Bias", Values: []string{EPBFromOutput(outputs)}},                                                                                                           // EpbSource, EpbBIOS, EpbOS
 		{Name: "Efficiency Latency Control", Values: []string{ELCSummaryFromOutput(outputs)}},                                                                                                 // Elc
-		{Name: "MemTotal", Values: []string{ValFromRegexSubmatch(outputs[script.MeminfoScriptName].Stdout, `^MemTotal:\s*(.+?)$`)}},                                                           // Meminfo
+		{Name: "Memory", Values: []string{memory}},                                                                                                                                            // Dmidecode,Meminfo
 		{Name: "NIC", Values: []string{NICSummaryFromOutput(outputs)}},                                                                                                                        // Lshw, NicInfo
 		{Name: "Disk", Values: []string{DiskSummaryFromOutput(outputs)}},                                                                                                                      // DiskInfo, Hdparm
 		{Name: "OS", Values: []string{OperatingSystemFromOutput(outputs)}},                                                                                                                    // EtcRelease


### PR DESCRIPTION
This pull request refactors how DIMM (memory module) information is handled and accessed throughout the codebase. The main change is moving the DIMM index constants and related helper functions from `cmd/report/dimm.go` to the `internal/common` package, making them reusable and centralizing DIMM parsing logic. All code that previously used local DIMM helpers and constants now references the shared versions in `internal/common`. This improves maintainability and reduces code duplication.

Key changes include:

**Improvements to Summary Table Logic:**
- Enhanced the brief summary table in `internal/common/table_defs.go` to prefer DIMM information from DMI decode, falling back to `/proc/meminfo` only if necessary, and updated the field name to "Memory" for clarity. [[1]](diffhunk://#diff-23f73eef7330924c62da67ac6da38ab46df56bd2cb814f0c61ba423776a87b5bR41-R50) [[2]](diffhunk://#diff-23f73eef7330924c62da67ac6da38ab46df56bd2cb814f0c61ba423776a87b5bL64-R69)

**Refactoring and Code Reuse:**
- Moved DIMM index constants (e.g., `BankLocatorIdx`, `SizeIdx`, etc.) and DIMM helper functions (`DimmInfoFromDmiDecode`, `InstalledMemoryFromOutput`) from `cmd/report/dimm.go` to `internal/common/table_helpers.go` for shared use across the codebase. [[1]](diffhunk://#diff-43cb64b530bf3f023d95cae45ad8facf59e87a4b7a34a9b1b76fac1ef27dc46aL16-R25) [[2]](diffhunk://#diff-f911cde0ba04d79b4bceb7f8a2be787de64e9fd103a75735a9067f98be552686R292-R360)

**Code Updates to Use Shared Helpers:**
- Updated all references in `cmd/report/dimm.go` to use `common.DimmInfoFromDmiDecode` and `common.<IndexConstant>` instead of local definitions. [[1]](diffhunk://#diff-43cb64b530bf3f023d95cae45ad8facf59e87a4b7a34a9b1b76fac1ef27dc46aL112-R43) [[2]](diffhunk://#diff-43cb64b530bf3f023d95cae45ad8facf59e87a4b7a34a9b1b76fac1ef27dc46aL162-R97) [[3]](diffhunk://#diff-43cb64b530bf3f023d95cae45ad8facf59e87a4b7a34a9b1b76fac1ef27dc46aL226-R158) [[4]](diffhunk://#diff-43cb64b530bf3f023d95cae45ad8facf59e87a4b7a34a9b1b76fac1ef27dc46aL247-R179) [[5]](diffhunk://#diff-43cb64b530bf3f023d95cae45ad8facf59e87a4b7a34a9b1b76fac1ef27dc46aL274-R211) [[6]](diffhunk://#diff-43cb64b530bf3f023d95cae45ad8facf59e87a4b7a34a9b1b76fac1ef27dc46aL628-R570)
- Updated summary and table rendering logic in `cmd/report/report_tables.go` and `cmd/report/system.go` to use `common.InstalledMemoryFromOutput` and `common.<IndexConstant>`. [[1]](diffhunk://#diff-f062097d9bc5deea35469f97e738fd4f7842285c74bdef2685288ffe3b6ddbc8L997-R997) [[2]](diffhunk://#diff-f062097d9bc5deea35469f97e738fd4f7842285c74bdef2685288ffe3b6ddbc8L1673-R1673) [[3]](diffhunk://#diff-f062097d9bc5deea35469f97e738fd4f7842285c74bdef2685288ffe3b6ddbc8L1694-R1744) [[4]](diffhunk://#diff-4cf26e05d1d6183f231ff419f0e8dfd056f12c0ef909bec5a779c53486565e24L68-R68)

These changes centralize DIMM parsing logic, reduce duplication, and ensure consistency across different parts of the codebase when handling memory module information.