### PR TITLE
refactor: eliminate global flag variables for input and format

### DIFF
--- a/cmd/benchmark/benchmark.go
+++ b/cmd/benchmark/benchmark.go
@@ -50,7 +50,9 @@ var Cmd = &cobra.Command{
 
 // flag vars
 var (
-	flagAll bool
+	flagInput  string
+	flagFormat []string
+	flagAll    bool
 
 	flagSpeed       bool
 	flagPower       bool
@@ -100,9 +102,9 @@ func init() {
 		Cmd.Flags().BoolVar(benchmark.FlagVar, benchmark.FlagName, benchmark.DefaultValue, benchmark.Help)
 	}
 	// set up other flags
-	Cmd.Flags().StringVar(&app.FlagInput, app.FlagInputName, "", "")
+	Cmd.Flags().StringVar(&flagInput, app.FlagInputName, "", "")
 	Cmd.Flags().BoolVar(&flagAll, flagAllName, true, "")
-	Cmd.Flags().StringSliceVar(&app.FlagFormat, app.FlagFormatName, []string{report.FormatAll}, "")
+	Cmd.Flags().StringSliceVar(&flagFormat, app.FlagFormatName, []string{report.FormatAll}, "")
 	Cmd.Flags().BoolVar(&flagNoSystemSummary, flagNoSystemSummaryName, false, "")
 	Cmd.Flags().StringVar(&flagStorageDir, flagStorageDirName, "/tmp", "")
 
@@ -197,7 +199,7 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 		}
 	}
 	// validate format options
