### PR TITLE
feature: add Energy Performance Preference to system summary table

### DIFF
--- a/cmd/report/report_tables.go
+++ b/cmd/report/report_tables.go
@@ -1682,6 +1682,7 @@ func systemSummaryTableValues(outputs map[string]script.ScriptOutput) []table.Fi
 		{Name: "Kernel", Values: []string{extract.ValFromRegexSubmatch(outputs[script.UnameScriptName].Stdout, `^Linux \S+ (\S+)`)}},
 		{Name: "TDP", Values: []string{extract.TDPFromOutput(outputs)}},
 		{Name: "Energy Performance Bias", Values: []string{extract.EPBFromOutput(outputs)}},
+		{Name: "Energy Performance Preference", Values: []string{extract.EPPFromOutput(outputs)}},
 		{Name: "Scaling Governor", Values: []string{strings.TrimSpace(outputs[script.ScalingGovernorScriptName].Stdout)}},
 		{Name: "Scaling Driver", Values: []string{strings.TrimSpace(outputs[script.ScalingDriverScriptName].Stdout)}},
 		{Name: "C-states", Values: []string{extract.CstatesSummaryFromOutput(outputs)}},


### PR DESCRIPTION
This pull request adds a new entry to the system summary table in the `report_tables.go` file. Specifically, it now includes the "Energy Performance Preference" value, which is extracted from the script outputs.

System summary table enhancement:

* Added "Energy Performance Preference" to the list of reported system summary values in the `systemSummaryTableValues` function, using the `extract.EPPFromOutput` helper to obtain the value.