### PR TITLE
feature: add command name to all_hosts report file name

### DIFF
--- a/internal/workflow/reports.go
+++ b/internal/workflow/reports.go
@@ -147,7 +147,11 @@ func (rc *ReportingCommand) createReports(appContext app.Context, orderedTargetS
 				err = fmt.Errorf("failed to create multi-target %s report: %w", format, err)
 				return nil, err
 			}
-			reportFilename := fmt.Sprintf("%s.%s", "all_hosts", format)
+			post := ""
+			if rc.ReportNamePost != "" {
+				post = "_" + rc.ReportNamePost
+			}
+			reportFilename := fmt.Sprintf("%s.%s", "all_hosts"+post, format)
 			reportPath := filepath.Join(appContext.OutputDir, reportFilename)
 			if err = writeReport(reportBytes, reportPath); err != nil {
 				err = fmt.Errorf("failed to write multi-target %s report: %w", format, err)


### PR DESCRIPTION
This pull request introduces a small but useful enhancement to the report generation logic. Now, if a `ReportNamePost` suffix is provided, it will be appended to the multi-target report filename, making it easier to distinguish between different report variants.

* Appended `ReportNamePost` as a suffix to the `all_hosts` multi-target report filename if provided, improving report file identification (`internal/workflow/reports.go`).