### PR TITLE
feature: event and metric file override

### DIFF
--- a/cmd/metrics/loader.go
+++ b/cmd/metrics/loader.go
@@ -57,7 +57,6 @@ type LoaderConfig struct {
 	// Override configurations
 	MetricDefinitionOverride string // For direct metric file override (legacy loader)
 	EventDefinitionOverride  string // For direct event file override  (legacy loader)
-	ConfigFileOverride       string // For config file that points to multiple files (perfmon loader)
 }
 type Loader interface {
 	Load(config LoaderConfig) (metrics []MetricDefinition, groups []GroupDefinition, err error)
@@ -80,7 +79,12 @@ type ComponentLoader struct {
 
 // NewLoader creates the right type of Loader for each CPU microarchitecture
 // Input is the CPU microarchitecture name as defined in the cpus module.
-func NewLoader(uarch string) (Loader, error) {
+// If useLegacyLoader is true, the legacy loader will be used regardless of microarchitecture.
+func NewLoader(uarch string, useLegacyLoader bool) (Loader, error) {
+	if useLegacyLoader {
+		slog.Debug("Using legacy loader due to override", slog.String("uarch", uarch))
+		return newLegacyLoader(), nil
+	}
 	switch uarch {
 	case cpus.UarchCLX, cpus.UarchSKX, cpus.UarchBDX, cpus.UarchBergamo, cpus.UarchGenoa, cpus.UarchTurinZen5, cpus.UarchTurinZen5c:
 		slog.Debug("Using legacy loader for microarchitecture", slog.String("uarch", uarch))

--- a/cmd/metrics/loader_perfmon.go
+++ b/cmd/metrics/loader_perfmon.go
@@ -189,22 +189,12 @@ func uarchToResourceName(uarch string) string {
 }
 
 func (l *PerfmonLoader) loadMetricsConfig(loaderConfig LoaderConfig) (MetricsConfig, error) {
-	var config MetricsConfig
-	var bytes []byte
-	if loaderConfig.ConfigFileOverride != "" {
-		var err error
-		bytes, err = os.ReadFile(loaderConfig.ConfigFileOverride)
-		if err != nil {
-			return MetricsConfig{}, fmt.Errorf("error reading metric config override file: %w", err)
-		}
-	} else {
-		var err error
-		resourceName := uarchToResourceName(loaderConfig.Metadata.Microarchitecture)
-		bytes, err = resources.ReadFile(filepath.Join("resources", "perfmon", resourceName, resourceName+".json"))
-		if err != nil {
-			return MetricsConfig{}, fmt.Errorf("error reading metrics config file: %w", err)
-		}
+	resourceName := uarchToResourceName(loaderConfig.Metadata.Microarchitecture)
+	bytes, err := resources.ReadFile(filepath.Join("resources", "perfmon", resourceName, resourceName+".json"))
+	if err != nil {
+		return MetricsConfig{}, fmt.Errorf("error reading metrics config file: %w", err)
 	}
+	var config MetricsConfig
 	if err := json.Unmarshal(bytes, &config); err != nil {
 		return MetricsConfig{}, fmt.Errorf("error unmarshaling metrics config JSON: %w", err)
 	}

--- a/cmd/metrics/trim.go
+++ b/cmd/metrics/trim.go
@@ -288,7 +288,7 @@ func getTrimmedSourceInfos(sourceDirOrFilename string) ([]trimSourceInfo, error)
 }
 
 func loadMetricDefinitions(metadata Metadata) ([]MetricDefinition, error) {
-	loader, err := NewLoader(metadata.Microarchitecture)
+	loader, err := NewLoader(metadata.Microarchitecture, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric definition loader: %w", err)
 	}


### PR DESCRIPTION
Re-enables event and metric file override using the --eventfile and --metricfile flags for architectures that use the perfmon and component loaders. If one file is specified, the other must be too. When these files are specified, the legacy loader will be used.

It is no longer possible to override perfmon loader JSON files.

The metrics trim command will not work if data was initially collected using the override files.

This pull request refactors how metric and event definition overrides are handled, clarifies flag requirements, and simplifies loader logic. The changes ensure that metric and event override files must be specified together, remove unused override paths from non-legacy loaders, and streamline loader configuration. 


The most important changes are grouped below:

**Loader and Override Handling Improvements:**

* The `NewLoader` function now accepts a `useLegacyLoader` boolean to explicitly select the legacy loader when both metric and event override files are provided, ensuring consistent override behavior. [[1]](diffhunk://#diff-aa0d00fb4223d9da0dc406c13ac62edaf94151405df0e34072a990b93123047aL83-R87) [[2]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L805-R801) [[3]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L1245-R1241) [[4]](diffhunk://#diff-54b18a23d6ee80926583b053c9122c74dbd191f249cddb15dbdd27c1c55c4e32L291-R291)
* The `ConfigFileOverride` field was removed from `LoaderConfig`, and only the legacy loader now supports metric and event file overrides; component and perfmon loaders no longer process these overrides. [[1]](diffhunk://#diff-aa0d00fb4223d9da0dc406c13ac62edaf94151405df0e34072a990b93123047aL60) [[2]](diffhunk://#diff-e5c1ab44b42f37049af8dbf5085ead70acdbf1c39959896d752635c86a800286L784-L793) [[3]](diffhunk://#diff-9deb35ab62b99662ef2f65dcd6157e1c8d2c31abb7294a0064fe413d7088a9d4L23-R22) [[4]](diffhunk://#diff-9deb35ab62b99662ef2f65dcd6157e1c8d2c31abb7294a0064fe413d7088a9d4L62-R76) [[5]](diffhunk://#diff-2722694c28060fc2ae0e3658161aa0ceed3aae8bdb46e3bc24a2505daecca860L192-R197)

**Flag Validation and Documentation:**

* Validation was added to require both `--metricfile` and `--eventfile` flags to be specified together, preventing misconfiguration.
* Help text for the `--metricfile` and `--eventfile` flags was updated to clarify that they must be used together.

**Code Cleanup:**

* Unused imports (such as `os`) were removed from `loader_component.go` to clean up dependencies.