### PR TITLE
fix: enhance native flamegraph to handle empty sample counts

### DIFF
--- a/cmd/flamegraph/flamegraph_tables.go
+++ b/cmd/flamegraph/flamegraph_tables.go
@@ -283,8 +283,18 @@ func mergeSystemFolded(perfFp string, perfDwarf string) (merged string, err erro
 	}
 	fpSampleCount := fpStacks.totalSamples()
 	dwarfSampleCount := dwarfStacks.totalSamples()
-	if fpSampleCount == 0 || dwarfSampleCount == 0 {
-		err = fmt.Errorf("sample counts cannot be zero")
+	if fpSampleCount == 0 && dwarfSampleCount == 0 {
+		err = fmt.Errorf("both fp and dwarf sample counts cannot be zero")
+		return
+	}
+	if fpSampleCount == 0 {
+		slog.Warn("no fp samples; using dwarf stacks")
+		merged = dwarfStacks.dumpFolded()
+		return
+	}
+	if dwarfSampleCount == 0 {
+		slog.Warn("no dwarf samples; using fp stacks")
+		merged = fpStacks.dumpFolded()
 		return
 	}
 	fpToDwarfScalingRatio := float64(fpSampleCount) / float64(dwarfSampleCount)

--- a/cmd/flamegraph/flamegraph_tables_test.go
+++ b/cmd/flamegraph/flamegraph_tables_test.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2021-2025 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+
+package flamegraph
+
+import "testing"
+
+func parseFoldedForTest(t *testing.T, folded string) ProcessStacks {
+	t.Helper()
+	stacks := make(ProcessStacks)
+	if err := stacks.parsePerfFolded(folded); err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	return stacks
+}
+
+func TestMergeSystemFoldedUsesDwarfWhenFpEmpty(t *testing.T) {
+	fpFolded := ""
+	dwarfFolded := "procA;foo;bar 3\nprocB;baz 2\n"
+
+	merged, err := mergeSystemFolded(fpFolded, dwarfFolded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := parseFoldedForTest(t, merged)
+	expected := parseFoldedForTest(t, dwarfFolded)
+	if got.totalSamples() != expected.totalSamples() {
+		t.Fatalf("expected %d samples, got %d", expected.totalSamples(), got.totalSamples())
+	}
+}
+
+func TestMergeSystemFoldedUsesFpWhenDwarfEmpty(t *testing.T) {
+	fpFolded := "procA;foo;bar 3\nprocB;baz 2\n"
+	dwarfFolded := ""
+
+	merged, err := mergeSystemFolded(fpFolded, dwarfFolded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := parseFoldedForTest(t, merged)
+	expected := parseFoldedForTest(t, fpFolded)
+	if got.totalSamples() != expected.totalSamples() {
+		t.Fatalf("expected %d samples, got %d", expected.totalSamples(), got.totalSamples())
+	}
+}
+
+func TestMergeSystemFoldedErrorsWhenBothEmpty(t *testing.T) {
+	_, err := mergeSystemFolded("", "")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
This pull request improves the handling of empty input cases in the `mergeSystemFolded` function and adds comprehensive unit tests to verify the new behaviors. The changes ensure that the function gracefully handles scenarios where either or both of the input folded stack traces are empty, and provides better logging and error messages.

**Enhanced error handling and logging:**

* Updated `mergeSystemFolded` in `flamegraph_tables.go` to:
  - Return a specific error only when both the `fp` and `dwarf` sample counts are zero, with a clearer error message.
  - Fall back to using the non-empty input when only one of the inputs is empty, and log a warning indicating which source is being used.

**Testing improvements:**

* Added `flamegraph_tables_test.go` with tests for:
  - Using the dwarf stacks when the fp input is empty.
  - Using the fp stacks when the dwarf input is empty.
  - Returning an error when both inputs are empty.