### PR TITLE
refactor: table-driven DIMM format parsing with tests

### DIFF
--- a/internal/extract/dimm.go
+++ b/internal/extract/dimm.go
@@ -564,7 +564,11 @@ func getDIMMSocketSlot(dt dimmType, reBankLoc *regexp.Regexp, reLoc *regexp.Rege
 		if f.locPat != nil {
 			locMatch = reLoc.FindStringSubmatch(locator)
 		}
-		if bankLocMatch != nil || locMatch != nil {
+		if f.matchBoth {
+			if bankLocMatch != nil && locMatch != nil {
+				return f.extractFunc(bankLocMatch, locMatch)
+			}
+		} else if bankLocMatch != nil || locMatch != nil {
 			return f.extractFunc(bankLocMatch, locMatch)
 		}
 		break

--- a/internal/extract/dimm_test.go
+++ b/internal/extract/dimm_test.go
@@ -621,3 +621,26 @@ func TestDeriveDIMMInfoOther(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDIMMSocketSlotMatchBothPartialMatch(t *testing.T) {
+	// For matchBoth formats (e.g., QuantaGNR), if only one of the two patterns
+	// matches a subsequent DIMM row, getDIMMSocketSlot must return an error
+	// rather than passing a nil match slice to extractFunc (which would panic).
+	//
+	// This simulates deriveDIMMInfoOther identifying the format from dimms[0],
+	// then encountering a later DIMM where only one pattern matches.
+	bankLocPat := dimmFormats[1].bankLocPat // QuantaGNR
+	locPat := dimmFormats[1].locPat
+
+	// locator matches but bankLocator does not
+	_, _, err := getDIMMSocketSlot(dimmTypeQuantaGNR, bankLocPat, locPat, "NOT_A_NODE", "CPU0_A1")
+	if err == nil {
+		t.Error("expected error when bankLocator doesn't match for matchBoth format, got nil")
+	}
+
+	// bankLocator matches but locator does not
+	_, _, err = getDIMMSocketSlot(dimmTypeQuantaGNR, bankLocPat, locPat, "_Node0_Channel0_Dimm1", "UNKNOWN")
+	if err == nil {
+		t.Error("expected error when locator doesn't match for matchBoth format, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Replace cascading if-else in `getDIMMParseInfo` and switch in `getDIMMSocketSlot` with a unified `dimmFormats` table where each entry holds pre-compiled regexes, match predicates, and extraction functions
- Fix regex bugs where `[\d+]` matched a single character instead of multi-digit numbers (affected Quanta GNR, Birchstream, and Forest City formats)
- Add descriptive `dimmType` names (`dimmTypeInspurICX`, `dimmTypeQuantaGNR`, etc.) replacing opaque `dimmType0`–`dimmType16`
- Add 66 characterization tests covering all 17 DIMM formats, ordering edge cases, and multi-digit regression cases

## Test plan
- [x] All 66 new DIMM tests pass (`go test ./internal/extract/ -run "TestGetDIMM|TestDeriveDIMMInfoOther"`)
- [x] Full test suite passes (`make test`) with zero failures
- [ ] Verify on real hardware with various DIMM configurations (Dell, HPE, SuperMicro, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)