-	for _, format := range app.FlagFormat {
+	for _, format := range flagFormat {
 		formatOptions := append([]string{report.FormatAll}, report.FormatOptions...)
 		if !slices.Contains(formatOptions, format) {
 			return workflow.FlagValidationError(cmd, fmt.Sprintf("format options are: %s", strings.Join(formatOptions, ", ")))
@@ -251,6 +253,8 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		SummaryTableName:       benchmarkSummaryTableName,
 		SummaryBeforeTableName: SpeedBenchmarkTableName,
 		InsightsFunc:           nil,
+		Input:                  flagInput,
+		Formats:                flagFormat,
 	}
 
 	report.RegisterHTMLRenderer(FrequencyBenchmarkTableName, frequencyBenchmarkTableHtmlRenderer)

--- a/cmd/lock/lock.go
+++ b/cmd/lock/lock.go
@@ -44,6 +44,7 @@ var Cmd = &cobra.Command{
 }
 
 var (
+	flagInput           string
 	flagDuration        int
 	flagFrequency       int
 	flagPackage         bool
@@ -59,7 +60,7 @@ const (
 )
 
 func init() {
-	Cmd.Flags().StringVar(&app.FlagInput, app.FlagInputName, "", "")
+	Cmd.Flags().StringVar(&flagInput, app.FlagInputName, "", "")
 	Cmd.Flags().StringSliceVar(&flagFormat, app.FlagFormatName, []string{report.FormatAll}, "")
 	Cmd.Flags().IntVar(&flagDuration, flagDurationName, 10, "")
 	Cmd.Flags().IntVar(&flagFrequency, flagFrequencyName, 11, "")
@@ -208,19 +209,15 @@ func runCmd(cmd *cobra.Command, args []string) error {
 			"Duration":  strconv.Itoa(flagDuration),
 			"Package":   strconv.FormatBool(flagPackage),
 		},
-		Tables: tables,
+		Tables:  tables,
+		Input:   flagInput,
+		Formats: formalizeOutputFormat(flagFormat),
 	}
 
 	// only try to download package when option specified
 	if flagPackage {
 		reportingCommand.AdhocFunc = pullDataFiles
 	}
-
-	// The app.FlagFormat designed to hold the output formats, but as a global variable,
-	// it would be overwrite by other command's initialization function. So the current
-	// workaround is to make an assignment to ensure the current command's output format
-	// flag takes effect as expected.
-	app.FlagFormat = formalizeOutputFormat(flagFormat)
 
 	report.RegisterHTMLRenderer(KernelLockAnalysisTableName, kernelLockAnalysisHTMLRenderer)
 

--- a/cmd/report/report.go
+++ b/cmd/report/report.go
@@ -40,7 +40,9 @@ var Cmd = &cobra.Command{
 
 // flag vars
 var (
-	flagAll bool
+	flagInput  string
+	flagFormat []string
+	flagAll    bool
 	// categories
 	flagSystemSummary  bool
 	flagHost           bool
@@ -156,9 +158,9 @@ func init() {
 		Cmd.Flags().BoolVar(cat.FlagVar, cat.FlagName, cat.DefaultValue, cat.Help)
 	}
 	// set up other flags
-	Cmd.Flags().StringVar(&app.FlagInput, app.FlagInputName, "", "")
+	Cmd.Flags().StringVar(&flagInput, app.FlagInputName, "", "")
 	Cmd.Flags().BoolVar(&flagAll, flagAllName, true, "")
-	Cmd.Flags().StringSliceVar(&app.FlagFormat, app.FlagFormatName, []string{report.FormatAll}, "")
+	Cmd.Flags().StringSliceVar(&flagFormat, app.FlagFormatName, []string{report.FormatAll}, "")
 
 	workflow.AddTargetFlags(Cmd)
 
@@ -243,7 +245,7 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 		}
 	}
 	// validate format options
-	for _, format := range app.FlagFormat {
+	for _, format := range flagFormat {
 		formatOptions := append([]string{report.FormatAll}, report.FormatOptions...)
 		if !slices.Contains(formatOptions, format) {
 			return workflow.FlagValidationError(cmd, fmt.Sprintf("format options are: %s", strings.Join(formatOptions, ", ")))
@@ -274,6 +276,8 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		Tables:                 tables,
 		InsightsFunc:           insightsFunc,
 		SystemSummaryTableName: SystemSummaryTableName,
+		Input:                  flagInput,
+		Formats:                flagFormat,
 	}
 
 	report.RegisterHTMLRenderer(DIMMTableName, dimmTableHTMLRenderer)

--- a/cmd/telemetry/telemetry.go
+++ b/cmd/telemetry/telemetry.go
@@ -47,6 +47,8 @@ var Cmd = &cobra.Command{
 }
 
 var (
+	flagInput    string
+	flagFormat   []string
 	flagDuration int
 	flagInterval int
 
@@ -125,9 +127,9 @@ func init() {
 	for _, cat := range categories {
 		Cmd.Flags().BoolVar(cat.FlagVar, cat.FlagName, cat.DefaultValue, cat.Help)
 	}
-	Cmd.Flags().StringVar(&app.FlagInput, app.FlagInputName, "", "")
+	Cmd.Flags().StringVar(&flagInput, app.FlagInputName, "", "")
 	Cmd.Flags().BoolVar(&flagAll, flagAllName, true, "")
-	Cmd.Flags().StringSliceVar(&app.FlagFormat, app.FlagFormatName, []string{report.FormatHtml}, "")
+	Cmd.Flags().StringSliceVar(&flagFormat, app.FlagFormatName, []string{report.FormatHtml}, "")
 	Cmd.Flags().IntVar(&flagDuration, flagDurationName, 0, "")
 	Cmd.Flags().IntVar(&flagInterval, flagIntervalName, 2, "")
 	Cmd.Flags().IntVar(&flagInstrMixPid, flagInstrMixPidName, 0, "")
@@ -237,7 +239,7 @@ func validateFlags(cmd *cobra.Command, args []string) error {
 		}
 	}
 	// validate format options
-	for _, format := range app.FlagFormat {
+	for _, format := range flagFormat {
 		formatOptions := []string{report.FormatAll}
 		formatOptions = append(formatOptions, report.FormatOptions...)
 		if !slices.Contains(formatOptions, format) {
@@ -327,6 +329,8 @@ func runCmd(cmd *cobra.Command, args []string) error {
 		SummaryTableName:       telemetrySummaryTableName,
 		SummaryBeforeTableName: CPUUtilizationTelemetryTableName,
 		InsightsFunc:           insightsFunc,
+		Input:                  flagInput,
+		Formats:                flagFormat,
 	}
 
 	report.RegisterHTMLRenderer(CPUUtilizationTelemetryTableName, cpuUtilizationTelemetryTableHTMLRenderer)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -38,12 +38,6 @@ const (
 	FlagFormatName = "format"
 )
 
-// Global flag variables for reporting commands.
-var (
-	FlagInput  string
-	FlagFormat []string
-)
-
 // Category represents a configuration category with associated tables and flags.
 type Category struct {
 	FlagName     string

--- a/internal/workflow/collection.go
+++ b/internal/workflow/collection.go
@@ -22,11 +22,11 @@ import (
 )
 
 // outputsFromInput reads the raw file(s) and returns the data in the order of the raw files
-func outputsFromInput(tables []table.TableDefinition, summaryTableName string) ([]TargetScriptOutputs, error) {
+func outputsFromInput(input string, tables []table.TableDefinition, summaryTableName string) ([]TargetScriptOutputs, error) {
 	orderedTargetScriptOutputs := []TargetScriptOutputs{}
 	includedTables := []table.TableDefinition{}
 	// read the raw file(s) as JSON
-	rawReports, err := report.ReadRawReports(app.FlagInput)
+	rawReports, err := report.ReadRawReports(input)
 	if err != nil {
 		err = fmt.Errorf("failed to read raw file(s): %w", err)
 		return nil, err

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -51,7 +51,9 @@ type ReportingCommand struct {
 	SummaryBeforeTableName string // the name of the table that the summary table should be placed before in the report
 	InsightsFunc           app.InsightsFunc
 	AdhocFunc              AdhocFunc
-	SystemSummaryTableName string // Optional: Only affects xlsx format reports. If set, the table with this name will be used as the "Brief" sheet in the xlsx report. If empty or unset, no "Brief" sheet is generated.
+	SystemSummaryTableName string   // Optional: Only affects xlsx format reports. If set, the table with this name will be used as the "Brief" sheet in the xlsx report. If empty or unset, no "Brief" sheet is generated.
+	Input                  string   // Input file/directory path for reading pre-collected data
+	Formats                []string // Output formats (e.g., "html", "json", "xlsx")
 }
 
 // Run is the common flow/logic for all reporting commands, i.e., 'report', 'telemetry', 'flame', 'lock'
@@ -76,9 +78,9 @@ func (rc *ReportingCommand) Run() error {
 
 	var myTargets []target.Target
 	var orderedTargetScriptOutputs []TargetScriptOutputs
-	if app.FlagInput != "" {
+	if rc.Input != "" {
 		var err error
-		orderedTargetScriptOutputs, err = outputsFromInput(rc.Tables, rc.SummaryTableName)
+		orderedTargetScriptOutputs, err = outputsFromInput(rc.Input, rc.Tables, rc.SummaryTableName)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			slog.Error(err.Error())
@@ -175,7 +177,7 @@ func (rc *ReportingCommand) Run() error {
 		return err
 	}
 	// check report formats
-	formats := app.FlagFormat
+	formats := rc.Formats
 	if slices.Contains(formats, report.FormatAll) {
 		formats = report.FormatOptions
 	}


### PR DESCRIPTION
## Summary

- Fixes bug where commands override each other's default format values during `init()`
- The recent change to default flamegraph/telemetry to HTML format was unintentionally affecting the report command due to shared global variables
- Replaces `app.FlagInput` and `app.FlagFormat` globals with local variables in each command
- Passes flag values through the `ReportingCommand` struct instead of reading globals

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test ./...` passes
- [ ] Manual test: `perfspect report` defaults to all formats
- [ ] Manual test: `perfspect flamegraph` defaults to HTML
- [ ] Manual test: `perfspect telemetry` defaults to HTML
- [ ] Manual test: `--format` flag works correctly for each command

🤖 Generated with [Claude Code](https://claude.com/claude-code)