### PR TITLE
fix: config command script LKM and binary dependencies

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -172,8 +172,8 @@ func setLlcSize(desiredLlcSize float64, myTarget target.Target, localTempDir str
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0xC90 %d", msrVal),
 		Superuser:      true,
 		Vendors:        []string{cpus.IntelVendor},
-		// Depends:        []string{"wrmsr"},
-		// Lkms:           []string{"msr"},
+		Depends:        []string{"wrmsr"},
+		Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -222,8 +222,8 @@ func setSSEFrequency(sseFrequency float64, myTarget target.Target, localTempDir 
 				ScriptTemplate: fmt.Sprintf("wrmsr 0x774 %d", value),
 				Superuser:      true,
 				Vendors:        []string{cpus.IntelVendor},
-				// Depends:        []string{"wrmsr"},
-				// Lkms:           []string{"msr"},
+				Depends:        []string{"wrmsr"},
+				Lkms:           []string{"msr"},
 			}
 		} else {
 			value := freqInt << uint(2*8)
@@ -232,8 +232,8 @@ func setSSEFrequency(sseFrequency float64, myTarget target.Target, localTempDir 
 				ScriptTemplate: fmt.Sprintf("wrmsr 0x199 %d", value),
 				Superuser:      true,
 				Vendors:        []string{cpus.IntelVendor},
-				// Depends:        []string{"wrmsr"},
-				// Lkms:           []string{"msr"},
+				Depends:        []string{"wrmsr"},
+				Lkms:           []string{"msr"},
 			}
 		}
 	} else {
@@ -247,8 +247,8 @@ func setSSEFrequency(sseFrequency float64, myTarget target.Target, localTempDir 
 			ScriptTemplate: fmt.Sprintf("wrmsr -a 0x1AD %d", value),
 			Superuser:      true,
 			Vendors:        []string{cpus.IntelVendor},
-			// Depends:        []string{"wrmsr"},
-			// Lkms:           []string{"msr"},
+			Depends:        []string{"wrmsr"},
+			Lkms:           []string{"msr"},
 		}
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
@@ -440,6 +440,8 @@ func setSSEFrequencies(sseFrequencies string, myTarget target.Target, localTempD
 				ScriptTemplate: fmt.Sprintf("wrmsr 0x774 %d", value),
 				Superuser:      true,
 				Vendors:        []string{cpus.IntelVendor},
+				Depends:        []string{"wrmsr"},
+				Lkms:           []string{"msr"},
 			}
 		} else {
 			// For non-intel_pstate driver
@@ -450,6 +452,8 @@ func setSSEFrequencies(sseFrequencies string, myTarget target.Target, localTempD
 				ScriptTemplate: fmt.Sprintf("wrmsr 0x199 %d", value),
 				Superuser:      true,
 				Vendors:        []string{cpus.IntelVendor},
+				Depends:        []string{"wrmsr"},
+				Lkms:           []string{"msr"},
 			}
 		}
 	} else {
@@ -464,6 +468,8 @@ func setSSEFrequencies(sseFrequencies string, myTarget target.Target, localTempD
 			ScriptTemplate: fmt.Sprintf("wrmsr -a 0x1AD %d", value),
 			Superuser:      true,
 			Vendors:        []string{cpus.IntelVendor},
+			Depends:        []string{"wrmsr"},
+			Lkms:           []string{"msr"},
 		}
 	}
 
