### PR TITLE
change: default output format to HTML for flamegraph and telemetry commands

### DIFF
--- a/cmd/flamegraph/flamegraph.go
+++ b/cmd/flamegraph/flamegraph.go
@@ -63,7 +63,7 @@ const (
 
 func init() {
 	Cmd.Flags().StringVar(&app.FlagInput, app.FlagInputName, "", "")
-	Cmd.Flags().StringSliceVar(&app.FlagFormat, app.FlagFormatName, []string{report.FormatAll}, "")
+	Cmd.Flags().StringSliceVar(&app.FlagFormat, app.FlagFormatName, []string{report.FormatHtml}, "")
 	Cmd.Flags().IntVar(&flagDuration, flagDurationName, 0, "")
 	Cmd.Flags().IntVar(&flagFrequency, flagFrequencyName, 11, "")
 	Cmd.Flags().IntSliceVar(&flagPids, flagPidsName, nil, "")

--- a/cmd/telemetry/telemetry.go
+++ b/cmd/telemetry/telemetry.go
@@ -128,7 +128,7 @@ func init() {
 	}
 	Cmd.Flags().StringVar(&app.FlagInput, app.FlagInputName, "", "")
 	Cmd.Flags().BoolVar(&flagAll, flagAllName, true, "")
-	Cmd.Flags().StringSliceVar(&app.FlagFormat, app.FlagFormatName, []string{report.FormatAll}, "")
+	Cmd.Flags().StringSliceVar(&app.FlagFormat, app.FlagFormatName, []string{report.FormatHtml}, "")
 	Cmd.Flags().IntVar(&flagDuration, flagDurationName, 0, "")
 	Cmd.Flags().IntVar(&flagInterval, flagIntervalName, 2, "")
 	Cmd.Flags().IntVar(&flagInstrMixPid, flagInstrMixPidName, 0, "")


### PR DESCRIPTION
This pull request updates the default output format for two command-line tools, changing it from generating all report formats to generating only HTML reports by default. This helps streamline the output and likely improves usability for most users.

**Flag default value updates:**

* Changed the default value of the `--format` flag from `all` to `html` in `cmd/flamegraph/flamegraph.go` so that only HTML reports are generated by default.
* Changed the default value of the `--format` flag from `all` to `html` in `cmd/telemetry/telemetry.go` for the same reason.