### PR TITLE
fix: input flag required for metrics trim command

### DIFF
--- a/cmd/metrics/trim.go
+++ b/cmd/metrics/trim.go
@@ -63,8 +63,6 @@ func init() {
 	trimCmd.Flags().IntVar(&flagTrimStartOffset, flagTrimStartOffsetName, 0, "seconds to skip from the beginning of the data")
 	trimCmd.Flags().IntVar(&flagTrimEndOffset, flagTrimEndOffsetName, 0, "seconds to exclude from the end of the data")
 
-	_ = trimCmd.MarkFlagRequired(flagTrimInputName) // error only occurs if flag doesn't exist
-
 	// Set custom usage function to avoid parent's usage function issues
 	trimCmd.SetUsageFunc(func(cmd *cobra.Command) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "Usage:\n  %s\n\n", cmd.UseLine())
@@ -83,6 +81,11 @@ func init() {
 
 // validateTrimFlags checks that the trim command flags are valid and consistent
 func validateTrimFlags(cmd *cobra.Command, args []string) error {
+	// Check that input flag was provided (required flag check)
+	if flagTrimInput == "" {
+		return workflow.FlagValidationError(cmd, "required flag \"--input\" not set")
+	}
+
 	// Check input file or directory exists
 	if _, err := os.Stat(flagTrimInput); err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
This pull request updates the required flag validation for the `trim` command in `cmd/metrics/trim.go`. Instead of relying on Cobra's `MarkFlagRequired`, the code now explicitly checks if the `--input` flag was provided and returns a custom error if not.

**Flag validation improvements:**

* Removed the use of `trimCmd.MarkFlagRequired` for the `--input` flag, eliminating reliance on Cobra's built-in required flag mechanism.
* Added an explicit check in `validateTrimFlags` to ensure that the `--input` flag is provided, returning a custom error message if it is missing.