### PR TITLE
feature: add extract command to extract embedded tool binaries

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -208,6 +208,31 @@ func GeoMean(vals []float64) (val float64) {
 	return
 }
 
+// ExtractAllResources recurcively extracts all resources as files into the specified directory.
+func ExtractAllResources(resources embed.FS, dir string) error {
+	// walk the embedded filesystem starting at "resources"
+	return fs.WalkDir(resources, "resources", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel("resources", path)
+		if err != nil {
+			return err
+		}
+		relPath = filepath.Join(dir, relPath)
+		if d.IsDir() {
+			if relPath == "." {
+				return nil
+			}
+			// create directory
+			return os.MkdirAll(relPath, 0700)
+		}
+		// extract file
+		_, err = ExtractResource(resources, path, filepath.Dir(relPath))
+		return err
+	})
+}
+
 // ExtractResource extracts a resource from the given embed.FS and saves it to the specified temporary directory.
 // It returns the path to the saved resource file and any error encountered during the process.
 func ExtractResource(resources embed.FS, resourcePath string, tempDir string) (string, error) {


### PR DESCRIPTION
This pull request introduces a new developer-facing CLI command to extract embedded script resources, and adds supporting utility code to handle resource extraction from the embedded filesystem. The changes are organized into two main themes: CLI enhancements and utility function additions.

**CLI Enhancements:**

* Added a new `extract` command to the CLI (`extractCmd` in `cmd/root.go`). This command allows developers to extract all embedded script resources to a specified output directory for inspection or modification. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR118) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR494-R516)
* Registered the new command under the "Other Commands" group and imported the necessary `internal/script` package.

**Utility Function Additions:**

* Implemented `ExtractAllResources` in `internal/util/util.go`, which recursively walks the embedded filesystem and extracts all resources as files into the specified directory, supporting the new `extract` command.