### PR TITLE
fix: L1 cache benchmark uses wrong buffer size due to case mismatch

### DIFF
--- a/internal/script/scripts.go
+++ b/internal/script/scripts.go
@@ -171,8 +171,8 @@ CORES_PER_SOCKET=$(lscpu | grep -E 'Core\(s\) per socket:' | head -1 | awk '{pri
 BUF_KB=$(( L3_KB * 2 / CORES_PER_SOCKET ))
 MIN_KB=102400
 [ $BUF_KB -lt $MIN_KB ] && BUF_KB=$MIN_KB`
-	// for measuring L1 bandwidth and latency (half of L1D cache size minus 4KB)
-	mlcBufferSetupL1 = `L1D_KB=$(cache_size_kb L1D)
+	// for measuring L1 bandwidth and latency (half of L1d cache size minus 4KB)
+	mlcBufferSetupL1 = `L1D_KB=$(cache_size_kb L1d)
 BUF_KB=$(( L1D_KB / 2 - 4 ))
 [ $BUF_KB -lt 1 ] && BUF_KB=1`
 	// for measuring L2 bandwidth and latency (half of L2 cache size)


### PR DESCRIPTION
## Summary
- The `cache_size_kb()` shell function looks up `L1D` (uppercase D) in `lscpu -C` output, but `lscpu` reports the L1 data cache as `L1d` (lowercase d). The case-sensitive awk match silently fails, causing the buffer size to fall back to 1 KB instead of the intended half-of-L1d size.
- Affects both L1 idle latency and L1 max bandwidth cache benchmarks on all platforms.
- Fix: change the lookup key from `L1D` to `L1d` to match `lscpu -C` output.

## Test plan
- [ ] Verify `lscpu -C` output uses `L1d` on target platforms (Intel GNR, Intel SRF/CWF, AMD EPYC, etc.)
- [ ] Run cache benchmarks and confirm L1 buffer size is now derived from actual L1d cache size
- [ ] Confirm L2 and L3 benchmarks are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)