@@ -546,8 +552,8 @@ func setUncoreFrequency(maxFreq bool, uncoreFrequency float64, myTarget target.T
 		Vendors:            []string{cpus.IntelVendor},
 		MicroArchitectures: []string{cpus.UarchGNR, cpus.UarchGNR_D, cpus.UarchSRF, cpus.UarchCWF},
 		Superuser:          true,
-		// Depends:        []string{"rdmsr"},
-		// Lkms:           []string{"msr"},
+		Depends:            []string{"rdmsr"},
+		Lkms:               []string{"msr"},
 	}
 	scriptOutput, err := workflow.RunScript(myTarget, getScript, localTempDir, false)
 	if err != nil {
@@ -576,8 +582,8 @@ func setUncoreFrequency(maxFreq bool, uncoreFrequency float64, myTarget target.T
 		Superuser:          true,
 		Vendors:            []string{cpus.IntelVendor},
 		MicroArchitectures: []string{cpus.UarchGNR, cpus.UarchGNR_D, cpus.UarchSRF, cpus.UarchCWF},
-		// Depends:        []string{"wrmsr"},
-		// Lkms:           []string{"msr"},
+		Depends:            []string{"wrmsr"},
+		Lkms:               []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -592,8 +598,8 @@ func setTDP(power int, myTarget target.Target, localTempDir string) error {
 		ScriptTemplate: "rdmsr 0x610",
 		Superuser:      true,
 		Vendors:        []string{cpus.IntelVendor},
-		// Lkms:           []string{"msr"},
-		// Depends:        []string{"rdmsr"},
+		Lkms:           []string{"msr"},
+		Depends:        []string{"rdmsr"},
 	}
 	readOutput, err := workflow.RunScript(myTarget, readScript, localTempDir, false)
 	if err != nil {
@@ -613,8 +619,8 @@ func setTDP(power int, myTarget target.Target, localTempDir string) error {
 				ScriptTemplate: fmt.Sprintf("wrmsr -a 0x610 %d", newVal),
 				Superuser:      true,
 				Vendors:        []string{cpus.IntelVendor},
-				// Depends:        []string{"wrmsr"},
-				// Lkms:           []string{"msr"},
+				Depends:        []string{"wrmsr"},
+				Lkms:           []string{"msr"},
 			}
 			_, err := runScript(myTarget, setScript, localTempDir)
 			if err != nil {
@@ -650,8 +656,8 @@ func setEPB(epb int, myTarget target.Target, localTempDir string) error {
 		ScriptTemplate: "rdmsr " + msr,
 		Vendors:        []string{cpus.IntelVendor},
 		Superuser:      true,
-		// Lkms:           []string{"msr"},
-		// Depends:        []string{"rdmsr"},
+		Lkms:           []string{"msr"},
+		Depends:        []string{"rdmsr"},
 	}
 	readOutput, err := runScript(myTarget, readScript, localTempDir)
 	if err != nil {
@@ -671,8 +677,8 @@ func setEPB(epb int, myTarget target.Target, localTempDir string) error {
 		ScriptTemplate: fmt.Sprintf("wrmsr -a %s %d", msr, msrValue),
 		Superuser:      true,
 		Vendors:        []string{cpus.IntelVendor},
-		// Depends:        []string{"wrmsr"},
-		// Lkms:           []string{"msr"},
+		Depends:        []string{"wrmsr"},
+		Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -691,8 +697,8 @@ func setEPP(epp int, myTarget target.Target, localTempDir string) error {
 		ScriptTemplate: "rdmsr 0x774", // IA32_HWP_REQUEST
 		Vendors:        []string{cpus.IntelVendor},
 		Superuser:      true,
-		// Lkms:           []string{"msr"},
-		// Depends:        []string{"rdmsr"},
+		Lkms:           []string{"msr"},
+		Depends:        []string{"rdmsr"},
 	}
 	stdout, err := runScript(myTarget, getScript, localTempDir)
 	if err != nil {
@@ -712,8 +718,8 @@ func setEPP(epp int, myTarget target.Target, localTempDir string) error {
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0x774 %d", eppValue),
 		Superuser:      true,
 		Vendors:        []string{cpus.IntelVendor},
-		// Depends:        []string{"wrmsr"},
-		// Lkms:           []string{"msr"},
+		Depends:        []string{"wrmsr"},
+		Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -725,8 +731,8 @@ func setEPP(epp int, myTarget target.Target, localTempDir string) error {
 		ScriptTemplate: "rdmsr 0x772", // IA32_HWP_REQUEST_PKG
 		Vendors:        []string{cpus.IntelVendor},
 		Superuser:      true,
-		// Lkms:           []string{"msr"},
-		// Depends:        []string{"rdmsr"},
+		Lkms:           []string{"msr"},
+		Depends:        []string{"rdmsr"},
 	}
 	stdout, err = runScript(myTarget, getScript, localTempDir)
 	if err != nil {
@@ -746,8 +752,8 @@ func setEPP(epp int, myTarget target.Target, localTempDir string) error {
 		ScriptTemplate: fmt.Sprintf("wrmsr -a 0x772 %d", eppValue),
 		Superuser:      true,
 		Vendors:        []string{cpus.IntelVendor},
-		// Depends:        []string{"wrmsr"},
-		// Lkms:           []string{"msr"},
+		Depends:        []string{"wrmsr"},
+		Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -829,8 +835,8 @@ func setPrefetcher(enableDisable string, myTarget target.Target, localTempDir st
 		ScriptTemplate: fmt.Sprintf("rdmsr %d", pf.Msr),
 		Vendors:        []string{cpus.IntelVendor},
 		Superuser:      true,
-		// Lkms:           []string{"msr"},
-		// Depends:        []string{"rdmsr"},
+		Lkms:           []string{"msr"},
+		Depends:        []string{"rdmsr"},
 	}
 	stdout, err := runScript(myTarget, getScript, localTempDir)
 	if err != nil {
@@ -860,8 +866,8 @@ func setPrefetcher(enableDisable string, myTarget target.Target, localTempDir st
 		ScriptTemplate: fmt.Sprintf("wrmsr -a %d %d", pf.Msr, newVal),
 		Superuser:      true,
 		Vendors:        []string{cpus.IntelVendor},
-		// Depends:        []string{"wrmsr"},
-		// Lkms:           []string{"msr"},
+		Depends:        []string{"wrmsr"},
+		Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {
@@ -929,8 +935,8 @@ func setC1Demotion(enableDisable string, myTarget target.Target, localTempDir st
 		ScriptTemplate: "rdmsr 0xe2",
 		Vendors:        []string{cpus.IntelVendor},
 		Superuser:      true,
-		// Lkms:           []string{"msr"},
-		// Depends:        []string{"rdmsr"},
+		Lkms:           []string{"msr"},
+		Depends:        []string{"rdmsr"},
 	}
 	stdout, err := runScript(myTarget, getScript, localTempDir)
 	if err != nil {
@@ -961,8 +967,8 @@ func setC1Demotion(enableDisable string, myTarget target.Target, localTempDir st
 		ScriptTemplate: fmt.Sprintf("wrmsr -a %d %d", 0xe2, newVal),
 		Vendors:        []string{cpus.IntelVendor},
 		Superuser:      true,
-		// Depends:        []string{"wrmsr"},
-		// Lkms:           []string{"msr"},
+		Depends:        []string{"wrmsr"},
+		Lkms:           []string{"msr"},
 	}
 	_, err = runScript(myTarget, setScript, localTempDir)
 	if err != nil {


### PR DESCRIPTION
This pull request refactors how MSR-related dependencies are handled in the configuration scripts for Intel CPUs. The main change is the removal of the global target preparation step, which previously ensured the `msr` kernel module was loaded before running configuration scripts. Instead, each individual configuration script now explicitly declares its dependency on the `msr` kernel module and the required utilities (`wrmsr`, `rdmsr`). This improves modularity and ensures that dependencies are managed at the script level, making the codebase clearer and reducing unnecessary global setup.

**Dependency handling improvements:**

* Removed the global `prepareTarget` function and its invocation from `cmd/config/config.go`, so targets are no longer prepped for MSR access in advance. [[1]](diffhunk://#diff-c6dc0c872cdd5407c8299f5b807a80a79ddf78e91e86c3c618508ca84c048d68L14) [[2]](diffhunk://#diff-c6dc0c872cdd5407c8299f5b807a80a79ddf78e91e86c3c618508ca84c048d68L223-L248)
* Updated all relevant script definitions in `cmd/config/set.go` to explicitly include `Depends: ["wrmsr"]` and/or `Depends: ["rdmsr"]`, and `Lkms: ["msr"]` where required, ensuring each script declares its own dependencies. [[1]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L175-R176) [[2]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L225-R226) [[3]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L235-R236) [[4]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L250-R251) [[5]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30R443-R444) [[6]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30R455-R456) [[7]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30R471-R472) [[8]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L549-R556) [[9]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L579-R586) [[10]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L595-R602) [[11]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L616-R623) [[12]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L653-R660) [[13]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L674-R681) [[14]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L694-R701) [[15]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L715-R722) [[16]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L728-R735) [[17]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L749-R756) [[18]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L832-R839) [[19]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L863-R870) [[20]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L932-R939) [[21]](diffhunk://#diff-6a5c7bcd026f8b5e33543c4bfc4c3144238df14ae0aeed563151472ae1739e30L964-R971)

These changes make the configuration process more robust and maintainable by localizing dependency management to each script.